### PR TITLE
feat(groq): Concurrently pings a list of URLs and reports their HTTP status codes, useful for quick health checks.

### DIFF
--- a/go-utils/nightly-nightly-go-concurrent-ping/README.md
+++ b/go-utils/nightly-nightly-go-concurrent-ping/README.md
@@ -1,0 +1,20 @@
+# nightly-go-concurrent-ping
+
+Utility that concurrently pings a list of URLs and reports their HTTP status. Useful for quick health checks.
+
+## Usage
+
+```sh
+go run ./src/main.go -file urls.txt -concurrency 5
+```
+
+`urls.txt` contains one URL per line.
+
+## Options
+
+- `-file` path to file with URLs (required)
+- `-concurrency` max concurrent requests (default 10)
+
+## Output
+
+Each line: `<url> -> <status>` where status is HTTP status code or error.

--- a/go-utils/nightly-nightly-go-concurrent-ping/src/main.go
+++ b/go-utils/nightly-nightly-go-concurrent-ping/src/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+    "bufio"
+    "flag"
+    "fmt"
+    "net/http"
+    "os"
+    "sort"
+    "strings"
+    "sync"
+    "time"
+)
+
+func pingURL(url string) string {
+    client := http.Client{
+        Timeout: 5 * time.Second,
+    }
+    resp, err := client.Get(url)
+    if err != nil {
+        return fmt.Sprintf("%s -> error: %s", url, err.Error())
+    }
+    defer resp.Body.Close()
+    return fmt.Sprintf("%s -> %d", url, resp.StatusCode)
+}
+
+// PingURLs reads URLs from filePath, pings them with max concurrency, and returns sorted results.
+func PingURLs(filePath string, concurrency int) ([]string, error) {
+    file, err := os.Open(filePath)
+    if err != nil {
+        return nil, err
+    }
+    defer file.Close()
+
+    scanner := bufio.NewScanner(file)
+    var urls []string
+    for scanner.Scan() {
+        line := strings.TrimSpace(scanner.Text())
+        if line != "" {
+            urls = append(urls, line)
+        }
+    }
+    if err := scanner.Err(); err != nil {
+        return nil, err
+    }
+
+    if concurrency <= 0 {
+        concurrency = 10
+    }
+    sem := make(chan struct{}, concurrency)
+    var wg sync.WaitGroup
+    var mu sync.Mutex
+    results := make([]string, 0, len(urls))
+
+    for _, u := range urls {
+        wg.Add(1)
+        go func(url string) {
+            defer wg.Done()
+            sem <- struct{}{}
+            res := pingURL(url)
+            mu.Lock()
+            results = append(results, res)
+            mu.Unlock()
+            <-sem
+        }(u)
+    }
+    wg.Wait()
+    sort.Strings(results)
+    return results, nil
+}
+
+func main() {
+    filePath := flag.String("file", "", "Path to file containing URLs (one per line)")
+    concurrency := flag.Int("concurrency", 10, "Maximum concurrent requests")
+    flag.Parse()
+
+    if *filePath == "" {
+        fmt.Fprintln(os.Stderr, "error: -file is required")
+        os.Exit(1)
+    }
+
+    results, err := PingURLs(*filePath, *concurrency)
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "error:", err)
+        os.Exit(1)
+    }
+    for _, line := range results {
+        fmt.Println(line)
+    }
+}

--- a/go-utils/nightly-nightly-go-concurrent-ping/tests/main_test.go
+++ b/go-utils/nightly-nightly-go-concurrent-ping/tests/main_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+    "fmt"
+    "io/ioutil"
+    "net/http"
+    "net/http/httptest"
+    "os"
+    "sort"
+    "strings"
+    "testing"
+    "time"
+)
+
+func TestPingURLs(t *testing.T) {
+    // Server returning 200
+    srv200 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer srv200.Close()
+
+    // Server returning 404
+    srv404 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusNotFound)
+    }))
+    defer srv404.Close()
+
+    // Server that times out (sleep longer than client timeout)
+    srvTimeout := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        time.Sleep(6 * time.Second)
+    }))
+    defer srvTimeout.Close()
+
+    urls := []string{srv200.URL, srv404.URL, srvTimeout.URL}
+    tmpFile, err := ioutil.TempFile("", "urls-*.txt")
+    if err != nil {
+        t.Fatalf("failed to create temp file: %v", err)
+    }
+    defer os.Remove(tmpFile.Name())
+
+    for _, u := range urls {
+        if _, err := tmpFile.WriteString(u + "\n"); err != nil {
+            t.Fatalf("failed to write to temp file: %v", err)
+        }
+    }
+    tmpFile.Close()
+
+    results, err := PingURLs(tmpFile.Name(), 2)
+    if err != nil {
+        t.Fatalf("PingURLs returned error: %v", err)
+    }
+
+    // Expected successful results (order after sorting)
+    expected := []string{
+        fmt.Sprintf("%s -> 200", srv200.URL),
+        fmt.Sprintf("%s -> 404", srv404.URL),
+    }
+
+    // Verify timeout server produced an error entry
+    foundTimeout := false
+    for _, r := range results {
+        if strings.Contains(r, srvTimeout.URL) && strings.Contains(r, "error") {
+            foundTimeout = true
+            break
+        }
+    }
+    if !foundTimeout {
+        t.Errorf("expected timeout error for %s, got results: %v", srvTimeout.URL, results)
+    }
+
+    // Verify the successful results are present
+    sort.Strings(expected)
+    sort.Strings(results)
+    for _, exp := range expected {
+        if !contains(results, exp) {
+            t.Errorf("expected result %q not found in %v", exp, results)
+        }
+    }
+}
+
+// helper to check slice contains a string
+func contains(slice []string, item string) bool {
+    for _, s := range slice {
+        if s == item {
+            return true
+        }
+    }
+    return false
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-go-concurrent-ping
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-go-concurrent-ping`
- **Files Created**: 3
- **Description**: Concurrently pings a list of URLs and reports their HTTP status codes, useful for quick health checks.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-go-concurrent-ping`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-go-concurrent-ping/README.md`
- Run tests located in `go-utils/nightly-nightly-go-concurrent-ping/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.