### PR TITLE
feat(groq): Convert timestamps to human‑readable relative phrases (e.g., “3 minutes ago”, “in 2 days”).

### DIFF
--- a/utils/nightly-nightly-relative-time-conver/utils/nightly-relative-time-converter/README.md
+++ b/utils/nightly-nightly-relative-time-conver/utils/nightly-relative-time-converter/README.md
@@ -1,0 +1,48 @@
+# Nightly Relative Time Converter
+
+A tiny, dependency‑free utility that turns a `datetime` into a friendly, human‑readable relative string such as:
+
+- `just now`
+- `45 seconds ago`
+- `in 3 minutes`
+- `2 days ago`
+- `in 1 year`
+
+## Why?
+
+When building CLIs, bots, or logs you often want to show *when* something happened without overwhelming the user with exact timestamps. This helper does the math for you and works offline.
+
+## Installation
+
+The utility is self‑contained. Just copy the `src/relative_time.py` file into your project or import it directly from this repo.
+
+```bash
+# Example usage (Python 3.11+)
+python - <<'PY'
+from datetime import datetime, timedelta
+from utils.nightly-relative-time-converter.src.relative_time import format_relative_time
+
+now = datetime.utcnow()
+print(format_relative_time(now - timedelta(seconds=30)))   # 30 seconds ago
+print(format_relative_time(now + timedelta(days=2)))      # in 2 days
+PY
+```
+
+## API
+
+```python
+format_relative_time(target: datetime, reference: Optional[datetime] = None) -> str
+```
+
+- **target** – The datetime you want to describe.
+- **reference** – The point of comparison (defaults to `datetime.utcnow()`).
+
+The function returns a short English phrase.
+
+## Testing
+
+Run the bundled tests with `pytest`:
+
+```bash
+pytest utils/nightly-relative-time-converter/tests
+```

--- a/utils/nightly-nightly-relative-time-conver/utils/nightly-relative-time-converter/src/relative_time.py
+++ b/utils/nightly-nightly-relative-time-conver/utils/nightly-relative-time-converter/src/relative_time.py
@@ -1,0 +1,79 @@
+import datetime
+from typing import Optional
+
+
+def _plural(value: int, singular: str, plural: Optional[str] = None) -> str:
+    """Return the appropriate singular/plural word for *value*.
+
+    If *plural* is not supplied, ``singular + 's'`` is used.
+    """
+    word = singular if value == 1 else (plural or f"{singular}s")
+    return f"{value} {word}"
+
+
+def format_relative_time(
+    target: datetime.datetime,
+    reference: Optional[datetime.datetime] = None,
+) -> str:
+    """Return a human‑readable relative time string.
+
+    Parameters
+    ----------
+    target:
+        The datetime to describe.
+    reference:
+        The datetime to compare against. If ``None`` the current UTC time is used.
+
+    Returns
+    -------
+    str
+        A phrase like ``"5 minutes ago"`` or ``"in 2 days"``.
+    """
+    if reference is None:
+        reference = datetime.datetime.utcnow()
+
+    # Ensure both are timezone‑aware or both naive for a fair comparison.
+    if target.tzinfo != reference.tzinfo:
+        # Simple approach: drop tzinfo (treat as UTC) – the utility is meant for quick scripts.
+        target = target.replace(tzinfo=None)
+        reference = reference.replace(tzinfo=None)
+
+    delta = target - reference
+    seconds = int(delta.total_seconds())
+    abs_seconds = abs(seconds)
+
+    # Very recent events
+    if abs_seconds < 5:
+        return "just now"
+
+    # Define thresholds
+    minute = 60
+    hour = 60 * minute
+    day = 24 * hour
+    week = 7 * day
+    month = 30 * day  # Approximation
+    year = 365 * day  # Approximation
+
+    def _choose(value: int, unit: str) -> str:
+        phrase = _plural(value, unit)
+        return f"{phrase} ago" if seconds < 0 else f"in {phrase}"
+
+    if abs_seconds < minute:
+        return _choose(abs_seconds, "second")
+    if abs_seconds < hour:
+        minutes = abs_seconds // minute
+        return _choose(minutes, "minute")
+    if abs_seconds < day:
+        hours = abs_seconds // hour
+        return _choose(hours, "hour")
+    if abs_seconds < week:
+        days = abs_seconds // day
+        return _choose(days, "day")
+    if abs_seconds < month:
+        weeks = abs_seconds // week
+        return _choose(weeks, "week")
+    if abs_seconds < year:
+        months = abs_seconds // month
+        return _choose(months, "month")
+    years = abs_seconds // year
+    return _choose(years, "year")

--- a/utils/nightly-nightly-relative-time-conver/utils/nightly-relative-time-converter/tests/test_relative_time.py
+++ b/utils/nightly-nightly-relative-time-conver/utils/nightly-relative-time-converter/tests/test_relative_time.py
@@ -1,0 +1,55 @@
+import datetime
+import sys
+from pathlib import Path
+
+# Adjust import path to locate the utility's src folder
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT / "src"))
+
+from relative_time import format_relative_time
+
+
+def test_just_now():
+    now = datetime.datetime(2025, 1, 1, 12, 0, 0)
+    # Target within 4 seconds of reference → "just now"
+    assert format_relative_time(now + datetime.timedelta(seconds=2), reference=now) == "just now"
+    assert format_relative_time(now - datetime.timedelta(seconds=3), reference=now) == "just now"
+
+
+def test_seconds_ago_and_future():
+    ref = datetime.datetime(2025, 1, 1, 12, 0, 0)
+    assert format_relative_time(ref - datetime.timedelta(seconds=45), reference=ref) == "45 seconds ago"
+    assert format_relative_time(ref + datetime.timedelta(seconds=45), reference=ref) == "in 45 seconds"
+
+
+def test_minutes():
+    ref = datetime.datetime(2025, 1, 1, 12, 0, 0)
+    assert format_relative_time(ref - datetime.timedelta(minutes=5), reference=ref) == "5 minutes ago"
+    assert format_relative_time(ref + datetime.timedelta(minutes=5), reference=ref) == "in 5 minutes"
+
+
+def test_hours():
+    ref = datetime.datetime(2025, 1, 1, 12, 0, 0)
+    assert format_relative_time(ref - datetime.timedelta(hours=2), reference=ref) == "2 hours ago"
+    assert format_relative_time(ref + datetime.timedelta(hours=2), reference=ref) == "in 2 hours"
+
+
+def test_days_and_weeks():
+    ref = datetime.datetime(2025, 1, 1, 12, 0, 0)
+    assert format_relative_time(ref - datetime.timedelta(days=1), reference=ref) == "1 day ago"
+    assert format_relative_time(ref + datetime.timedelta(days=3), reference=ref) == "in 3 days"
+    assert format_relative_time(ref - datetime.timedelta(days=10), reference=ref) == "1 week ago"
+    assert format_relative_time(ref + datetime.timedelta(days=21), reference=ref) == "in 3 weeks"
+
+
+def test_months_and_years():
+    ref = datetime.datetime(2025, 1, 1, 12, 0, 0)
+    # Approximate month = 30 days
+    assert format_relative_time(ref - datetime.timedelta(days=45), reference=ref) == "1 month ago"
+    assert format_relative_time(ref + datetime.timedelta(days=75), reference=ref) == "in 2 months"
+    # Approximate year = 365 days
+    assert format_relative_time(ref - datetime.timedelta(days=400), reference=ref) == "1 year ago"
+    assert format_relative_time(ref + datetime.timedelta(days=800), reference=ref) == "in 2 years"
+
+# Mock rationale comments (no external network calls are performed)
+# Mock rationale: All datetime objects are constructed locally; no I/O.


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-relative-time-converter
- **Provider**: groq
- **Location**: `utils/nightly-nightly-relative-time-conver`
- **Files Created**: 3
- **Description**: Convert timestamps to human‑readable relative phrases (e.g., “3 minutes ago”, “in 2 days”).

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `utils/nightly-nightly-relative-time-conver`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `utils/nightly-nightly-relative-time-conver/README.md`
- Run tests located in `utils/nightly-nightly-relative-time-conver/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.