### PR TITLE
feat(gemini): A high-performance Rust CLI tool to identify and optionally remove 'temporal dust' (old, unused files) from directories based on configurable age and patterns.

### DIFF
--- a/rust-utils/nightly-nightly-temporal-dust-sweepe/Cargo.toml
+++ b/rust-utils/nightly-nightly-temporal-dust-sweepe/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "nightly-temporal-dust-sweeper"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+walkdir = "2"
+chrono = "0.11"
+regex = "1"
+filetime = "0.2" # For setting file modification times in tests and potentially main if access_time is used
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "0.1"
+tempfile = "3"

--- a/rust-utils/nightly-nightly-temporal-dust-sweepe/README.md
+++ b/rust-utils/nightly-nightly-temporal-dust-sweepe/README.md
@@ -1,0 +1,79 @@
+# Nightly Temporal Dust Sweeper
+
+A high-performance Rust CLI tool designed to help you clean up your digital wasteland by identifying and optionally removing "temporal dust" — old, unused files that accumulate over time.
+
+## ✨ Features
+
+*   **Efficient Scanning**: Utilizes `walkdir` for fast directory traversal.
+*   **Age-Based Filtering**: Identify files older than a specified number of days.
+*   **Time Reference**: Filter by last modification time (default) or last access time.
+*   **Pattern Matching**: Filter files by regular expression patterns in their names.
+*   **Extension Filtering**: Target specific file types (e.g., `.log`, `.tmp`).
+*   **Dry Run Mode**: Safely preview which files would be swept without deleting anything.
+*   **Sweep Mode**: Permanently remove identified files.
+*   **Whimsical Output**: Adds a touch of apocalyptic charm to your cleanup routine.
+
+## 📦 Installation
+
+To install the Temporal Dust Sweeper, you'll need Rust and Cargo installed on your system. If you don't have them, visit [rust-lang.org](https://www.rust-lang.org/).
+
+```bash
+cargo install nightly-temporal-dust-sweeper
+```
+
+Alternatively, you can clone the repository and build from source:
+
+```bash
+git clone https://github.com/polsala/ApocalypsAI.git
+cd ApocalypsAI/rust-utils/nightly-temporal-dust-sweeper
+cargo build --release
+# The executable will be in target/release/nightly-temporal-dust-sweeper
+```
+
+## 💻 Usage
+
+```bash
+nightly-temporal-dust-sweeper [OPTIONS]
+```
+
+### Options
+
+*   `-p, --path <PATH>`: Path to the directory to sweep (default: current directory `.`)
+*   `-a, --age-days <DAYS>`: Files older than this many days will be considered 'dust' (default: `30`)
+*   `-d, --dry-run`: Perform a dry run: list files that would be swept, but don't delete them.
+*   `-s, --sweep`: Actually sweep (delete) the identified temporal dust. **Use with caution!**
+*   `-A, --access-time`: Use last access time instead of last modification time for age calculation.
+*   `-P, --pattern <REGEX>`: Only consider files matching this regex pattern (e.g., `".*\\.log$"`).
+*   `-e, --extension <EXT>`: Only consider files with this extension (e.g., `log`, `tmp`).
+
+### Examples
+
+1.  **List all files older than 60 days in the current directory (dry run):**
+
+    ```bash
+    nightly-temporal-dust-sweeper --age-days 60 --dry-run
+    ```
+
+2.  **Sweep (delete) all `.tmp` files older than 7 days in a specific directory:**
+
+    ```bash
+    nightly-temporal-dust-sweeper --path /var/log/old_temps --age-days 7 --extension tmp --sweep
+    ```
+
+3.  **Find old log files matching a specific pattern, using access time:**
+
+    ```bash
+    nightly-temporal-dust-sweeper --path /var/log --age-days 90 --access-time --pattern "^app_error_.*\.log$" --dry-run
+    ```
+
+4.  **List all files older than the default 30 days (dry run is default if no action specified):**
+
+    ```bash
+    nightly-temporal-dust-sweeper
+    ```
+
+    (This will perform a dry run by default, listing files older than 30 days in the current directory.)
+
+## ⚠️ Warning
+
+Using the `--sweep` flag will permanently delete files. Always perform a `--dry-run` first to ensure you are only targeting the intended files. The ApocalypsAI Nightly Integrator agent is not responsible for any data loss caused by reckless sweeping.

--- a/rust-utils/nightly-nightly-temporal-dust-sweepe/src/main.rs
+++ b/rust-utils/nightly-nightly-temporal-dust-sweepe/src/main.rs
@@ -1,0 +1,126 @@
+use clap::Parser;
+use walkdir::WalkDir;
+use chrono::{Utc, Duration, DateTime, TimeZone};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about = "Temporal Dust Sweeper: Identify and remove old, unused files.", long_about = None)]
+struct Args {
+    /// Path to the directory to sweep
+    #[clap(short, long, default_value = ".")]
+    path: PathBuf,
+
+    /// Files older than this many days will be considered 'dust'
+    #[clap(short, long, default_value_t = 30)]
+    age_days: u64,
+
+    /// Perform a dry run: list files that would be swept, but don't delete them
+    #[clap(short, long)]
+    dry_run: bool,
+
+    /// Actually sweep (delete) the identified temporal dust
+    #[clap(short, long)]
+    sweep: bool,
+
+    /// Use last access time instead of last modification time for age calculation
+    #[clap(short, long)]
+    access_time: bool,
+
+    /// Only consider files matching this regex pattern (e.g., ".*\\.log$")
+    #[clap(short, long)]
+    pattern: Option<String>,
+
+    /// Only consider files with this extension (e.g., "log", "tmp")
+    #[clap(short, long)]
+    extension: Option<String>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    if args.sweep && args.dry_run {
+        eprintln!("Error: Cannot use --sweep and --dry-run simultaneously. Choose one.");
+        std::process::exit(1);
+    }
+
+    let is_dry_run = args.dry_run || !args.sweep;
+
+    if !args.sweep && !args.dry_run {
+        println!("No action specified. Performing a dry run by default. Use --sweep to delete files.");
+    }
+
+    let cutoff_time = Utc::now() - Duration::days(args.age_days as i64);
+    let mut files_to_process = Vec::new();
+
+    let regex_pattern = args.pattern.as_ref().map(|p| regex::Regex::new(p).map_err(|e| format!("Invalid regex pattern: {}", e))).transpose()?;
+
+    println!("Scanning directory: {}", args.path.display());
+    println!("Looking for files older than {} days (cutoff: {})", args.age_days, cutoff_time.to_rfc2822());
+
+    for entry in WalkDir::new(&args.path).into_iter().filter_map(|e| e.ok()) {
+        if entry.file_type().is_file() {
+            let path = entry.path();
+            let metadata = fs::metadata(path)?;
+
+            let file_time_system = if args.access_time {
+                metadata.accessed()?
+            } else {
+                metadata.modified()?
+            };
+
+            let file_time: DateTime<Utc> = file_time_system
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e| format!("File time is before UNIX_EPOCH: {}", e))
+                .and_then(|d| Utc.timestamp_opt(d.as_secs() as i64, d.subsec_nanos()).single().ok_or_else(|| "Invalid timestamp".to_string()))?;
+
+            if file_time < cutoff_time {
+                let mut include_file = true;
+
+                if let Some(ref re) = regex_pattern {
+                    if !re.is_match(&path.to_string_lossy()) {
+                        include_file = false;
+                    }
+                }
+
+                if include_file {
+                    if let Some(ref ext) = args.extension {
+                        if path.extension().map_or(true, |e| e.to_string_lossy().to_lowercase() != ext.to_lowercase()) {
+                            include_file = false;
+                        }
+                    }
+                }
+
+                if include_file {
+                    files_to_process.push(path.to_path_buf());
+                }
+            }
+        }
+    }
+
+    if files_to_process.is_empty() {
+        println!("No temporal dust found in '{}'. The wasteland is clean!", args.path.display());
+        return Ok(());
+    }
+
+    println!("\nIdentified {} pieces of temporal dust:", files_to_process.len());
+    for file_path in &files_to_process {
+        println!("  - {}", file_path.display());
+    }
+
+    if args.sweep {
+        println!("\nSweeping away the temporal dust...");
+        for file_path in &files_to_process {
+            match fs::remove_file(file_path) {
+                Ok(_) => println!("  [SWEPT] {}", file_path.display()),
+                Err(e) => eprintln!("  [ERROR] Failed to sweep {}: {}", file_path.display(), e),
+            }
+        }
+        println!("\nTemporal dust sweeping complete. The wasteland is a bit cleaner now!");
+    } else if is_dry_run {
+        println!("\nThis was a dry run. No files were swept. Use --sweep to remove them.");
+    }
+
+    Ok(())
+}

--- a/rust-utils/nightly-nightly-temporal-dust-sweepe/tests/integration_test.rs
+++ b/rust-utils/nightly-nightly-temporal-dust-sweepe/tests/integration_test.rs
@@ -1,0 +1,185 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+use chrono::{Utc, Duration};
+
+// Helper to create a file with a specific modification time
+fn create_file_with_mtime(dir: &Path, filename: &str, days_ago: u64) -> PathBuf {
+    let file_path = dir.join(filename);
+    let mut file = File::create(&file_path).unwrap();
+    writeln!(file, "test content").unwrap();
+
+    // Set modification time
+    let mtime = Utc::now() - Duration::days(days_ago as i64);
+    let system_time = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(mtime.timestamp() as u64);
+    filetime::set_file_mtime(&file_path, filetime::FileTime::from_system_time(system_time)).unwrap();
+
+    file_path
+}
+
+#[test]
+fn test_dry_run_identifies_old_files() {
+    // Mock rationale: Create a temporary directory and files with controlled timestamps
+    // to simulate a file system state for deterministic testing.
+    let temp_dir = tempdir().unwrap();
+    let path = temp_dir.path();
+
+    // Create an old file (older than default 30 days)
+    let old_file = create_file_with_mtime(path, "old_log.log", 35);
+    // Create a recent file
+    let recent_file = create_file_with_mtime(path, "recent_data.txt", 5);
+    // Create another old file with a different extension
+    let old_config = create_file_with_mtime(path, "old_config.conf", 40);
+
+    let mut cmd = Command::cargo_bin("nightly-temporal-dust-sweeper").unwrap();
+    cmd.arg("--path").arg(path)
+       .arg("--dry-run")
+       .assert()
+       .success()
+       .stdout(predicate::str::contains(old_file.to_string_lossy().as_ref()))
+       .stdout(predicate::str::contains(old_config.to_string_lossy().as_ref()))
+       .stdout(predicate::str::contains("Identified 2 pieces of temporal dust:"))
+       .stdout(predicate::str::contains("This was a dry run. No files were swept."))
+       .stdout(predicate::str::does_not_contain(recent_file.to_string_lossy().as_ref()));
+
+    // Ensure files still exist after dry run
+    assert!(old_file.exists());
+    assert!(recent_file.exists());
+    assert!(old_config.exists());
+}
+
+#[test]
+fn test_sweep_deletes_old_files() {
+    // Mock rationale: Create a temporary directory and files with controlled timestamps
+    // to simulate a file system state for deterministic testing of deletion.
+    let temp_dir = tempdir().unwrap();
+    let path = temp_dir.path();
+
+    let old_file = create_file_with_mtime(path, "old_temp.tmp", 45);
+    let recent_file = create_file_with_mtime(path, "current_project.rs", 10);
+
+    let mut cmd = Command::cargo_bin("nightly-temporal-dust-sweeper").unwrap();
+    cmd.arg("--path").arg(path)
+       .arg("--sweep")
+       .assert()
+       .success()
+       .stdout(predicate::str::contains(old_file.to_string_lossy().as_ref()))
+       .stdout(predicate::str::contains("[SWEPT]"))
+       .stdout(predicate::str::contains("Identified 1 pieces of temporal dust:"))
+       .stdout(predicate::str::does_not_contain(recent_file.to_string_lossy().as_ref()));
+
+    // Ensure old file is deleted and recent file still exists
+    assert!(!old_file.exists());
+    assert!(recent_file.exists());
+}
+
+#[test]
+fn test_age_days_parameter() {
+    // Mock rationale: Create files with specific ages to test the age_days filter.
+    let temp_dir = tempdir().unwrap();
+    let path = temp_dir.path();
+
+    let very_old_file = create_file_with_mtime(path, "v_old.txt", 60);
+    let moderately_old_file = create_file_with_mtime(path, "m_old.txt", 20);
+    let recent_file = create_file_with_mtime(path, "recent.txt", 5);
+
+    // Test with age_days = 25 (should catch very_old and moderately_old)
+    let mut cmd = Command::cargo_bin("nightly-temporal-dust-sweeper").unwrap();
+    cmd.arg("--path").arg(path)
+       .arg("--age-days").arg("25")
+       .arg("--dry-run")
+       .assert()
+       .success()
+       .stdout(predicate::str::contains(very_old_file.to_string_lossy().as_ref()))
+       .stdout(predicate::str::contains(moderately_old_file.to_string_lossy().as_ref()))
+       .stdout(predicate::str::contains("Identified 2 pieces of temporal dust:"))
+       .stdout(predicate::str::does_not_contain(recent_file.to_string_lossy().as_ref()));
+
+    // Test with age_days = 40 (should only catch very_old)
+    let mut cmd2 = Command::cargo_bin("nightly-temporal-dust-sweeper").unwrap();
+    cmd2.arg("--path").arg(path)
+        .arg("--age-days").arg("40")
+        .arg("--dry-run")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(very_old_file.to_string_lossy().as_ref()))
+        .stdout(predicate::str::contains("Identified 1 pieces of temporal dust:"))
+        .stdout(predicate::str::does_not_contain(moderately_old_file.to_string_lossy().as_ref()))
+        .stdout(predicate::str::does_not_contain(recent_file.to_string_lossy().as_ref()));
+}
+
+#[test]
+fn test_extension_filter() {
+    // Mock rationale: Create files with different extensions to test the extension filter.
+    let temp_dir = tempdir().unwrap();
+    let path = temp_dir.path();
+
+    let old_log = create_file_with_mtime(path, "old.log", 35);
+    let old_txt = create_file_with_mtime(path, "old.txt", 35);
+    let old_json = create_file_with_mtime(path, "old.json", 35);
+
+    let mut cmd = Command::cargo_bin("nightly-temporal-dust-sweeper").unwrap();
+    cmd.arg("--path").arg(path)
+       .arg("--dry-run")
+       .arg("--extension").arg("log")
+       .assert()
+       .success()
+       .stdout(predicate::str::contains(old_log.to_string_lossy().as_ref()))
+       .stdout(predicate::str::contains("Identified 1 pieces of temporal dust:"))
+       .stdout(predicate::str::does_not_contain(old_txt.to_string_lossy().as_ref()))
+       .stdout(predicate::str::does_not_contain(old_json.to_string_lossy().as_ref()));
+}
+
+#[test]
+fn test_pattern_filter() {
+    // Mock rationale: Create files with names matching/not matching a regex pattern.
+    let temp_dir = tempdir().unwrap();
+    let path = temp_dir.path();
+
+    let old_error_log = create_file_with_mtime(path, "error_2023.log", 35);
+    let old_access_log = create_file_with_mtime(path, "access_2023.log", 35);
+    let old_data_file = create_file_with_mtime(path, "data.txt", 35);
+
+    let mut cmd = Command::cargo_bin("nightly-temporal-dust-sweeper").unwrap();
+    cmd.arg("--path").arg(path)
+       .arg("--dry-run")
+       .arg("--pattern").arg("error_.*\\.log$")
+       .assert()
+       .success()
+       .stdout(predicate::str::contains(old_error_log.to_string_lossy().as_ref()))
+       .stdout(predicate::str::contains("Identified 1 pieces of temporal dust:"))
+       .stdout(predicate::str::does_not_contain(old_access_log.to_string_lossy().as_ref()))
+       .stdout(predicate::str::does_not_contain(old_data_file.to_string_lossy().as_ref()));
+}
+
+#[test]
+fn test_no_dust_found() {
+    // Mock rationale: Create a temporary directory with only recent files.
+    let temp_dir = tempdir().unwrap();
+    let path = temp_dir.path();
+
+    create_file_with_mtime(path, "recent_file_1.txt", 5);
+    create_file_with_mtime(path, "recent_file_2.log", 10);
+
+    let mut cmd = Command::cargo_bin("nightly-temporal-dust-sweeper").unwrap();
+    cmd.arg("--path").arg(path)
+       .arg("--dry-run")
+       .assert()
+       .success()
+       .stdout(predicate::str::contains("No temporal dust found in"))
+       .stdout(predicate::str::contains("The wasteland is clean!"));
+}
+
+#[test]
+fn test_sweep_and_dry_run_conflict() {
+    let mut cmd = Command::cargo_bin("nightly-temporal-dust-sweeper").unwrap();
+    cmd.arg("--sweep")
+       .arg("--dry-run")
+       .assert()
+       .failure()
+       .stderr(predicate::str::contains("Error: Cannot use --sweep and --dry-run simultaneously. Choose one."));
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-temporal-dust-sweeper
- **Provider**: gemini
- **Location**: `rust-utils/nightly-nightly-temporal-dust-sweepe`
- **Files Created**: 4
- **Description**: A high-performance Rust CLI tool to identify and optionally remove 'temporal dust' (old, unused files) from directories based on configurable age and patterns.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-temporal-dust-sweepe`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-temporal-dust-sweepe/README.md`
- Run tests located in `rust-utils/nightly-nightly-temporal-dust-sweepe/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.