### PR TITLE
feat(openrouter): A whimsical yet practical Ansible playbook that orchestrates controlled chaos experiments across infrastructure with detailed reporting and cleanup.

### DIFF
--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/README.md
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/README.md
@@ -1,0 +1,57 @@
+# Nightly Ansible Chaos Orchestrator
+
+A whimsical yet practical Ansible playbook that orchestrates controlled chaos experiments across your infrastructure. Inspired by chaos engineering principles, this tool helps you build confidence in your system's resilience.
+
+## Features
+
+- **Chaos Scenarios**: Network latency, service failures, resource exhaustion, and time manipulation
+- **Whimsical Reporting**: Generates a chaos report with ASCII art and humorous commentary
+- **Automatic Cleanup**: Ensures systems are restored after chaos experiments
+- **Configurable**: Easy to customize chaos scenarios and targets
+
+## Requirements
+
+- Ansible 2.10+
+- Target hosts must have `tc` (traffic control) for network chaos
+- Root/sudo access on target hosts
+
+## Usage
+
+1. Clone this repository
+2. Update the `inventory` file with your target hosts
+3. Customize `vars/chaos_scenarios.yml` to configure chaos experiments
+4. Run the playbook:
+
+```bash
+./run_chaos.sh
+```
+
+## Example Output
+
+```
+========================================
+          CHAOS EXPERIMENT REPORT
+========================================
+
+Target Host: server-01
+Experiment: Network Latency
+Duration: 60 seconds
+Status: SUCCESS
+
+ASCII Art: 
+  (╯°□°）╯︵ ┻━┻
+
+Commentary: Looks like someone spilled coffee on the network cables!
+
+========================================
+```
+
+## Safety First
+
+- Always test in development environments first
+- Ensure you have rollback procedures
+- Monitor your systems during chaos experiments
+
+## License
+
+MIT

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/chaos_orchestrator.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/chaos_orchestrator.yml
@@ -1,0 +1,88 @@
+---
+# Nightly Ansible Chaos Orchestrator
+# A whimsical yet practical chaos engineering playbook
+
+- name: Chaos Engineering Experiment Orchestrator
+  hosts: all
+  become: true
+  gather_facts: false
+  vars_files:
+    - vars/chaos_scenarios.yml
+  vars:
+    chaos_report: []
+    start_time: "{{ ansible_date_time.epoch }}"
+  tasks:
+    - name: Display chaos experiment banner
+      debug:
+        msg: |
+          ========================================
+                    CHAOS ORCHESTRATOR
+          ========================================
+          Experiment: {{ chaos_scenario.name }}
+          Target: {{ inventory_hostname }}
+          Duration: {{ chaos_scenario.duration }}s
+          ========================================
+
+    - name: Record pre-chaos system state
+      shell: |
+        echo "CPU: $(grep 'cpu ' /proc/stat | awk '{usage=($2+$4)*100/($2+$3+$4+$5)} END {print usage}')%"
+        echo "Memory: $(free -h | grep Mem | awk '{print $3 '/' $2}')"
+        echo "Load: $(uptime | awk -F'load average:' '{print $2}')"
+      register: pre_chaos_state
+      changed_when: false
+
+    - name: Execute chaos scenario
+      include_tasks: tasks/chaos/{{ chaos_scenario.type }}.yml
+      vars:
+        chaos_duration: "{{ chaos_scenario.duration }}"
+        chaos_params: "{{ chaos_scenario.params | default({}) }}"
+
+    - name: Record post-chaos system state
+      shell: |
+        echo "CPU: $(grep 'cpu ' /proc/stat | awk '{usage=($2+$4)*100/($2+$3+$4+$5)} END {print usage}')%"
+        echo "Memory: $(free -h | grep Mem | awk '{print $3 '/' $2}')"
+        echo "Load: $(uptime | awk -F'load average:' '{print $2}')"
+      register: post_chaos_state
+      changed_when: false
+
+    - name: Execute cleanup tasks
+      include_tasks: tasks/cleanup.yml
+
+    - name: Generate chaos report entry
+      set_fact:
+        report_entry: >-
+          {
+            "host": "{{ inventory_hostname }}",
+            "scenario": "{{ chaos_scenario.name }}",
+            "type": "{{ chaos_scenario.type }}",
+            "duration": {{ chaos_scenario.duration }},
+            "status": "SUCCESS",
+            "pre_state": "{{ pre_chaos_state.stdout }}",
+            "post_state": "{{ post_chaos_state.stdout }}",
+            "timestamp": "{{ ansible_date_time.iso8601 }}"
+          }
+
+    - name: Append to chaos report
+      set_fact:
+        chaos_report: "{{ chaos_report + [report_entry | from_json] }}"
+
+    - name: Display chaos experiment results
+      debug:
+        msg: |
+          ========================================
+          CHAOS EXPERIMENT COMPLETE
+          ========================================
+          Host: {{ inventory_hostname }}
+          Scenario: {{ chaos_scenario.name }}
+          Type: {{ chaos_scenario.type }}
+          Duration: {{ chaos_scenario.duration }}s
+          Status: SUCCESS
+          ========================================
+
+  handlers:
+    - name: Ensure services are running after chaos
+      service:
+        name: "{{ item }}"
+        state: started
+      loop: "{{ chaos_scenario.params.services | default([]) }}"
+      when: chaos_scenario.type == 'service' and chaos_scenario.params.services is defined

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/inventory
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/inventory
@@ -1,0 +1,17 @@
+# Ansible Inventory for Chaos Engineering
+# Update this file with your target hosts
+
+[chaos_targets]
+# Example hosts - replace with your actual hosts
+# server-01 ansible_host=192.168.1.10
+# server-02 ansible_host=192.168.1.11
+# localhost ansible_connection=local
+
+[all:vars]
+# Default chaos scenario (can be overridden with -e chaos_scenario_name=scenario_name)
+chaos_scenario_name=network_latency
+
+# SSH settings
+ansible_ssh_user=root
+ansible_ssh_private_key_file=~/.ssh/id_rsa
+ansible_ssh_common_args='-o StrictHostKeyChecking=no'

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/run_chaos.sh
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/run_chaos.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+# Nightly Ansible Chaos Orchestrator Runner
+# A whimsical script to execute controlled chaos experiments
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLAYBOOK="${SCRIPT_DIR}/chaos_orchestrator.yml"
+INVENTORY="${SCRIPT_DIR}/inventory"
+REPORT_DIR="${SCRIPT_DIR}/reports"
+REPORT_FILE="${REPORT_DIR}/chaos_report_$(date +%Y%m%d_%H%M%S).txt"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to display usage
+usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Nightly Ansible Chaos Orchestrator - Execute controlled chaos experiments
+
+OPTIONS:
+    -h, --help              Show this help message
+    -i, --inventory FILE    Specify inventory file (default: ./inventory)
+    -s, --scenario NAME     Specify chaos scenario name
+    -t, --target HOST       Specify target host (default: all)
+    -v, --verbose           Enable verbose output
+    --list-scenarios        List available chaos scenarios
+    --dry-run               Perform a dry run without executing chaos
+
+EXAMPLES:
+    $0                                    # Run default scenario on all hosts
+    $0 -s network_latency -t server-01     # Run network latency on specific host
+    $0 --list-scenarios                   # Show available scenarios
+
+EOF
+    exit 1
+}
+
+# Function to list available scenarios
+list_scenarios() {
+    echo "Available Chaos Scenarios:"
+    echo "  - network_latency: Add network latency to simulate slow connections"
+    echo "  - network_packet_loss: Drop packets to simulate unreliable networks"
+    echo "  - service_restart: Restart services to simulate failures"
+    echo "  - service_stop: Stop services to simulate outages"
+    echo "  - cpu_stress: Stress CPU to simulate high load"
+    echo "  - memory_stress: Consume memory to simulate memory pressure"
+    echo "  - disk_io_stress: Stress disk I/O to simulate slow storage"
+    echo "  - time_warp: Manipulate system time (for testing time-sensitive apps)"
+    echo "  - random_kill: Randomly kill processes"
+    echo "  - random_reboot: Randomly reboot systems"
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            ;;
+        -i|--inventory)
+            INVENTORY="$2"
+            shift 2
+            ;;
+        -s|--scenario)
+            CHAOS_SCENARIO="$2"
+            shift 2
+            ;;
+        -t|--target)
+            TARGET_HOST="$2"
+            shift 2
+            ;;
+        -v|--verbose)
+            VERBOSE="-v"
+            shift
+            ;;
+        --list-scenarios)
+            list_scenarios
+            exit 0
+            ;;
+        --dry-run)
+            DRY_RUN="--check"
+            shift
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Check if inventory file exists
+if [[ ! -f "$INVENTORY" ]]; then
+    print_error "Inventory file not found: $INVENTORY"
+    echo "Please create an inventory file or specify one with -i/--inventory"
+    exit 1
+fi
+
+# Create reports directory
+mkdir -p "$REPORT_DIR"
+
+# Build ansible-playbook command
+ANSIBLE_CMD="ansible-playbook $VERBOSE $DRY_RUN -i $INVENTORY $PLAYBOOK"
+
+# Add scenario variable if specified
+if [[ -n "$CHAOS_SCENARIO" ]]; then
+    ANSIBLE_CMD="$ANSIBLE_CMD -e chaos_scenario_name=$CHAOS_SCENARIO"
+fi
+
+# Add target host if specified
+if [[ -n "$TARGET_HOST" ]]; then
+    ANSIBLE_CMD="$ANSIBLE_CMD -l $TARGET_HOST"
+fi
+
+# Display banner
+print_status "========================================"
+print_status "    Nightly Ansible Chaos Orchestrator"
+print_status "========================================"
+print_status "Inventory: $INVENTORY"
+print_status "Report: $REPORT_FILE"
+if [[ -n "$CHAOS_SCENARIO" ]]; then
+    print_status "Scenario: $CHAOS_SCENARIO"
+fi
+if [[ -n "$TARGET_HOST" ]]; then
+    print_status "Target: $TARGET_HOST"
+fi
+print_status "========================================"
+
+# Execute the playbook
+print_status "Executing chaos experiment..."
+if $ANSIBLE_CMD; then
+    print_success "Chaos experiment completed successfully!"
+    print_status "Check the report: $REPORT_FILE"
+else
+    print_error "Chaos experiment failed!"
+    exit 1
+fi
+
+# Display post-execution message
+print_warning "Remember: With great power comes great responsibility!"
+print_status "Monitor your systems and ensure they recover properly."

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tasks/chaos/network.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tasks/chaos/network.yml
@@ -1,0 +1,39 @@
+# Network Chaos Tasks
+# Simulate network issues like latency and packet loss
+
+- name: Ensure tc (traffic control) is installed
+  package:
+    name: iproute2
+    state: present
+  when: ansible_os_family == 'Debian' or ansible_os_family == 'RedHat'
+
+- name: Add network latency
+  shell: |
+    interface=$(ip route | grep default | awk '{print $5}' | head -1)
+    tc qdisc add dev $interface root netem delay {{ chaos_params.latency | default(100) }}ms {{ chaos_params.jitter | default(10) }}ms 2>/dev/null || tc qdisc change dev $interface root netem delay {{ chaos_params.latency | default(100) }}ms {{ chaos_params.jitter | default(10) }}ms
+  args:
+    warn: false
+  when: chaos_scenario.type == 'network_latency'
+
+- name: Add network packet loss
+  shell: |
+    interface=$(ip route | grep default | awk '{print $5}' | head -1)
+    tc qdisc add dev $interface root netem loss {{ chaos_params.packet_loss | default(10) }}% 2>/dev/null || tc qdisc change dev $interface root netem loss {{ chaos_params.packet_loss | default(10) }}%
+  args:
+    warn: false
+  when: chaos_scenario.type == 'network_packet_loss'
+
+- name: Wait for network chaos duration
+  wait_for:
+    timeout: "{{ chaos_duration | int }}"
+  when: chaos_scenario.type in ['network_latency', 'network_packet_loss']
+
+- name: Display network chaos ASCII art
+  debug:
+    msg: |
+      Network Chaos Applied! 
+      (╯°□°）╯︵ ┻━┻
+      Latency: {{ chaos_params.latency | default(100) }}ms
+      Jitter: {{ chaos_params.jitter | default(10) }}ms
+      Packet Loss: {{ chaos_params.packet_loss | default(0) }}%
+  when: chaos_scenario.type in ['network_latency', 'network_packet_loss']

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tasks/chaos/random.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tasks/chaos/random.yml
@@ -1,0 +1,36 @@
+# Random Chaos Tasks
+# Unpredictable chaos for maximum surprise
+
+- name: Select random process to kill
+  shell: ps aux | grep -v PID | awk '{print $2}' | sort -R | head -1
+  register: random_pid
+  when: chaos_scenario.type == 'random_kill'
+
+- name: Kill random process
+  shell: kill -9 {{ random_pid.stdout }}
+  when: chaos_scenario.type == 'random_kill' and random_pid.stdout is defined and random_pid.stdout != ''
+
+- name: Display random kill message
+  debug:
+    msg: |
+      Random Process Killed!
+      PID: {{ random_pid.stdout }}
+      (╯°Д°）╯︵/'
+  when: chaos_scenario.type == 'random_kill'
+
+- name: Schedule random reboot
+  shell: echo 'reboot' | at now + {{ (1..60) | random }} minutes
+  when: chaos_scenario.type == 'random_reboot'
+
+- name: Display random reboot message
+  debug:
+    msg: |
+      Random Reboot Scheduled!
+      (╯°□°）╯︵ ┻━┻
+      System will reboot in a few minutes...
+  when: chaos_scenario.type == 'random_reboot'
+
+- name: Wait for random chaos duration
+  wait_for:
+    timeout: "{{ chaos_duration | int }}"
+  when: chaos_scenario.type in ['random_kill', 'random_reboot']

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tasks/chaos/resource.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tasks/chaos/resource.yml
@@ -1,0 +1,40 @@
+# Resource Chaos Tasks
+# Stress system resources like CPU, memory, and disk I/O
+
+- name: Install stress tool
+  package:
+    name: stress
+    state: present
+  when: ansible_os_family == 'Debian' or ansible_os_family == 'RedHat'
+
+- name: Stress CPU
+  shell: stress --cpu {{ chaos_params.cores | default(2) }} --timeout {{ chaos_duration }}s
+  async: 3600
+  poll: 0
+  when: chaos_scenario.type == 'cpu_stress'
+
+- name: Stress Memory
+  shell: stress --vm {{ chaos_params.processes | default(1) }} --vm-bytes {{ chaos_params.size | default('256') }}M --timeout {{ chaos_duration }}s
+  async: 3600
+  poll: 0
+  when: chaos_scenario.type == 'memory_stress'
+
+- name: Stress Disk I/O
+  shell: stress --io {{ chaos_params.processes | default(2) }} --timeout {{ chaos_duration }}s
+  async: 3600
+  poll: 0
+  when: chaos_scenario.type == 'disk_io_stress'
+
+- name: Wait for resource stress duration
+  wait_for:
+    timeout: "{{ (chaos_duration | int) + 10 }}"
+  when: chaos_scenario.type in ['cpu_stress', 'memory_stress', 'disk_io_stress']
+
+- name: Display resource stress ASCII art
+  debug:
+    msg: |
+      Resource Stress Applied!
+      (╯°□°）╯︵ ┻━┻
+      Type: {{ chaos_scenario.type }}
+      Duration: {{ chaos_duration }}s
+  when: chaos_scenario.type in ['cpu_stress', 'memory_stress', 'disk_io_stress']

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tasks/chaos/service.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tasks/chaos/service.yml
@@ -1,0 +1,45 @@
+# Service Chaos Tasks
+# Manipulate services to simulate failures
+
+- name: Get list of running services
+  shell: systemctl list-units --type=service --state=running --no-pager --no-legend | awk '{print $1}' | head -10
+  register: running_services
+  when: chaos_scenario.type == 'service_restart' and chaos_scenario.params.services is not defined
+
+- name: Set services to restart
+  set_fact:
+    target_services: "{{ running_services.stdout_lines | default([]) }}"
+  when: chaos_scenario.type == 'service_restart' and chaos_scenario.params.services is not defined
+
+- name: Set services from params
+  set_fact:
+    target_services: "{{ chaos_scenario.params.services | default([]) }}"
+  when: chaos_scenario.type in ['service_restart', 'service_stop']
+
+- name: Restart services
+  service:
+    name: "{{ item }}"
+    state: restarted
+  loop: "{{ target_services }}"
+  when: chaos_scenario.type == 'service_restart'
+
+- name: Stop services
+  service:
+    name: "{{ item }}"
+    state: stopped
+  loop: "{{ target_services }}"
+  when: chaos_scenario.type == 'service_stop'
+
+- name: Wait for service chaos duration
+  wait_for:
+    timeout: "{{ chaos_duration | int }}"
+  when: chaos_scenario.type in ['service_restart', 'service_stop']
+
+- name: Display service chaos ASCII art
+  debug:
+    msg: |
+      Service Chaos Applied!
+      (╯°□°）╯︵ ┻━┻
+      Services: {{ target_services | join(', ') }}
+      Action: {{ 'Restarted' if chaos_scenario.type == 'service_restart' else 'Stopped' }}
+  when: chaos_scenario.type in ['service_restart', 'service_stop']

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tasks/chaos/time.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tasks/chaos/time.yml
@@ -1,0 +1,30 @@
+# Time Manipulation Chaos Tasks
+# Manipulate system time for testing time-sensitive applications
+
+- name: Backup original date
+  shell: date
+  register: original_date
+  when: chaos_scenario.type == 'time_warp'
+
+- name: Set system time forward
+  shell: date -s "{{ (ansible_date_time.epoch | int) + (chaos_params.offset | default(3600) | int) }} seconds"
+  when: chaos_scenario.type == 'time_warp' and chaos_params.direction == 'forward'
+
+- name: Set system time backward
+  shell: date -s "{{ (ansible_date_time.epoch | int) - (chaos_params.offset | default(3600) | int) }} seconds"
+  when: chaos_scenario.type == 'time_warp' and chaos_params.direction == 'backward'
+
+- name: Display time warp message
+  debug:
+    msg: |
+      Time Warp Applied!
+      (╯°□°）╯︵ ┻━┻
+      Original: {{ original_date.stdout }}
+      New Time: {{ ansible_date_time.iso8601 }}
+      Offset: {{ chaos_params.offset | default(3600) }} seconds {{ chaos_params.direction | default('forward') }}
+  when: chaos_scenario.type == 'time_warp'
+
+- name: Wait for time warp duration
+  wait_for:
+    timeout: "{{ chaos_duration | int }}"
+  when: chaos_scenario.type == 'time_warp'

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tasks/cleanup.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tasks/cleanup.yml
@@ -1,0 +1,39 @@
+# Cleanup Tasks
+# Restore systems to normal state after chaos experiments
+
+- name: Remove network latency and packet loss
+  shell: |
+    interface=$(ip route | grep default | awk '{print $5}' | head -1)
+    tc qdisc del dev $interface root 2>/dev/null || true
+  args:
+    warn: false
+  when: chaos_scenario.type in ['network_latency', 'network_packet_loss']
+
+- name: Restart services that were stopped
+  service:
+    name: "{{ item }}"
+    state: started
+  loop: "{{ chaos_scenario.params.services | default([]) }}"
+  when: chaos_scenario.type == 'service_stop'
+
+- name: Restore original system time
+  shell: date -s "{{ original_date.stdout }}"
+  when: chaos_scenario.type == 'time_warp'
+
+- name: Kill any remaining stress processes
+  shell: pkill -f stress || true
+  when: chaos_scenario.type in ['cpu_stress', 'memory_stress', 'disk_io_stress']
+
+- name: Display cleanup message
+  debug:
+    msg: |
+      Cleanup Complete!
+      System restored to normal state.
+      (╯°□°）╯︵ ┻━┻ → ┬─┬
+
+- name: Generate final chaos report
+  template:
+    src: templates/chaos_report.j2
+    dest: "{{ playbook_dir }}/reports/chaos_report_{{ ansible_date_time.epoch }}.txt"
+  delegate_to: localhost
+  run_once: true

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/templates/chaos_report.j2
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/templates/chaos_report.j2
@@ -1,0 +1,76 @@
+{% set report_time = ansible_date_time.strftime('%Y-%m-%d %H:%M:%S') %}
+========================================
+          CHAOS EXPERIMENT REPORT
+========================================
+
+Generated: {{ report_time }}
+Target Host: {{ inventory_hostname }}
+Experiment: {{ chaos_scenario.name }}
+Type: {{ chaos_scenario.type }}
+Duration: {{ chaos_scenario.duration }} seconds
+
+ASCII Art: 
+  {% if chaos_scenario.type == 'network_latency' %}
+  (╯°□°）╯︵ ┻━┻
+  {% elif chaos_scenario.type == 'network_packet_loss' %}
+  (╯°□°）╯︵ ┻━┻
+  {% elif chaos_scenario.type == 'service_restart' %}
+  (╯°□°）╯︵ ┻━┻
+  {% elif chaos_scenario.type == 'service_stop' %}
+  (╯°□°）╯︵ ┻━┻
+  {% elif chaos_scenario.type == 'cpu_stress' %}
+  (╯°□°）╯︵ ┻━┻
+  {% elif chaos_scenario.type == 'memory_stress' %}
+  (╯°□°）╯︵ ┻━┻
+  {% elif chaos_scenario.type == 'disk_io_stress' %}
+  (╯°□°）╯︵ ┻━┻
+  {% elif chaos_scenario.type == 'time_warp' %}
+  (╯°□°）╯︵ ┻━┻
+  {% elif chaos_scenario.type == 'random_kill' %}
+  (╯°□°）╯︵ ┻━┻
+  {% elif chaos_scenario.type == 'random_reboot' %}
+  (╯°□°）╯︵ ┻━┻
+  {% else %}
+  (╯°□°）╯︵ ┻━┻
+  {% endif %}
+
+Commentary: 
+  {% if chaos_scenario.type == 'network_latency' %}
+  Looks like someone spilled coffee on the network cables!
+  {% elif chaos_scenario.type == 'network_packet_loss' %}
+  The network is feeling a bit forgetful today.
+  {% elif chaos_scenario.type == 'service_restart' %}
+  Services needed a quick nap, I suppose.
+  {% elif chaos_scenario.type == 'service_stop' %}
+  Someone pulled the plug on the services!
+  {% elif chaos_scenario.type == 'cpu_stress' %}
+  CPU is working overtime - someone call HR!
+  {% elif chaos_scenario.type == 'memory_stress' %}
+  Memory is feeling a bit cramped in there.
+  {% elif chaos_scenario.type == 'disk_io_stress' %}
+  Disk is moving at a snail's pace.
+  {% elif chaos_scenario.type == 'time_warp' %}
+  Time is all wonky - Back to the Future much?
+  {% elif chaos_scenario.type == 'random_kill' %}
+  Random process met its untimely demise.
+  {% elif chaos_scenario.type == 'random_reboot' %}
+  System decided it needed a fresh start.
+  {% else %}
+  Chaos happened. What did you expect?
+  {% endif %}
+
+Pre-Chaos State:
+{{ pre_chaos_state.stdout }}
+
+Post-Chaos State:
+{{ post_chaos_state.stdout }}
+
+Status: SUCCESS
+
+========================================
+
+Remember: 
+"With great power comes great responsibility!"
+
+Monitor your systems and ensure they recover properly.
+========================================

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tests/test_chaos_orchestrator.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tests/test_chaos_orchestrator.yml
@@ -1,0 +1,129 @@
+---
+# Test Playbook for Chaos Orchestrator
+# Tests the functionality of the chaos engineering playbook
+
+- name: Test Chaos Orchestrator
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Test inventory file exists
+      stat:
+        path: "{{ playbook_dir }}/inventory"
+      register: inventory_file
+
+    - name: Assert inventory file exists
+      assert:
+        that:
+          - inventory_file.stat.exists
+        msg: "Inventory file should exist"
+
+    - name: Test playbook file exists
+      stat:
+        path: "{{ playbook_dir }}/chaos_orchestrator.yml"
+      register: playbook_file
+
+    - name: Assert playbook file exists
+      assert:
+        that:
+          - playbook_file.stat.exists
+        msg: "Chaos orchestrator playbook should exist"
+
+    - name: Test variables file exists
+      stat:
+        path: "{{ playbook_dir }}/vars/chaos_scenarios.yml"
+      register: vars_file
+
+    - name: Assert variables file exists
+      assert:
+        that:
+          - vars_file.stat.exists
+        msg: "Chaos scenarios variables file should exist"
+
+    - name: Test tasks directory exists
+      stat:
+        path: "{{ playbook_dir }}/tasks"
+      register: tasks_dir
+
+    - name: Assert tasks directory exists
+      assert:
+        that:
+          - tasks_dir.stat.exists
+          - tasks_dir.stat.isdir
+        msg: "Tasks directory should exist"
+
+    - name: Test chaos tasks directory exists
+      stat:
+        path: "{{ playbook_dir }}/tasks/chaos"
+      register: chaos_tasks_dir
+
+    - name: Assert chaos tasks directory exists
+      assert:
+        that:
+          - chaos_tasks_dir.stat.exists
+          - chaos_tasks_dir.stat.isdir
+        msg: "Chaos tasks directory should exist"
+
+    - name: Test cleanup tasks file exists
+      stat:
+        path: "{{ playbook_dir }}/tasks/cleanup.yml"
+      register: cleanup_file
+
+    - name: Assert cleanup tasks file exists
+      assert:
+        that:
+          - cleanup_file.stat.exists
+        msg: "Cleanup tasks file should exist"
+
+    - name: Test templates directory exists
+      stat:
+        path: "{{ playbook_dir }}/templates"
+      register: templates_dir
+
+    - name: Assert templates directory exists
+      assert:
+        that:
+          - templates_dir.stat.exists
+          - templates_dir.stat.isdir
+        msg: "Templates directory should exist"
+
+    - name: Test report template exists
+      stat:
+        path: "{{ playbook_dir }}/templates/chaos_report.j2"
+      register: report_template
+
+    - name: Assert report template exists
+      assert:
+        that:
+          - report_template.stat.exists
+        msg: "Chaos report template should exist"
+
+    - name: Test shell script exists
+      stat:
+        path: "{{ playbook_dir }}/run_chaos.sh"
+      register: script_file
+
+    - name: Assert shell script exists
+      assert:
+        that:
+          - script_file.stat.exists
+        msg: "Chaos runner script should exist"
+
+    - name: Test shell script is executable
+      stat:
+        path: "{{ playbook_dir }}/run_chaos.sh"
+      register: script_permissions
+
+    - name: Assert shell script is executable
+      assert:
+        that:
+          - script_permissions.stat.mode is defined
+          - script_permissions.stat.mode | regex_search('rwx')
+        msg: "Chaos runner script should be executable"
+
+    - name: Display test results
+      debug:
+        msg: |
+          All tests passed!
+          Chaos Orchestrator is ready to deploy chaos!
+          (╯°□°）╯︵ ┻━┻ → ┬─┬

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tests/test_inventory
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tests/test_inventory
@@ -1,0 +1,14 @@
+# Test Inventory for Chaos Engineering
+# Used for testing the chaos orchestrator
+
+[chaos_targets]
+localhost ansible_connection=local
+
+[all:vars]
+# Default chaos scenario for testing
+chaos_scenario_name=network_latency
+
+# SSH settings (for localhost)
+ansible_ssh_user=root
+ansible_ssh_private_key_file=~/.ssh/id_rsa
+ansible_ssh_common_args='-o StrictHostKeyChecking=no'

--- a/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/vars/chaos_scenarios.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/vars/chaos_scenarios.yml
@@ -1,0 +1,77 @@
+# Chaos Scenarios Configuration
+# Define different chaos experiments that can be run
+
+chaos_scenarios:
+  network_latency:
+    name: "Network Latency"
+    type: "network_latency"
+    duration: 60
+    params:
+      latency: 100  # milliseconds
+      jitter: 10    # milliseconds
+
+  network_packet_loss:
+    name: "Network Packet Loss"
+    type: "network_packet_loss"
+    duration: 60
+    params:
+      packet_loss: 10  # percentage
+
+  service_restart:
+    name: "Service Restart"
+    type: "service_restart"
+    duration: 30
+    params:
+      services: []  # Empty means random services
+
+  service_stop:
+    name: "Service Stop"
+    type: "service_stop"
+    duration: 30
+    params:
+      services: []  # Empty means random services
+
+  cpu_stress:
+    name: "CPU Stress"
+    type: "cpu_stress"
+    duration: 120
+    params:
+      cores: 2
+
+  memory_stress:
+    name: "Memory Stress"
+    type: "memory_stress"
+    duration: 120
+    params:
+      processes: 1
+      size: 256  # MB
+
+  disk_io_stress:
+    name: "Disk I/O Stress"
+    type: "disk_io_stress"
+    duration: 120
+    params:
+      processes: 2
+
+  time_warp:
+    name: "Time Warp"
+    type: "time_warp"
+    duration: 60
+    params:
+      direction: "forward"  # or "backward"
+      offset: 3600          # seconds
+
+  random_kill:
+    name: "Random Kill"
+    type: "random_kill"
+    duration: 30
+    params: {}
+
+  random_reboot:
+    name: "Random Reboot"
+    type: "random_reboot"
+    duration: 30
+    params: {}
+
+# Default scenario to use if none specified
+chaos_scenario: "{{ chaos_scenarios[chaos_scenario_name | default('network_latency')] }}"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansible-chaos-orchestrator
- **Provider**: openrouter
- **Location**: `ansible-playbooks/nightly-nightly-ansible-chaos-orches-2`
- **Files Created**: 14
- **Description**: A whimsical yet practical Ansible playbook that orchestrates controlled chaos experiments across infrastructure with detailed reporting and cleanup.

## Rationale
- Automated proposal from the OpenRouter generator delivering a fresh community utility.
- This utility was generated using the **openrouter** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-ansible-chaos-orches-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-ansible-chaos-orches-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.