### PR TITLE
feat(groq): A whimsical concurrent port scanner written in Rust that reports open TCP ports in a given range.

### DIFF
--- a/rust-utils/nightly-nightly-nightly-porcupine-sc/Cargo.toml
+++ b/rust-utils/nightly-nightly-nightly-porcupine-sc/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nightly-nightly-porcupine-scan"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-nightly-porcupine-sc/README.md
+++ b/rust-utils/nightly-nightly-nightly-porcupine-sc/README.md
@@ -1,0 +1,26 @@
+Nightly Porcupine Port Scan
+=========================
+A whimsical yet useful concurrent port scanner written in Rust. It scans a range of TCP ports on a given host and reports which ports are open.
+
+Usage
+-----
+```bash
+cargo run --release -- 127.0.0.1 8000 8010
+```
+The program will output a list of open ports in the specified range.
+
+Features
+--------
+- Concurrent scanning with a configurable concurrency limit.
+- Simple command‑line interface.
+- No external dependencies.
+
+Installation
+------------
+```bash
+cargo install nightly-nightly-porcupine-scan
+```
+
+Testing
+-------
+Run the test suite with `cargo test`.

--- a/rust-utils/nightly-nightly-nightly-porcupine-sc/src/lib.rs
+++ b/rust-utils/nightly-nightly-nightly-porcupine-sc/src/lib.rs
@@ -1,0 +1,45 @@
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
+use std::sync::mpsc::{channel, sync_channel};
+use std::thread;
+
+/// Scans the given host for open TCP ports in the inclusive range [start, end].
+/// Returns a sorted vector of open port numbers.
+///
+/// # Arguments
+/// * `host` - The target host as a string slice.
+/// * `start` - The starting port number.
+/// * `end` - The ending port number.
+/// * `concurrency` - Maximum number of concurrent scan threads.
+pub fn scan_ports(host: &str, start: u16, end: u16, concurrency: usize) -> Vec<u16> {
+    let (tx, rx) = channel();
+    let (sem_tx, sem_rx) = sync_channel(concurrency);
+    let mut handles = Vec::new();
+
+    for port in start..=end {
+        let host = host.to_string();
+        let tx = tx.clone();
+        let sem_tx = sem_tx.clone();
+        let sem_rx = sem_rx.clone();
+        let handle = thread::spawn(move || {
+            // Acquire semaphore slot
+            sem_tx.send(()).unwrap();
+            let addr = format!("{}:{}", host, port);
+            let timeout = Duration::from_millis(200);
+            if TcpStream::connect_timeout(&addr.to_socket_addrs().unwrap().next().unwrap(), timeout).is_ok() {
+                tx.send(port).unwrap();
+            }
+            // Release semaphore slot
+            sem_rx.recv().unwrap();
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let mut open_ports: Vec<u16> = rx.iter().collect();
+    open_ports.sort_unstable();
+    open_ports
+}

--- a/rust-utils/nightly-nightly-nightly-porcupine-sc/src/main.rs
+++ b/rust-utils/nightly-nightly-nightly-porcupine-sc/src/main.rs
@@ -1,0 +1,15 @@
+use std::env;
+use std::process;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 4 {
+        eprintln!("Usage: {} <host> <start_port> <end_port>", args[0]);
+        process::exit(1);
+    }
+    let host = &args[1];
+    let start: u16 = args[2].parse().expect("Invalid start port");
+    let end: u16 = args[3].parse().expect("Invalid end port");
+    let open_ports = crate::scan_ports(host, start, end, 100);
+    println!("Open ports: {:?}", open_ports);
+}

--- a/rust-utils/nightly-nightly-nightly-porcupine-sc/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-nightly-porcupine-sc/tests/test_main.rs
@@ -1,0 +1,20 @@
+use std::net::TcpListener;
+
+#[test]
+fn test_open_port_detected() {
+    // Bind to an available port
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let open_ports = crate::scan_ports("127.0.0.1", port, port, 10);
+    assert!(open_ports.contains(&port));
+}
+
+#[test]
+fn test_no_open_ports() {
+    // Bind to an available port and immediately drop the listener
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let open_ports = crate::scan_ports("127.0.0.1", port, port, 10);
+    assert!(open_ports.is_empty());
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-nightly-porcupine-scan
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-nightly-porcupine-sc`
- **Files Created**: 5
- **Description**: A whimsical concurrent port scanner written in Rust that reports open TCP ports in a given range.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-nightly-porcupine-sc`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-nightly-porcupine-sc/README.md`
- Run tests located in `rust-utils/nightly-nightly-nightly-porcupine-sc/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.