### PR TITLE
feat(groq): Generate a harmonious palette of hex colors from a single base color using hue rotation in HSL space.

### DIFF
--- a/rust-utils/nightly-nightly-hex-palette-generato/Cargo.toml
+++ b/rust-utils/nightly-nightly-hex-palette-generato/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nightly-hex-palette-generator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-hex-palette-generato/README.md
+++ b/rust-utils/nightly-nightly-hex-palette-generato/README.md
@@ -1,0 +1,21 @@
+# nightly-hex-palette-generator
+
+Generate a harmonious palette of hex colors based on a single input color.
+
+## Overview
+
+`nightly-hex-palette-generator` is a tiny CLI tool written in Rust that takes a base hex color (e.g., `#3498db`) and produces a palette of complementary colors by rotating the hue in HSL space. The number of colors can be specified; default is 5.
+
+## Installation
+
+```sh
+cargo install --path .
+```
+
+## Usage
+
+```sh
+nightly-hex-palette-generator #3498db 7
+```
+
+Outputs 7 hex colors, one per line.

--- a/rust-utils/nightly-nightly-hex-palette-generato/src/lib.rs
+++ b/rust-utils/nightly-nightly-hex-palette-generato/src/lib.rs
@@ -1,0 +1,87 @@
+pub type Rgb = (f64, f64, f64);
+pub type Hsl = (f64, f64, f64);
+
+/// Convert a hex string ("#RRGGBB" or "RRGGBB") to an RGB tuple.
+pub fn hex_to_rgb(hex: &str) -> Option<Rgb> {
+    let hex = hex.trim_start_matches('#');
+    if hex.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()? as f64;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()? as f64;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()? as f64;
+    Some((r, g, b))
+}
+
+/// Convert an RGB tuple (0..255) to HSL (h in 0..360, s,l in 0..1).
+pub fn rgb_to_hsl(rgb: Rgb) -> Hsl {
+    let (r, g, b) = (rgb.0 / 255.0, rgb.1 / 255.0, rgb.2 / 255.0);
+    let max = r.max(g.max(b));
+    let min = r.min(g.min(b));
+    let delta = max - min;
+
+    // Lightness
+    let l = (max + min) / 2.0;
+
+    // Saturation
+    let s = if delta == 0.0 {
+        0.0
+    } else {
+        delta / (1.0 - (2.0 * l - 1.0).abs())
+    };
+
+    // Hue
+    let h = if delta == 0.0 {
+        0.0
+    } else if max == r {
+        60.0 * (((g - b) / delta) % 6.0)
+    } else if max == g {
+        60.0 * (((b - r) / delta) + 2.0)
+    } else {
+        60.0 * (((r - g) / delta) + 4.0)
+    };
+    let h = if h < 0.0 { h + 360.0 } else { h };
+    (h, s, l)
+}
+
+/// Convert HSL back to an RGB tuple (0..255).
+pub fn hsl_to_rgb(hsl: Hsl) -> Rgb {
+    let (h, s, l) = hsl;
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    let x = c * (1.0 - ((h / 60.0) % 2.0 - 1.0).abs());
+    let m = l - c / 2.0;
+
+    let (r1, g1, b1) = if (0.0..60.0).contains(&h) {
+        (c, x, 0.0)
+    } else if (60.0..120.0).contains(&h) {
+        (x, c, 0.0)
+    } else if (120.0..180.0).contains(&h) {
+        (0.0, c, x)
+    } else if (180.0..240.0).contains(&h) {
+        (0.0, x, c)
+    } else if (240.0..300.0).contains(&h) {
+        (x, 0.0, c)
+    } else {
+        (c, 0.0, x)
+    };
+    let r = ((r1 + m) * 255.0).round() as u8;
+    let g = ((g1 + m) * 255.0).round() as u8;
+    let b = ((b1 + m) * 255.0).round() as u8;
+    (r as f64, g as f64, b as f64)
+}
+
+/// Convert an RGB tuple to a hex string "#RRGGBB".
+pub fn rgb_to_hex(rgb: Rgb) -> String {
+    format!("#{{:02X}}{{:02X}}{{:02X}}", rgb.0 as u8, rgb.1 as u8, rgb.2 as u8)
+}
+
+/// Generate a palette by rotating the hue evenly around the color wheel.
+pub fn generate_palette(base: Hsl, count: usize) -> Vec<Rgb> {
+    let step = 360.0 / count as f64;
+    (0..count)
+        .map(|i| {
+            let h = (base.0 + step * i as f64) % 360.0;
+            hsl_to_rgb((h, base.1, base.2))
+        })
+        .collect()
+}

--- a/rust-utils/nightly-nightly-hex-palette-generato/src/main.rs
+++ b/rust-utils/nightly-nightly-hex-palette-generato/src/main.rs
@@ -1,0 +1,37 @@
+use std::env;
+use std::process;
+use nightly_hex_palette_generator::{hex_to_rgb, rgb_to_hex, generate_palette, rgb_to_hsl};
+
+fn print_usage() {
+    eprintln!("Usage: nightly-hex-palette-generator <hex_color> [count]");
+    eprintln!("Example: nightly-hex-palette-generator #3498db 7");
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 || args.len() > 3 {
+        print_usage();
+        process::exit(1);
+    }
+    let hex = args[1].trim();
+    let count: usize = if args.len() == 3 {
+        args[2].parse().unwrap_or_else(|_| {
+            eprintln!("Invalid count: {}", args[2]);
+            process::exit(1);
+        })
+    } else {
+        5
+    };
+    let base_rgb = match hex_to_rgb(hex) {
+        Some(rgb) => rgb,
+        None => {
+            eprintln!("Invalid hex color: {}", hex);
+            process::exit(1);
+        }
+    };
+    let base_hsl = rgb_to_hsl(base_rgb);
+    let palette = generate_palette(base_hsl, count);
+    for color in palette {
+        println!("{}", rgb_to_hex(color));
+    }
+}

--- a/rust-utils/nightly-nightly-hex-palette-generato/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-hex-palette-generato/tests/test_main.rs
@@ -1,0 +1,41 @@
+#[cfg(test)]
+mod tests {
+    use nightly_hex_palette_generator::{hex_to_rgb, rgb_to_hex, rgb_to_hsl, hsl_to_rgb, generate_palette};
+
+    #[test]
+    fn test_hex_to_rgb() {
+        assert_eq!(hex_to_rgb("#000000"), Some((0.0, 0.0, 0.0)));
+        assert_eq!(hex_to_rgb("FFFFFF"), Some((255.0, 255.0, 255.0)));
+        assert_eq!(hex_to_rgb("#1A2B3C"), Some((26.0, 43.0, 60.0)));
+        assert_eq!(hex_to_rgb("GGGGGG"), None);
+    }
+
+    #[test]
+    fn test_rgb_to_hex() {
+        assert_eq!(rgb_to_hex((0.0, 0.0, 0.0)), "#000000");
+        assert_eq!(rgb_to_hex((255.0, 255.0, 255.0)), "#FFFFFF");
+        assert_eq!(rgb_to_hex((26.0, 43.0, 60.0)), "#1A2B3C");
+    }
+
+    #[test]
+    fn test_rgb_hsl_roundtrip() {
+        let original = (123.0, 200.0, 45.0);
+        let hsl = rgb_to_hsl(original);
+        let rgb = hsl_to_rgb(hsl);
+        assert!((original.0 - rgb.0).abs() < 1.0);
+        assert!((original.1 - rgb.1).abs() < 1.0);
+        assert!((original.2 - rgb.2).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_generate_palette_count() {
+        let base = (180.0, 0.5, 0.5);
+        let palette = generate_palette(base, 4);
+        assert_eq!(palette.len(), 4);
+        let hues: Vec<f64> = palette.iter().map(|rgb| rgb_to_hsl(*rgb).0).collect();
+        let expected = vec![180.0, 270.0, 0.0, 90.0];
+        for (h, e) in hues.iter().zip(expected.iter()) {
+            assert!((h - e).abs() < 1.0);
+        }
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-hex-palette-generator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-hex-palette-generato`
- **Files Created**: 5
- **Description**: Generate a harmonious palette of hex colors from a single base color using hue rotation in HSL space.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-hex-palette-generato`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-hex-palette-generato/README.md`
- Run tests located in `rust-utils/nightly-nightly-hex-palette-generato/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.