### PR TITLE
feat(openrouter): A whimsical CLI tool that generates quantum-themed programming jokes with deterministic randomness based on input parameters.

### DIFF
--- a/rust-utils/nightly-nightly-quantum-quip-generat-5/Cargo.toml
+++ b/rust-utils/nightly-nightly-quantum-quip-generat-5/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nightly-quantum-quip-generator"
+version = "1.0.0"
+edition = "2021"
+authors = ["ApocalypsAI"]
+description = "A whimsical CLI tool that generates quantum-themed programming jokes with deterministic randomness"
+license = "MIT"
+repository = "https://github.com/polsala/ApocalypsAI"
+homepage = "https://github.com/polsala/ApocalypsAI"
+documentation = "https://github.com/polsala/ApocalypsAI"
+keywords = ["cli", "jokes", "quantum", "programming", "ai"]
+categories = ["command-line-utilities", "games"]
+
+[dependencies]
+clap = { version = "4.0", features = ["derive"] }
+colored = "2.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]

--- a/rust-utils/nightly-nightly-quantum-quip-generat-5/README.md
+++ b/rust-utils/nightly-nightly-quantum-quip-generat-5/README.md
@@ -1,0 +1,110 @@
+# Nightly Quantum Quip Generator
+
+A whimsical CLI tool that generates quantum-themed programming jokes with deterministic randomness based on input parameters.
+
+## Features
+
+- Generate quantum-themed programming jokes
+- Deterministic randomness based on input parameters
+- Configurable joke categories (quantum physics, programming, AI)
+- Export jokes to various formats (JSON, plain text)
+- Command-line interface with interactive mode
+
+## Installation
+
+```bash
+# Clone the repository
+git clone <repo-url>
+
+cd rust-utils/nightly-quantum-quip-generator
+
+# Build the project
+cargo build --release
+
+# Run the CLI
+cargo run --release -- --help
+```
+
+## Usage
+
+### Basic Usage
+
+```bash
+# Generate a random quantum programming joke
+cargo run --release --
+
+# Generate a joke with specific seed
+cargo run --release -- --seed 42
+
+# Generate a joke from specific category
+cargo run --release -- --category quantum
+```
+
+### Advanced Usage
+
+```bash
+# Export jokes to JSON file
+cargo run --release -- --export json --output jokes.json
+
+# Export jokes to plain text file
+cargo run --release -- --export text --output jokes.txt
+
+# Generate multiple jokes
+cargo run --release -- --count 5
+
+# Interactive mode
+cargo run --release -- --interactive
+```
+
+### Command Line Options
+
+- `--seed <number>`: Set a specific seed for deterministic randomness
+- `--category <quantum|programming|ai>`: Filter jokes by category
+- `--count <number>`: Generate multiple jokes
+- `--export <json|text>`: Export format
+- `--output <file>`: Output file path
+- `--interactive`: Start interactive mode
+- `--help`: Show help information
+
+## Examples
+
+```bash
+# Generate 3 quantum physics jokes with seed 123
+cargo run --release -- --seed 123 --category quantum --count 3
+
+# Export 10 random jokes to JSON
+cargo run --release -- --count 10 --export json --output my_jokes.json
+
+# Interactive mode for browsing jokes
+cargo run --release -- --interactive
+```
+
+## License
+
+MIT License
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## Joke Categories
+
+- **Quantum Physics**: Jokes about superposition, entanglement, and quantum mechanics
+- **Programming**: Jokes about coding, debugging, and software development
+- **AI**: Jokes about artificial intelligence, machine learning, and robotics
+
+## Technical Details
+
+The generator uses a deterministic pseudo-random number generator (PCG) seeded with user input to ensure reproducible joke sequences. Jokes are stored as templates with placeholders that are filled in based on the generated random values.
+
+## Dependencies
+
+- `clap`: Command-line argument parsing
+- `serde`: Serialization framework
+- `serde_json`: JSON serialization
+- `pcg_rand`: Pseudo-random number generator
+- `colored`: Terminal color output

--- a/rust-utils/nightly-nightly-quantum-quip-generat-5/src/generator.rs
+++ b/rust-utils/nightly-nightly-quantum-quip-generat-5/src/generator.rs
@@ -1,0 +1,166 @@
+use crate::jokes::*;
+use crate::pcg::Pcg32;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy)]
+pub enum JokeCategory {
+    Quantum,
+    Programming,
+    AI,
+    Any,
+}
+
+pub struct JokeData {
+    pub category: JokeCategory,
+    pub setup: String,
+    pub punchline: String,
+    pub explanation: String,
+}
+
+pub struct JokeGenerator {
+    rng: Pcg32,
+    quantum_jokes: Vec<QuantumJoke>,
+    programming_jokes: Vec<ProgrammingJoke>,
+    ai_jokes: Vec<AIJoke>,
+}
+
+impl JokeGenerator {
+    pub fn new(seed: u64) -> Self {
+        Self {
+            rng: Pcg32::new(seed),
+            quantum_jokes: QUANTUM_JOKES.to_vec(),
+            programming_jokes: PROGRAMMING_JOKES.to_vec(),
+            ai_jokes: AI_JOKES.to_vec(),
+        }
+    }
+
+    pub fn set_seed(&mut self, seed: u64) {
+        self.rng = Pcg32::new(seed);
+    }
+
+    pub fn generate_joke(&mut self, category: JokeCategory) -> JokeData {
+        let chosen_category = if category == JokeCategory::Any {
+            self.select_random_category()
+        } else {
+            category
+        };
+
+        match chosen_category {
+            JokeCategory::Quantum => self.generate_quantum_joke(),
+            JokeCategory::Programming => self.generate_programming_joke(),
+            JokeCategory::AI => self.generate_ai_joke(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn select_random_category(&mut self) -> JokeCategory {
+        let roll = self.rng.next_u32() % 3;
+        match roll {
+            0 => JokeCategory::Quantum,
+            1 => JokeCategory::Programming,
+            _ => JokeCategory::AI,
+        }
+    }
+
+    fn generate_quantum_joke(&mut self) -> JokeData {
+        let joke = &self.quantum_jokes[self.rng.next_u32() as usize % self.quantum_jokes.len()];
+        let setup = self.replace_placeholders(&joke.setup);
+        let punchline = self.replace_placeholders(&joke.punchline);
+        let explanation = self.replace_placeholders(&joke.explanation);
+
+        JokeData {
+            category: JokeCategory::Quantum,
+            setup,
+            punchline,
+            explanation,
+        }
+    }
+
+    fn generate_programming_joke(&mut self) -> JokeData {
+        let joke = &self.programming_jokes[self.rng.next_u32() as usize % self.programming_jokes.len()];
+        let setup = self.replace_placeholders(&joke.setup);
+        let punchline = self.replace_placeholders(&joke.punchline);
+        let explanation = self.replace_placeholders(&joke.explanation);
+
+        JokeData {
+            category: JokeCategory::Programming,
+            setup,
+            punchline,
+            explanation,
+        }
+    }
+
+    fn generate_ai_joke(&mut self) -> JokeData {
+        let joke = &self.ai_jokes[self.rng.next_u32() as usize % self.ai_jokes.len()];
+        let setup = self.replace_placeholders(&joke.setup);
+        let punchline = self.replace_placeholders(&joke.punchline);
+        let explanation = self.replace_placeholders(&joke.explanation);
+
+        JokeData {
+            category: JokeCategory::AI,
+            setup,
+            punchline,
+            explanation,
+        }
+    }
+
+    fn replace_placeholders(&mut self, text: &str) -> String {
+        let mut result = text.to_string();
+        
+        // Replace {name} placeholders
+        if result.contains("{name}") {
+            result = result.replace("{name}", &self.generate_name());
+        }
+        
+        // Replace {number} placeholders
+        if result.contains("{number}") {
+            result = result.replace("{number}", &self.generate_number().to_string());
+        }
+        
+        // Replace {quantum_term} placeholders
+        if result.contains("{quantum_term}") {
+            result = result.replace("{quantum_term}", &self.generate_quantum_term());
+        }
+        
+        // Replace {programming_term} placeholders
+        if result.contains("{programming_term}") {
+            result = result.replace("{programming_term}", &self.generate_programming_term());
+        }
+        
+        // Replace {ai_term} placeholders
+        if result.contains("{ai_term}") {
+            result = result.replace("{ai_term}", &self.generate_ai_term());
+        }
+        
+        result
+    }
+
+    fn generate_name(&mut self) -> String {
+        let first_names = ["Schrödinger", "Heisenberg", "Dirac", "Pauli", "Bohr", "Einstein", "Feynman", "Planck", "Curie", "Newton"];
+        let last_names = ["Quantum", "Bit", "Byte", "Code", "Logic", "Syntax", "Compile", "Debug", "Runtime", "Variable"];
+        
+        let first = &first_names[self.rng.next_u32() as usize % first_names.len()];
+        let last = &last_names[self.rng.next_u32() as usize % last_names.len()];
+        
+        format!("{} {}", first, last)
+    }
+
+    fn generate_number(&mut self) -> u32 {
+        self.rng.next_u32() % 1000
+    }
+
+    fn generate_quantum_term(&mut self) -> String {
+        let terms = ["superposition", "entanglement", "quantum tunneling", "wave function", "quantum foam", "quantum leap", "quantum state", "quantum field", "quantum particle", "quantum fluctuation"];
+        terms[self.rng.next_u32() as usize % terms.len()].to_string()
+    }
+
+    fn generate_programming_term(&mut self) -> String {
+        let terms = ["function", "variable", "loop", "recursion", "algorithm", "debugger", "compiler", "interpreter", "framework", "library"];
+        terms[self.rng.next_u32() as usize % terms.len()].to_string()
+    }
+
+    fn generate_ai_term(&mut self) -> String {
+        let terms = ["neural network", "machine learning", "deep learning", "artificial intelligence", "algorithm", "training data", "neural pathway", "cognitive computing", "pattern recognition", "natural language processing"];
+        terms[self.rng.next_u32() as usize % terms.len()].to_string()
+    }
+}

--- a/rust-utils/nightly-nightly-quantum-quip-generat-5/src/jokes.rs
+++ b/rust-utils/nightly-nightly-quantum-quip-generat-5/src/jokes.rs
@@ -1,0 +1,181 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuantumJoke {
+    pub setup: String,
+    pub punchline: String,
+    pub explanation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgrammingJoke {
+    pub setup: String,
+    pub punchline: String,
+    pub explanation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AIJoke {
+    pub setup: String,
+    pub punchline: String,
+    pub explanation: String,
+}
+
+pub const QUANTUM_JOKES: &[QuantumJoke] = &[
+    QuantumJoke {
+        setup: "Why did Schrödinger's cat apply for a job at the quantum computing company?",
+        punchline: "Because it heard they were looking for someone who could be both employed and unemployed at the same time!",
+        explanation: "In quantum mechanics, superposition allows particles to exist in multiple states simultaneously until observed. The cat is both alive and dead until the box is opened."
+    },
+    QuantumJoke {
+        setup: "What do you call a quantum physicist who tells jokes about {quantum_term}?",
+        punchline: "A superposition of a comedian and a scientist!",
+        explanation: "Quantum superposition is the principle that a particle can exist in multiple states at once, much like how a quantum physicist can be both serious and funny simultaneously."
+    },
+    QuantumJoke {
+        setup: "Why don't quantum particles ever get lost?",
+        punchline: "Because they're always in a state of quantum entanglement with their destination!",
+        explanation: "Quantum entanglement is a phenomenon where particles become interconnected, and the state of one instantly influences the other, regardless of distance."
+    },
+    QuantumJoke {
+        setup: "What's a quantum computer's favorite type of music?",
+        punchline: "Entangled beats and superpositioned rhythms!",
+        explanation: "Quantum computers use quantum bits (qubits) that can exist in superposition, allowing them to process multiple states simultaneously, much like how music can have multiple layers and rhythms."
+    },
+    QuantumJoke {
+        setup: "Why did the quantum particle break up with its partner?",
+        punchline: "Because their relationship was in a state of quantum uncertainty!",
+        explanation: "Heisenberg's uncertainty principle states that certain pairs of physical properties cannot be simultaneously known to arbitrary precision, much like the uncertainty in relationships."
+    },
+    QuantumJoke {
+        setup: "What do you call a quantum physicist who can predict the future?",
+        punchline: "A quantum fortune teller who sees all possible outcomes!",
+        explanation: "In quantum mechanics, the wave function describes all possible states of a system, and upon measurement, one outcome is realized from many possibilities."
+    },
+    QuantumJoke {
+        setup: "Why don't quantum particles ever get caught speeding?",
+        punchline: "Because they're always in a state of quantum tunneling through speed traps!",
+        explanation: "Quantum tunneling allows particles to pass through barriers that would be impossible to cross according to classical physics, making them effectively invisible to speed traps."
+    },
+    QuantumJoke {
+        setup: "What's the difference between a classical bit and a quantum bit?",
+        punchline: "A classical bit is either 0 or 1, but a quantum bit can be 0, 1, or both at the same time!",
+        explanation: "Classical bits have definite states (0 or 1), while quantum bits (qubits) can exist in superposition, representing multiple states simultaneously until measured."
+    },
+    QuantumJoke {
+        setup: "Why did the quantum computer go to therapy?",
+        punchline: "It had too many conflicting states and needed to work through its quantum anxiety!",
+        explanation: "Quantum computers deal with multiple states and probabilities, which can be seen as a form of 'anxiety' about which state will be realized upon measurement."
+    },
+    QuantumJoke {
+        setup: "What do you call a quantum physicist who's always late?",
+        punchline: "Someone who's in a superposition of being on time and late!",
+        explanation: "In quantum mechanics, particles can exist in multiple states simultaneously, so a quantum physicist could theoretically be both punctual and tardy at the same time."
+    },
+];
+
+pub const PROGRAMMING_JOKES: &[ProgrammingJoke] = &[
+    ProgrammingJoke {
+        setup: "Why do programmers prefer dark mode?",
+        punchline: "Because light attracts bugs!",
+        explanation: "In programming, 'bugs' refer to errors or flaws in code. The joke plays on the double meaning of bugs, suggesting that programmers prefer dark mode to avoid attracting actual insects to their screens."
+    },
+    ProgrammingJoke {
+        setup: "How many programmers does it take to change a light bulb?",
+        punchline: "None, that's a hardware problem!",
+        explanation: "Programmers work with software, not hardware. The joke highlights the distinction between software and hardware issues in computing."
+    },
+    ProgrammingJoke {
+        setup: "Why did the programmer quit his job?",
+        punchline: "Because he didn't get arrays (a raise)!",
+        explanation: "Arrays are a fundamental data structure in programming. The joke plays on the similarity in pronunciation between 'arrays' and 'a raise' (salary increase)."
+    },
+    ProgrammingJoke {
+        setup: "What's a programmer's favorite hangout place?",
+        punchline: "Foo Bar!",
+        explanation: "'Foo' and 'Bar' are commonly used placeholder names in programming examples, similar to 'John Doe' in legal contexts. The joke suggests that programmers would naturally hang out at a place with these familiar terms."
+    },
+    ProgrammingJoke {
+        setup: "Why do Java developers wear glasses?",
+        punchline: "Because they can't C#!",
+        explanation: "This joke plays on the names of programming languages Java, C, and C#. It suggests that Java developers need glasses because they can't see (C) the features of C#.",
+    },
+    ProgrammingJoke {
+        setup: "What do you call a programmer who doesn't comment their code?",
+        punchline: "A mystery writer!",
+        explanation: "Comments in code are essential for documentation and understanding. Without comments, the code becomes a mystery to other developers trying to understand it."
+    },
+    ProgrammingJoke {
+        setup: "Why did the function break up with the variable?",
+        punchline: "Because it had no class!",
+        explanation: "In object-oriented programming, functions are often methods within classes. The joke plays on the double meaning of 'class' as both a programming construct and social status."
+    },
+    ProgrammingJoke {
+        setup: "What's the object-oriented way to become wealthy?",
+        punchline: "Inheritance!",
+        explanation: "In object-oriented programming, inheritance allows a class to derive properties and methods from another class. The joke plays on the financial meaning of inheritance."
+    },
+    ProgrammingJoke {
+        setup: "Why don't programmers like nature?",
+        punchline: "It has too many bugs!",
+        explanation: "This is a classic programming joke that plays on the double meaning of 'bugs' as both insects and software errors."
+    },
+    ProgrammingJoke {
+        setup: "What do you call a programmer who works on weekends?",
+        punchline: "A weekend warrior of code!",
+        explanation: "The joke suggests that programmers who work on weekends are like warriors fighting battles in the realm of code, even during their supposed leisure time."
+    },
+];
+
+pub const AI_JOKES: &[AIJoke] = &[
+    AIJoke {
+        setup: "Why did the AI go to therapy?",
+        punchline: "It had deep learning issues!",
+        explanation: "Deep learning is a subset of machine learning that uses neural networks with many layers. The joke plays on the double meaning of 'deep learning' as both a technical term and emotional introspection."
+    },
+    AIJoke {
+        setup: "What do you call an AI that can predict the future?",
+        punchline: "Artificial Intelligence with foresight!",
+        explanation: "The joke plays on the literal meaning of 'artificial intelligence' and the concept of having the ability to see or predict future events."
+    },
+    AIJoke {
+        setup: "Why don't AI researchers ever get lost?",
+        punchline: "Because they always have a neural network to guide them!",
+        explanation: "Neural networks are a fundamental concept in AI, inspired by the human brain. The joke suggests that AI researchers are always connected to their neural networks for guidance."
+    },
+    AIJoke {
+        setup: "What's an AI's favorite type of music?",
+        punchline: "Artificial beats and neural rhythms!",
+        explanation: "The joke combines AI terminology (artificial, neural) with musical terms (beats, rhythms) to create a playful description of AI's hypothetical musical preferences."
+    },
+    AIJoke {
+        setup: "Why did the robot go on a diet?",
+        punchline: "Because it had too many bytes!",
+        explanation: "The joke plays on the double meaning of 'bytes' as both units of digital information and portions of food that one might consume."
+    },
+    AIJoke {
+        setup: "What do you call an AI that can write poetry?",
+        punchline: "A literate algorithm!",
+        explanation: "The joke combines the concept of AI algorithms with the ability to produce literature, suggesting that an AI capable of writing poetry is both algorithmic and literate."
+    },
+    AIJoke {
+        setup: "Why don't AI systems ever get lonely?",
+        punchline: "Because they're always connected to the cloud!",
+        explanation: "Cloud computing is essential for many AI systems. The joke plays on the double meaning of 'cloud' as both a computing infrastructure and weather phenomenon."
+    },
+    AIJoke {
+        setup: "What's an AI's favorite game?",
+        punchline: "Chess, because it loves calculating moves!",
+        explanation: "Chess is often associated with AI due to famous matches between computers and human champions. The joke suggests that AI enjoys chess because it involves complex calculations."
+    },
+    AIJoke {
+        setup: "Why did the AI apply for a job at the bakery?",
+        punchline: "Because it kneaded the dough and had a lot of crust!",
+        explanation: "The joke plays on the double meaning of 'knead' (to work dough) and 'needed', as well as 'crust' (bread outer layer) and 'crass' (rudely lacking in taste)."
+    },
+    AIJoke {
+        setup: "What do you call an AI that can solve any problem?",
+        punchline: "A problem-solving algorithm!",
+        explanation: "The joke combines the concept of AI algorithms with the ability to solve problems, suggesting that an AI capable of solving any problem is essentially a sophisticated problem-solving algorithm."
+    },
+];

--- a/rust-utils/nightly-nightly-quantum-quip-generat-5/src/main.rs
+++ b/rust-utils/nightly-nightly-quantum-quip-generat-5/src/main.rs
@@ -1,0 +1,277 @@
+use clap::{Arg, Command};
+use colored::*;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, Write};
+
+mod generator;
+mod jokes;
+mod pcg;
+
+use generator::{JokeCategory, JokeGenerator};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Joke {
+    category: String,
+    setup: String,
+    punchline: String,
+    explanation: String,
+}
+
+impl Joke {
+    fn new(category: JokeCategory, setup: String, punchline: String, explanation: String) -> Self {
+        Self {
+            category: format!("{:?}", category).to_lowercase(),
+            setup,
+            punchline,
+            explanation,
+        }
+    }
+
+    fn display(&self, detailed: bool) {
+        println!("\n{}", "Quantum Quip Generator".bright_cyan().bold());
+        println!("{}", "=".repeat(50).bright_cyan());
+        println!("{}: {}", "Category".bright_yellow(), self.category.bright_green());
+        println!("{}: {}", "Setup".bright_yellow(), self.setup.bright_white());
+        println!("{}: {}", "Punchline".bright_yellow(), self.punchline.bright_magenta());
+        
+        if detailed {
+            println!("{}: {}", "Explanation".bright_yellow(), self.explanation.bright_blue());
+        }
+        
+        println!("{}", "=".repeat(50).bright_cyan());
+    }
+}
+
+fn main() {
+    let matches = Command::new("Quantum Quip Generator")
+        .version("1.0.0")
+        .author("ApocalypsAI")
+        .about("Generates quantum-themed programming jokes with deterministic randomness")
+        .arg(
+            Arg::new("seed")
+                .short('s')
+                .long("seed")
+                .value_name("NUMBER")
+                .help("Set a specific seed for deterministic randomness")
+                .default_value("0")
+        )
+        .arg(
+            Arg::new("category")
+                .short('c')
+                .long("category")
+                .value_name("CATEGORY")
+                .help("Filter jokes by category: quantum, programming, or ai")
+                .possible_values(["quantum", "programming", "ai"])
+        )
+        .arg(
+            Arg::new("count")
+                .short('n')
+                .long("count")
+                .value_name("NUMBER")
+                .help("Number of jokes to generate")
+                .default_value("1")
+        )
+        .arg(
+            Arg::new("export")
+                .long("export")
+                .value_name("FORMAT")
+                .help("Export format: json or text")
+                .possible_values(["json", "text"])
+        )
+        .arg(
+            Arg::new("output")
+                .short('o')
+                .long("output")
+                .value_name("FILE")
+                .help("Output file path")
+        )
+        .arg(
+            Arg::new("interactive")
+                .short('i')
+                .long("interactive")
+                .help("Start interactive mode")
+        )
+        .arg(
+            Arg::new("detailed")
+                .short('d')
+                .long("detailed")
+                .help("Show detailed explanations")
+        )
+        .get_matches();
+
+    let seed: u64 = matches
+        .get_one::<String>("seed")
+        .unwrap()
+        .parse()
+        .expect("Seed must be a valid number");
+
+    let category = matches
+        .get_one::<String>("category")
+        .map(|c| match c.as_str() {
+            "quantum" => JokeCategory::Quantum,
+            "programming" => JokeCategory::Programming,
+            "ai" => JokeCategory::AI,
+            _ => JokeCategory::Any,
+        })
+        .unwrap_or(JokeCategory::Any);
+
+    let count: usize = matches
+        .get_one::<String>("count")
+        .unwrap()
+        .parse()
+        .expect("Count must be a valid number");
+
+    let export_format = matches.get_one::<String>("export").map(|s| s.clone());
+    let output_file = matches.get_one::<String>("output").map(|s| s.clone());
+    let interactive = matches.get_flag("interactive");
+    let detailed = matches.get_flag("detailed");
+
+    let mut generator = JokeGenerator::new(seed);
+
+    if interactive {
+        run_interactive_mode(&mut generator);
+    } else {
+        let jokes: Vec<Joke> = (0..count)
+            .map(|_| {
+                let joke_data = generator.generate_joke(category);
+                Joke::new(
+                    joke_data.category,
+                    joke_data.setup,
+                    joke_data.punchline,
+                    joke_data.explanation,
+                )
+            })
+            .collect();
+
+        if let Some(format) = export_format {
+            export_jokes(&jokes, &format, output_file.as_deref()).expect("Failed to export jokes");
+        } else {
+            for joke in jokes {
+                joke.display(detailed);
+            }
+        }
+    }
+}
+
+fn run_interactive_mode(generator: &mut JokeGenerator) {
+    println!("{}", "Welcome to Quantum Quip Generator Interactive Mode!".bright_cyan().bold());
+    println!("{}", "Type 'help' for available commands, 'quit' to exit.".bright_yellow());
+    println!();
+
+    loop {
+        print!("{} ", "Quantum>".bright_green().bold());
+        io::stdout().flush().unwrap();
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input).expect("Failed to read line");
+        let input = input.trim();
+
+        match input.to_lowercase().as_str() {
+            "quit" | "exit" => {
+                println!("{}", "Thanks for using Quantum Quip Generator!".bright_cyan());
+                break;
+            }
+            "help" => show_help(),
+            "random" | "generate" | "" => {
+                let joke_data = generator.generate_joke(JokeCategory::Any);
+                let joke = Joke::new(
+                    joke_data.category,
+                    joke_data.setup,
+                    joke_data.punchline,
+                    joke_data.explanation,
+                );
+                joke.display(true);
+            }
+            "quantum" => {
+                let joke_data = generator.generate_joke(JokeCategory::Quantum);
+                let joke = Joke::new(
+                    joke_data.category,
+                    joke_data.setup,
+                    joke_data.punchline,
+                    joke_data.explanation,
+                );
+                joke.display(true);
+            }
+            "programming" => {
+                let joke_data = generator.generate_joke(JokeCategory::Programming);
+                let joke = Joke::new(
+                    joke_data.category,
+                    joke_data.setup,
+                    joke_data.punchline,
+                    joke_data.explanation,
+                );
+                joke.display(true);
+            }
+            "ai" => {
+                let joke_data = generator.generate_joke(JokeCategory::AI);
+                let joke = Joke::new(
+                    joke_data.category,
+                    joke_data.setup,
+                    joke_data.punchline,
+                    joke_data.explanation,
+                );
+                joke.display(true);
+            }
+            cmd => {
+                if cmd.starts_with("seed ") {
+                    if let Some(seed_str) = cmd.split_whitespace().nth(1) {
+                        match seed_str.parse::<u64>() {
+                            Ok(seed) => {
+                                generator.set_seed(seed);
+                                println!("{}", format!("Seed set to: {}", seed).bright_green());
+                            }
+                            Err(_) => println!("{}", "Invalid seed value. Please provide a number.".bright_red()),
+                        }
+                    } else {
+                        println!("{}", "Please specify a seed value. Usage: seed <number>".bright_yellow());
+                    }
+                } else {
+                    println!("{}", "Unknown command. Type 'help' for available commands.".bright_red());
+                }
+            }
+        }
+    }
+}
+
+fn show_help() {
+    println!("{}", "Available commands:".bright_cyan().bold());
+    println!("  {} - Generate a random joke", "random".bright_green());
+    println!("  {} - Generate a quantum physics joke", "quantum".bright_green());
+    println!("  {} - Generate a programming joke", "programming".bright_green());
+    println!("  {} - Generate an AI joke", "ai".bright_green());
+    println!("  {} <number> - Set the random seed", "seed".bright_green());
+    println!("  {} - Show this help message", "help".bright_green());
+    println!("  {} - Exit interactive mode", "quit".bright_green());
+    println!();
+}
+
+fn export_jokes(jokes: &[Joke], format: &str, output_file: Option<&str>) -> io::Result<()> {
+    let output = match format {
+        "json" => {
+            let json = serde_json::to_string_pretty(jokes)?;
+            json
+        }
+        "text" => {
+            let mut text = String::new();
+            for joke in jokes {
+                text.push_str(&format!("Category: {}\n", joke.category));
+                text.push_str(&format!("Setup: {}\n", joke.setup));
+                text.push_str(&format!("Punchline: {}\n", joke.punchline));
+                text.push_str(&format!("Explanation: {}\n", joke.explanation));
+                text.push_str("\n");
+            }
+            text
+        }
+        _ => return Err(io::Error::new(io::ErrorKind::InvalidInput, "Unknown export format")),
+    };
+
+    if let Some(file_path) = output_file {
+        fs::write(file_path, output)?;
+        println!("{}", format!("Jokes exported to: {}", file_path).bright_green());
+    } else {
+        println!("{}", output);
+    }
+
+    Ok(())
+}

--- a/rust-utils/nightly-nightly-quantum-quip-generat-5/src/pcg.rs
+++ b/rust-utils/nightly-nightly-quantum-quip-generat-5/src/pcg.rs
@@ -1,0 +1,201 @@
+/// Permuted Congruential Generator (PCG) - a fast, high-quality pseudo-random number generator
+/// Based on the PCG-XSH-RR variant
+pub struct Pcg32 {
+    state: u64,
+    inc: u64,
+}
+
+impl Pcg32 {
+    /// Create a new PCG generator with the given seed
+    pub fn new(seed: u64) -> Self {
+        let mut pcg = Pcg32 {
+            state: 0,
+            inc: (seed << 1) | 1,
+        };
+        
+        // Initialize the state
+        pcg.next_u32();
+        pcg.state = pcg.state.wrapping_add(seed);
+        pcg.next_u32();
+        
+        pcg
+    }
+
+    /// Generate the next 32-bit random number
+    pub fn next_u32(&mut self) -> u32 {
+        let oldstate = self.state;
+        
+        // Advance internal state
+        self.state = oldstate.wrapping_mul(6364136223846793005).wrapping_add(self.inc | 1);
+        
+        // Calculate output function (XSH RR), uses old state for max ILP
+        let word = ((oldstate >> 18) ^ oldstate) >> 27;
+        let rot = oldstate >> 59;
+        
+        word.rotate_right(rot) as u32
+    }
+
+    /// Generate the next 64-bit random number
+    pub fn next_u64(&mut self) -> u64 {
+        (self.next_u32() as u64) << 32 | self.next_u32() as u64
+    }
+
+    /// Generate a random float in [0, 1)
+    pub fn next_float(&mut self) -> f32 {
+        self.next_u32() as f32 / (u32::MAX as f32 + 1.0)
+    }
+
+    /// Generate a random double in [0, 1)
+    pub fn next_double(&mut self) -> f64 {
+        self.next_u64() as f64 / (u64::MAX as f64 + 1.0)
+    }
+
+    /// Generate a random number in the range [min, max]
+    pub fn next_range(&mut self, min: u32, max: u32) -> u32 {
+        min + (self.next_u32() % (max - min + 1))
+    }
+
+    /// Shuffle a slice in-place using the Fisher-Yates algorithm
+    pub fn shuffle<T>(&mut self, slice: &mut [T]) {
+        for i in (1..slice.len()).rev() {
+            let j = self.next_range(0, i as u32) as usize;
+            slice.swap(i, j);
+        }
+    }
+
+    /// Select a random element from a slice
+    pub fn choose<T>(&mut self, slice: &[T]) -> Option<&T> {
+        if slice.is_empty() {
+            None
+        } else {
+            Some(&slice[self.next_range(0, slice.len() as u32 - 1) as usize])
+        }
+    }
+
+    /// Set the stream (sequence) for this generator
+    pub fn set_stream(&mut self, stream: u64) {
+        self.inc = (stream << 1) | 1;
+    }
+
+    /// Get the current state (for debugging or saving state)
+    pub fn get_state(&self) -> (u64, u64) {
+        (self.state, self.inc)
+    }
+
+    /// Set the state (for restoring a saved state)
+    pub fn set_state(&mut self, state: u64, inc: u64) {
+        self.state = state;
+        self.inc = inc | 1; // Ensure inc is always odd
+    }
+}
+
+impl Default for Pcg32 {
+    fn default() -> Self {
+        Self::new(42)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_generation() {
+        let mut pcg = Pcg32::new(12345);
+        
+        // Test that we can generate numbers
+        let a = pcg.next_u32();
+        let b = pcg.next_u32();
+        let c = pcg.next_u32();
+        
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_deterministic() {
+        let mut pcg1 = Pcg32::new(42);
+        let mut pcg2 = Pcg32::new(42);
+        
+        // Same seed should produce same sequence
+        for _ in 0..100 {
+            assert_eq!(pcg1.next_u32(), pcg2.next_u32());
+        }
+    }
+
+    #[test]
+    fn test_range() {
+        let mut pcg = Pcg32::new(42);
+        
+        for _ in 0..1000 {
+            let val = pcg.next_range(10, 20);
+            assert!(val >= 10 && val <= 20);
+        }
+    }
+
+    #[test]
+    fn test_float_range() {
+        let mut pcg = Pcg32::new(42);
+        
+        for _ in 0..1000 {
+            let val = pcg.next_float();
+            assert!(val >= 0.0 && val < 1.0);
+        }
+    }
+
+    #[test]
+    fn test_shuffle() {
+        let mut pcg = Pcg32::new(42);
+        let mut vec = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        
+        // Make a copy to compare
+        let original = vec.clone();
+        pcg.shuffle(&mut vec);
+        
+        // Should be different order (very unlikely to be the same)
+        assert_ne!(vec, original);
+        
+        // But should contain the same elements
+        vec.sort();
+        assert_eq!(vec, original);
+    }
+
+    #[test]
+    fn test_choose() {
+        let mut pcg = Pcg32::new(42);
+        let vec = vec![1, 2, 3, 4, 5];
+        
+        for _ in 0..100 {
+            let chosen = pcg.choose(&vec).unwrap();
+            assert!(vec.contains(chosen));
+        }
+        
+        // Test empty slice
+        let empty: Vec<i32> = vec![];
+        assert_eq!(pcg.choose(&empty), None);
+    }
+
+    #[test]
+    fn test_state_management() {
+        let mut pcg = Pcg32::new(42);
+        
+        // Generate some numbers
+        let a = pcg.next_u32();
+        let b = pcg.next_u32();
+        
+        // Save state
+        let (state, inc) = pcg.get_state();
+        
+        // Generate more numbers
+        let c = pcg.next_u32();
+        let d = pcg.next_u32();
+        
+        // Restore state
+        pcg.set_state(state, inc);
+        
+        // Should generate the same sequence
+        assert_eq!(pcg.next_u32(), c);
+        assert_eq!(pcg.next_u32(), d);
+    }
+}

--- a/rust-utils/nightly-nightly-quantum-quip-generat-5/tests/integration_test.rs
+++ b/rust-utils/nightly-nightly-quantum-quip-generat-5/tests/integration_test.rs
@@ -1,0 +1,220 @@
+use nightly_quantum_quip_generator::*;
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn test_joke_generation_deterministic() {
+    let mut generator1 = JokeGenerator::new(42);
+    let mut generator2 = JokeGenerator::new(42);
+    
+    // Generate jokes with same seed
+    let joke1 = generator1.generate_joke(JokeCategory::Any);
+    let joke2 = generator2.generate_joke(JokeCategory::Any);
+    
+    // Should be identical
+    assert_eq!(joke1.setup, joke2.setup);
+    assert_eq!(joke1.punchline, joke2.punchline);
+    assert_eq!(joke1.explanation, joke2.explanation);
+}
+
+#[test]
+fn test_joke_generation_different_seeds() {
+    let mut generator1 = JokeGenerator::new(42);
+    let mut generator2 = JokeGenerator::new(123);
+    
+    // Generate multiple jokes
+    for _ in 0..10 {
+        let joke1 = generator1.generate_joke(JokeCategory::Any);
+        let joke2 = generator2.generate_joke(JokeCategory::Any);
+        
+        // Should be different (very unlikely to be the same)
+        assert_ne!(joke1.setup, joke2.setup);
+    }
+}
+
+#[test]
+fn test_category_filtering() {
+    let mut generator = JokeGenerator::new(42);
+    
+    // Test quantum category
+    for _ in 0..10 {
+        let joke = generator.generate_joke(JokeCategory::Quantum);
+        assert_eq!(joke.category, JokeCategory::Quantum);
+    }
+    
+    // Test programming category
+    for _ in 0..10 {
+        let joke = generator.generate_joke(JokeCategory::Programming);
+        assert_eq!(joke.category, JokeCategory::Programming);
+    }
+    
+    // Test AI category
+    for _ in 0..10 {
+        let joke = generator.generate_joke(JokeCategory::AI);
+        assert_eq!(joke.category, JokeCategory::AI);
+    }
+}
+
+#[test]
+fn test_placeholder_replacement() {
+    let mut generator = JokeGenerator::new(42);
+    
+    // Generate a joke that should have placeholders replaced
+    let joke = generator.generate_joke(JokeCategory::Any);
+    
+    // Check that placeholders are replaced
+    assert!(!joke.setup.contains("{name}"));
+    assert!(!joke.setup.contains("{number}"));
+    assert!(!joke.setup.contains("{quantum_term}"));
+    assert!(!joke.setup.contains("{programming_term}"));
+    assert!(!joke.setup.contains("{ai_term}"));
+    
+    assert!(!joke.punchline.contains("{name}"));
+    assert!(!joke.punchline.contains("{number}"));
+    assert!(!joke.punchline.contains("{quantum_term}"));
+    assert!(!joke.punchline.contains("{programming_term}"));
+    assert!(!joke.punchline.contains("{ai_term}"));
+    
+    assert!(!joke.explanation.contains("{name}"));
+    assert!(!joke.explanation.contains("{number}"));
+    assert!(!joke.explanation.contains("{quantum_term}"));
+    assert!(!joke.explanation.contains("{programming_term}"));
+    assert!(!joke.explanation.contains("{ai_term}"));
+}
+
+#[test]
+fn test_export_json() {
+    let mut generator = JokeGenerator::new(42);
+    
+    // Generate some jokes
+    let jokes: Vec<Joke> = (0..5)
+        .map(|_| {
+            let joke_data = generator.generate_joke(JokeCategory::Any);
+            Joke::new(
+                joke_data.category,
+                joke_data.setup,
+                joke_data.punchline,
+                joke_data.explanation,
+            )
+        })
+        .collect();
+    
+    // Export to JSON
+    let temp_file = "/tmp/test_jokes.json";
+    export_jokes(&jokes, "json", Some(temp_file)).expect("Failed to export JSON");
+    
+    // Check file exists and can be read
+    assert!(Path::new(temp_file).exists());
+    
+    let content = fs::read_to_string(temp_file).expect("Failed to read file");
+    let parsed: Vec<Joke> = serde_json::from_str(&content).expect("Failed to parse JSON");
+    
+    assert_eq!(parsed.len(), 5);
+    
+    // Clean up
+    fs::remove_file(temp_file).expect("Failed to remove temp file");
+}
+
+#[test]
+fn test_export_text() {
+    let mut generator = JokeGenerator::new(42);
+    
+    // Generate some jokes
+    let jokes: Vec<Joke> = (0..3)
+        .map(|_| {
+            let joke_data = generator.generate_joke(JokeCategory::Any);
+            Joke::new(
+                joke_data.category,
+                joke_data.setup,
+                joke_data.punchline,
+                joke_data.explanation,
+            )
+        })
+        .collect();
+    
+    // Export to text
+    let temp_file = "/tmp/test_jokes.txt";
+    export_jokes(&jokes, "text", Some(temp_file)).expect("Failed to export text");
+    
+    // Check file exists and has content
+    assert!(Path::new(temp_file).exists());
+    
+    let content = fs::read_to_string(temp_file).expect("Failed to read file");
+    assert!(content.contains("Category:"));
+    assert!(content.contains("Setup:"));
+    assert!(content.contains("Punchline:"));
+    assert!(content.contains("Explanation:"));
+    
+    // Clean up
+    fs::remove_file(temp_file).expect("Failed to remove temp file");
+}
+
+#[test]
+fn test_invalid_export_format() {
+    let mut generator = JokeGenerator::new(42);
+    let jokes: Vec<Joke> = vec![];
+    
+    // Test invalid format
+    let result = export_jokes(&jokes, "invalid", None);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_joke_data_structure() {
+    let mut generator = JokeGenerator::new(42);
+    
+    // Generate a joke
+    let joke_data = generator.generate_joke(JokeCategory::Any);
+    
+    // Check that all fields are populated
+    assert!(!format!("{:?}", joke_data.category).is_empty());
+    assert!(!joke_data.setup.is_empty());
+    assert!(!joke_data.punchline.is_empty());
+    assert!(!joke_data.explanation.is_empty());
+}
+
+#[test]
+fn test_multiple_joke_generation() {
+    let mut generator = JokeGenerator::new(42);
+    
+    // Generate multiple jokes
+    let jokes: Vec<_> = (0..100)
+        .map(|_| generator.generate_joke(JokeCategory::Any))
+        .collect();
+    
+    // Check we got the right number
+    assert_eq!(jokes.len(), 100);
+    
+    // Check all jokes have content
+    for joke in &jokes {
+        assert!(!joke.setup.is_empty());
+        assert!(!joke.punchline.is_empty());
+        assert!(!joke.explanation.is_empty());
+    }
+}
+
+#[test]
+fn test_seed_setting() {
+    let mut generator = JokeGenerator::new(42);
+    
+    // Generate a joke
+    let joke1 = generator.generate_joke(JokeCategory::Any);
+    
+    // Change seed
+    generator.set_seed(123);
+    
+    // Generate another joke
+    let joke2 = generator.generate_joke(JokeCategory::Any);
+    
+    // Should be different
+    assert_ne!(joke1.setup, joke2.setup);
+    
+    // Set back to original seed
+    generator.set_seed(42);
+    
+    // Should generate same as first
+    let joke3 = generator.generate_joke(JokeCategory::Any);
+    assert_eq!(joke1.setup, joke3.setup);
+    assert_eq!(joke1.punchline, joke3.punchline);
+    assert_eq!(joke1.explanation, joke3.explanation);
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-quantum-quip-generator
- **Provider**: openrouter
- **Location**: `rust-utils/nightly-nightly-quantum-quip-generat-5`
- **Files Created**: 7
- **Description**: A whimsical CLI tool that generates quantum-themed programming jokes with deterministic randomness based on input parameters.

## Rationale
- Automated proposal from the OpenRouter generator delivering a fresh community utility.
- This utility was generated using the **openrouter** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-quantum-quip-generat-5`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-quantum-quip-generat-5/README.md`
- Run tests located in `rust-utils/nightly-nightly-quantum-quip-generat-5/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.