### PR TITLE
feat(groq): A tiny utility to convert between hexadecimal color strings and RGB tuples, with a simple CLI.

### DIFF
--- a/utils/nightly-nightly-hex-color-converter/utils/nightly-hex-color-converter/README.md
+++ b/utils/nightly-nightly-hex-color-converter/utils/nightly-hex-color-converter/README.md
@@ -1,0 +1,33 @@
+# Nightly Hex Color Converter
+
+A whimsical yet handy utility that converts colors between the common hexadecimal string format (e.g., `#ff00aa`) and an RGB tuple `(255, 0, 170)`.  It ships with a tiny command‑line interface and a full test suite.
+
+## Features
+
+- `hex_to_rgb(hex_str) → (r, g, b)`
+- `rgb_to_hex(r, g, b) → "#rrggbb"`
+- Simple CLI: `python -m color_converter <hex|rgb> <value>`
+
+## Installation & Usage
+
+The utility is self‑contained; just copy the `src/` directory into your project or run it directly:
+
+```bash
+python -m utils/nightly-hex-color-converter/src/color_converter hex #ff00aa
+# => (255, 0, 170)
+
+python -m utils/nightly-hex-color-converter/src/color_converter rgb 255 0 170
+# => #ff00aa
+```
+
+## Testing
+
+Run the bundled tests with:
+
+```bash
+python -m unittest discover utils/nightly-hex-color-converter/tests
+```
+
+---
+
+*Created by the ApocalypsAI Nightly Integrator.*

--- a/utils/nightly-nightly-hex-color-converter/utils/nightly-hex-color-converter/src/color_converter.py
+++ b/utils/nightly-nightly-hex-color-converter/utils/nightly-hex-color-converter/src/color_converter.py
@@ -1,0 +1,97 @@
+"""color_converter.py
+
+Utility functions for converting between hexadecimal color strings and RGB tuples.
+
+Both functions raise ``ValueError`` on malformed input.
+"""
+
+from __future__ import annotations
+import sys
+from typing import Tuple
+
+HEX_PREFIX = "#"
+
+def _normalize_hex(hex_str: str) -> str:
+    """Return a 6‑character hex string without the leading '#'.
+
+    Accepts forms like "#ff00aa", "ff00aa", "#F0A", or "F0A".
+    """
+    hex_str = hex_str.strip().lstrip(HEX_PREFIX).lower()
+    if len(hex_str) == 3:
+        # Expand short form, e.g. "f0a" -> "ff00aa"
+        hex_str = "".join(ch * 2 for ch in hex_str)
+    if len(hex_str) != 6 or any(c not in "0123456789abcdef" for c in hex_str):
+        raise ValueError(f"Invalid hex color: '{hex_str}'")
+    return hex_str
+
+def hex_to_rgb(hex_str: str) -> Tuple[int, int, int]:
+    """Convert a hex color string to an ``(r, g, b)`` tuple.
+
+    Parameters
+    ----------
+    hex_str: str
+        Hexadecimal color, with or without a leading '#'.  Short form (3 digits) is supported.
+
+    Returns
+    -------
+    tuple[int, int, int]
+        Red, green, and blue components in the range 0‑255.
+    """
+    hex_clean = _normalize_hex(hex_str)
+    r = int(hex_clean[0:2], 16)
+    g = int(hex_clean[2:4], 16)
+    b = int(hex_clean[4:6], 16)
+    return (r, g, b)
+
+def rgb_to_hex(r: int, g: int, b: int) -> str:
+    """Convert an ``(r, g, b)`` tuple to a hex color string prefixed with '#'.
+
+    Parameters
+    ----------
+    r, g, b: int
+        Color components; must be in the range 0‑255.
+
+    Returns
+    -------
+    str
+        Hexadecimal representation, e.g. "#ff00aa".
+    """
+    for comp, name in zip((r, g, b), ("r", "g", "b")):
+        if not (0 <= comp <= 255):
+            raise ValueError(f"{name} component {comp} out of range 0‑255")
+    return f"{HEX_PREFIX}{r:02x}{g:02x}{b:02x}"
+
+def _cli() -> None:
+    """Very small command‑line interface.
+
+    Usage:
+        python -m color_converter hex <hex_string>
+        python -m color_converter rgb <r> <g> <b>
+    """
+    if len(sys.argv) < 3:
+        print("Usage: python -m color_converter <hex|rgb> <value...>")
+        sys.exit(1)
+    mode = sys.argv[1].lower()
+    if mode == "hex":
+        try:
+            rgb = hex_to_rgb(sys.argv[2])
+            print(rgb)
+        except ValueError as e:
+            print(e)
+            sys.exit(1)
+    elif mode == "rgb":
+        if len(sys.argv) != 5:
+            print("RGB mode requires three integer components.")
+            sys.exit(1)
+        try:
+            r, g, b = map(int, sys.argv[2:5])
+            print(rgb_to_hex(r, g, b))
+        except ValueError as e:
+            print(e)
+            sys.exit(1)
+    else:
+        print(f"Unknown mode '{mode}'. Use 'hex' or 'rgb'.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    _cli()

--- a/utils/nightly-nightly-hex-color-converter/utils/nightly-hex-color-converter/tests/test_color_converter.py
+++ b/utils/nightly-nightly-hex-color-converter/utils/nightly-hex-color-converter/tests/test_color_converter.py
@@ -1,0 +1,35 @@
+import unittest
+from utils.nightly_hex_color_converter.src.color_converter import hex_to_rgb, rgb_to_hex
+
+class TestColorConverter(unittest.TestCase):
+    def test_hex_to_rgb_full(self):
+        self.assertEqual(hex_to_rgb("#ff00aa"), (255, 0, 170))
+        self.assertEqual(hex_to_rgb("ff00aa"), (255, 0, 170))
+
+    def test_hex_to_rgb_short(self):
+        # Short form #f0a expands to #ff00aa
+        self.assertEqual(hex_to_rgb("#f0a"), (255, 0, 170))
+        self.assertEqual(hex_to_rgb("f0a"), (255, 0, 170))
+
+    def test_hex_to_rgb_invalid(self):
+        with self.assertRaises(ValueError):
+            hex_to_rgb("#gggggg")  # non‑hex characters
+        with self.assertRaises(ValueError):
+            hex_to_rgb("#1234")   # wrong length
+
+    def test_rgb_to_hex(self):
+        self.assertEqual(rgb_to_hex(255, 0, 170), "#ff00aa")
+        self.assertEqual(rgb_to_hex(0, 0, 0), "#000000")
+        self.assertEqual(rgb_to_hex(255, 255, 255), "#ffffff")
+
+    def test_rgb_to_hex_invalid(self):
+        # Mock rationale: ensure out‑of‑range values raise ValueError without external calls.
+        with self.assertRaises(ValueError):
+            rgb_to_hex(-1, 0, 0)
+        with self.assertRaises(ValueError):
+            rgb_to_hex(0, 256, 0)
+        with self.assertRaises(ValueError):
+            rgb_to_hex(300, 300, 300)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-hex-color-converter
- **Provider**: groq
- **Location**: `utils/nightly-nightly-hex-color-converter`
- **Files Created**: 3
- **Description**: A tiny utility to convert between hexadecimal color strings and RGB tuples, with a simple CLI.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `utils/nightly-nightly-hex-color-converter`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `utils/nightly-nightly-hex-color-converter/README.md`
- Run tests located in `utils/nightly-nightly-hex-color-converter/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.