### PR TITLE
feat(groq): Parse ISO 8601 duration strings (e.g., PT1H30M) into total seconds.

### DIFF
--- a/utils/nightly-nightly-iso8601-duration-par/utils/nightly-iso8601-duration-parser/README.md
+++ b/utils/nightly-nightly-iso8601-duration-par/utils/nightly-iso8601-duration-parser/README.md
@@ -1,0 +1,19 @@
+# ISO8601 Duration Parser
+
+Utility to parse ISO 8601 duration strings (e.g., `PT1H30M`) into a total number of seconds.
+
+## Usage
+```python
+from src.parser import parse_iso8601_duration
+
+seconds = parse_iso8601_duration("PT2H45M10S")
+print(seconds)  # 9910
+```
+
+Supported components:
+- Days (`P3D`)
+- Hours (`PT4H`)
+- Minutes (`PT5M`)
+- Seconds (`PT6S`)
+
+The parser follows the subset of ISO 8601 used by most APIs and is deterministic, requiring no external resources.

--- a/utils/nightly-nightly-iso8601-duration-par/utils/nightly-iso8601-duration-parser/src/parser.py
+++ b/utils/nightly-nightly-iso8601-duration-par/utils/nightly-iso8601-duration-parser/src/parser.py
@@ -1,0 +1,57 @@
+import re
+from typing import Dict
+
+__all__ = ["parse_iso8601_duration"]
+
+# Regex pattern for a subset of ISO 8601 durations.
+# Supports days, hours, minutes, seconds (e.g., P3DT4H5M6S or PT4H5M).
+_DURATION_RE = re.compile(
+    r"^P"
+    r"(?:(?P<days>\d+)D)?"
+    r"(?:T"
+    r"(?:(?P<hours>\d+)H)?"
+    r"(?:(?P<minutes>\d+)M)?"
+    r"(?:(?P<seconds>\d+)S)?"
+    r")?$"
+)
+
+def _to_int(value: str | None) -> int:
+    """Convert optional numeric string to int, defaulting to 0."""
+    return int(value) if value is not None else 0
+
+def parse_iso8601_duration(duration: str) -> int:
+    """Parse an ISO 8601 duration string and return total seconds.
+
+    Parameters
+    ----------
+    duration: str
+        ISO 8601 duration (e.g., ``"PT1H30M"``).
+
+    Returns
+    -------
+    int
+        Total number of seconds represented by the duration.
+
+    Raises
+    ------
+    ValueError
+        If the string does not match the supported ISO 8601 subset.
+    """
+    match = _DURATION_RE.fullmatch(duration)
+    if not match:
+        raise ValueError(f"Invalid ISO8601 duration: {duration!r}")
+
+    parts: Dict[str, int] = {
+        "days": _to_int(match.group("days")),
+        "hours": _to_int(match.group("hours")),
+        "minutes": _to_int(match.group("minutes")),
+        "seconds": _to_int(match.group("seconds")),
+    }
+
+    total_seconds = (
+        parts["days"] * 86400 +
+        parts["hours"] * 3600 +
+        parts["minutes"] * 60 +
+        parts["seconds"]
+    )
+    return total_seconds

--- a/utils/nightly-nightly-iso8601-duration-par/utils/nightly-iso8601-duration-parser/tests/test_parser.py
+++ b/utils/nightly-nightly-iso8601-duration-par/utils/nightly-iso8601-duration-parser/tests/test_parser.py
@@ -1,0 +1,30 @@
+import unittest
+from src.parser import parse_iso8601_duration
+
+class TestISO8601DurationParser(unittest.TestCase):
+    def test_basic_components(self):
+        cases = {
+            "PT0S": 0,
+            "PT45S": 45,
+            "PT2M": 120,
+            "PT2M30S": 150,
+            "PT1H": 3600,
+            "PT1H15M": 4500,
+            "PT1H15M30S": 4530,
+            "P1DT2H": 90000,  # 1 day + 2 hours
+            "P3DT4H5M6S": 277506,
+        }
+        for iso, expected in cases.items():
+            with self.subTest(iso=iso):
+                self.assertEqual(parse_iso8601_duration(iso), expected)
+
+    def test_invalid_formats(self):
+        invalid = ["", "P", "PT", "1H30M", "P-1DT", "PT1M60S"]
+        for iso in invalid:
+            with self.subTest(iso=iso):
+                # Mock rationale: ensure deterministic failure without external calls.
+                with self.assertRaises(ValueError):
+                    parse_iso8601_duration(iso)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-iso8601-duration-parser
- **Provider**: groq
- **Location**: `utils/nightly-nightly-iso8601-duration-par`
- **Files Created**: 3
- **Description**: Parse ISO 8601 duration strings (e.g., PT1H30M) into total seconds.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `utils/nightly-nightly-iso8601-duration-par`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `utils/nightly-nightly-iso8601-duration-par/README.md`
- Run tests located in `utils/nightly-nightly-iso8601-duration-par/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.