### PR TITLE
feat(openrouter): Generates an ASCII-art calendar for any month/year with optional event markers.

### DIFF
--- a/python-utils/nightly-nightly-ascii-art-calendar/README.md
+++ b/python-utils/nightly-nightly-ascii-art-calendar/README.md
@@ -1,0 +1,41 @@
+# Nightly ASCII Art Calendar
+
+A whimsical utility that generates ASCII-art calendars for any month/year, with optional event markers.
+
+## Features
+
+- Generate a calendar for any month and year
+- Mark specific dates with custom symbols
+- Clean, readable ASCII output
+- Command-line interface
+
+## Usage
+
+```bash
+python src/calendar.py --year 2024 --month 12
+python src/calendar.py --year 2024 --month 12 --events 2024-12-25=🎄 2024-12-31=🎆
+```
+
+## Installation
+
+No installation required. Just run the script directly.
+
+## Examples
+
+### Basic Calendar
+
+```bash
+python src/calendar.py --year 2024 --month 12
+```
+
+### Calendar with Events
+
+```bash
+python src/calendar.py --year 2024 --month 12 --events 2024-12-25=🎄 2024-12-31=🎆
+```
+
+This will mark December 25th with a Christmas tree emoji and December 31st with fireworks.
+
+## License
+
+MIT

--- a/python-utils/nightly-nightly-ascii-art-calendar/src/calendar.py
+++ b/python-utils/nightly-nightly-ascii-art-calendar/src/calendar.py
@@ -1,0 +1,148 @@
+import argparse
+import calendar
+import sys
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+
+def generate_ascii_calendar(
+    year: int,
+    month: int,
+    events: Optional[Dict[str, str]] = None,
+    show_year: bool = True,
+) -> str:
+    """
+    Generate an ASCII-art calendar for the given month and year.
+    
+    Args:
+        year: The year (e.g., 2024)
+        month: The month (1-12)
+        events: Dictionary mapping YYYY-MM-DD strings to symbols
+        show_year: Whether to include the year in the header
+    
+    Returns:
+        String containing the ASCII calendar
+    """
+    if not (1 <= month <= 12):
+        raise ValueError("Month must be between 1 and 12")
+    
+    if events is None:
+        events = {}
+    
+    # Get calendar data
+    cal = calendar.monthcalendar(year, month)
+    month_name = calendar.month_name[month]
+    
+    # Build header
+    if show_year:
+        header = f"{month_name} {year}"
+    else:
+        header = f"{month_name}"
+    
+    # Center header
+    header_line = f"{header:^21}"
+    
+    # Day headers
+    day_headers = "Su Mo Tu We Th Fr Sa"
+    
+    # Separator
+    separator = "--------------------"
+    
+    # Build calendar body
+    calendar_lines = [header_line, day_headers, separator]
+    
+    for week in cal:
+        week_line = ""
+        for day in week:
+            if day == 0:
+                # Empty day
+                week_line += "   "
+            else:
+                # Format day with potential event marker
+                date_str = f"{year:04d}-{month:02d}-{day:02d}"
+                if date_str in events:
+                    # Day with event
+                    marker = events[date_str]
+                    if len(marker) == 1:
+                        week_line += f" {marker} "
+                    else:
+                        # Truncate long markers
+                        week_line += f" {marker[:1]} "
+                else:
+                    # Regular day
+                    week_line += f"{day:2d} "
+        calendar_lines.append(week_line.rstrip())
+    
+    return "\n".join(calendar_lines)
+
+
+def parse_events(event_args: List[str]) -> Dict[str, str]:
+    """
+    Parse event arguments into a dictionary.
+    
+    Args:
+        event_args: List of strings in format "YYYY-MM-DD=symbol"
+    
+    Returns:
+        Dictionary mapping date strings to symbols
+    """
+    events = {}
+    for event in event_args:
+        if "=" not in event:
+            raise ValueError(f"Event format should be YYYY-MM-DD=symbol, got: {event}")
+        
+        date_str, symbol = event.split("=", 1)
+        
+        # Validate date format
+        try:
+            datetime.strptime(date_str, "%Y-%m-%d")
+        except ValueError:
+            raise ValueError(f"Invalid date format: {date_str}. Use YYYY-MM-DD.")
+        
+        events[date_str] = symbol
+    return events
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate an ASCII-art calendar for any month/year"
+    )
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=datetime.now().year,
+        help="Year (default: current year)",
+    )
+    parser.add_argument(
+        "--month",
+        type=int,
+        default=datetime.now().month,
+        help="Month (1-12, default: current month)",
+    )
+    parser.add_argument(
+        "--events",
+        nargs="*",
+        default=[],
+        help="Events in format YYYY-MM-DD=symbol (e.g., 2024-12-25=🎄)",
+    )
+    parser.add_argument(
+        "--no-year",
+        action="store_true",
+        help="Hide year in header",
+    )
+    
+    args = parser.parse_args()
+    
+    try:
+        events = parse_events(args.events)
+        calendar_output = generate_ascii_calendar(
+            args.year, args.month, events, show_year=not args.no_year
+        )
+        print(calendar_output)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/python-utils/nightly-nightly-ascii-art-calendar/tests/test_calendar.py
+++ b/python-utils/nightly-nightly-ascii-art-calendar/tests/test_calendar.py
@@ -1,0 +1,133 @@
+import unittest
+from datetime import datetime
+from src.calendar import generate_ascii_calendar, parse_events
+
+
+class TestAsciiCalendar(unittest.TestCase):
+    def test_generate_basic_calendar(self):
+        """Test generating a basic calendar without events."""
+        result = generate_ascii_calendar(2024, 1)
+        
+        # Check that the result contains the header
+        self.assertIn("January 2024", result)
+        
+        # Check that it contains day headers
+        self.assertIn("Su Mo Tu We Th Fr Sa", result)
+        
+        # Check that it contains day 1
+        self.assertIn(" 1", result)
+        
+        # Check that it contains day 31 (Jan 2024 ends on the 31st)
+        self.assertIn("31", result)
+    
+    def test_generate_calendar_no_year(self):
+        """Test generating a calendar without year in header."""
+        result = generate_ascii_calendar(2024, 1, show_year=False)
+        self.assertIn("January", result)
+        self.assertNotIn("2024", result)
+    
+    def test_generate_calendar_with_events(self):
+        """Test generating a calendar with event markers."""
+        events = {
+            "2024-01-01": "🎉",
+            "2024-01-25": "⭐",
+        }
+        result = generate_ascii_calendar(2024, 1, events)
+        
+        # Check that events are marked
+        self.assertIn("🎉", result)
+        self.assertIn("⭐", result)
+        
+        # Verify the header is still there
+        self.assertIn("January 2024", result)
+    
+    def test_generate_calendar_invalid_month(self):
+        """Test that invalid month raises ValueError."""
+        with self.assertRaises(ValueError):
+            generate_ascii_calendar(2024, 13)
+        
+        with self.assertRaises(ValueError):
+            generate_ascii_calendar(2024, 0)
+    
+    def test_parse_events_valid(self):
+        """Test parsing valid event arguments."""
+        event_args = ["2024-12-25=🎄", "2024-12-31=🎆"]
+        result = parse_events(event_args)
+        
+        expected = {
+            "2024-12-25": "🎄",
+            "2024-12-31": "🎆",
+        }
+        self.assertEqual(result, expected)
+    
+    def test_parse_events_invalid_format(self):
+        """Test that invalid event format raises ValueError."""
+        with self.assertRaises(ValueError):
+            parse_events(["2024-12-25"])
+    
+    def test_parse_events_invalid_date(self):
+        """Test that invalid date format raises ValueError."""
+        with self.assertRaises(ValueError):
+            parse_events(["24-12-25=🎄"])
+        
+        with self.assertRaises(ValueError):
+            parse_events(["2024-13-45=🎄"])
+    
+    def test_parse_events_empty(self):
+        """Test parsing empty event list."""
+        result = parse_events([])
+        self.assertEqual(result, {})
+    
+    def test_generate_calendar_february_2024(self):
+        """Test generating February 2024 calendar (leap year)."""
+        result = generate_ascii_calendar(2024, 2)
+        
+        self.assertIn("February 2024", result)
+        self.assertIn("29", result)  # 2024 is a leap year
+        self.assertNotIn("30", result)
+    
+    def test_generate_calendar_february_2023(self):
+        """Test generating February 2023 calendar (non-leap year)."""
+        result = generate_ascii_calendar(2023, 2)
+        
+        self.assertIn("February 2023", result)
+        self.assertNotIn("29", result)  # 2023 is not a leap year
+        self.assertIn("28", result)
+    
+    def test_generate_calendar_long_marker_truncation(self):
+        """Test that long markers are truncated to single character."""
+        events = {
+            "2024-01-01": "🎉🎊🎈",  # Multi-character marker
+        }
+        result = generate_ascii_calendar(2024, 1, events)
+        
+        # Should show only the first character
+        self.assertIn("🎉", result)
+        # Should not show the full marker
+        self.assertNotIn("🎊", result)
+    
+    def test_generate_calendar_different_month_lengths(self):
+        """Test calendars for months with different lengths."""
+        # April has 30 days
+        result_april = generate_ascii_calendar(2024, 4)
+        self.assertIn("April 2024", result_april)
+        self.assertIn("30", result_april)
+        self.assertNotIn("31", result_april)
+        
+        # June has 30 days
+        result_june = generate_ascii_calendar(2024, 6)
+        self.assertIn("June 2024", result_june)
+        self.assertIn("30", result_june)
+        self.assertNotIn("31", result_june)
+        
+        # December has 31 days
+        result_dec = generate_ascii_calendar(2024, 12)
+        self.assertIn("December 2024", result_dec)
+        self.assertIn("31", result_dec)
+
+
+if __name__ == "__main__":
+    # Mock rationale: These tests are deterministic and run entirely offline
+    # No external APIs or network calls are made
+    # All test data is hardcoded and self-contained
+    unittest.main()


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ascii-art-calendar
- **Provider**: openrouter
- **Location**: `python-utils/nightly-nightly-ascii-art-calendar`
- **Files Created**: 3
- **Description**: Generates an ASCII-art calendar for any month/year with optional event markers.

## Rationale
- Automated proposal from the OpenRouter generator delivering a fresh community utility.
- This utility was generated using the **openrouter** AI provider.

## Why safe to merge
- Utility is isolated to `python-utils/nightly-nightly-ascii-art-calendar`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `python-utils/nightly-nightly-ascii-art-calendar/README.md`
- Run tests located in `python-utils/nightly-nightly-ascii-art-calendar/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.