### PR TITLE
feat(groq): Terraform module that creates a whimsical “safehouse” local storage directory with a random pet name and a version file.

### DIFF
--- a/terraform-modules/nightly-nightly-safehouse-storage/README.md
+++ b/terraform-modules/nightly-nightly-safehouse-storage/README.md
@@ -1,0 +1,29 @@
+# Safehouse Storage Terraform Module
+
+Creates a whimsical “safehouse” storage directory on the local filesystem. The directory name is a random pet name (e.g., "fluffy-otter"). Inside, a placeholder file `version.txt` is written with the version number you specify. Useful for local development, demos, or as a metaphorical vault for post‑apocalyptic data.
+
+## Usage
+
+```hcl
+module "safehouse" {
+  source  = "git::https://github.com/yourorg/ApocalypsAI.git//terraform-modules/nightly-safehouse-storage"
+  version = "1"
+}
+```
+
+Outputs:
+
+- `safehouse_name` – the generated pet name.
+- `safehouse_path` – absolute path to the created directory.
+
+## Requirements
+
+- Terraform ≥ 1.0
+- No cloud provider needed; works entirely locally.
+
+## Testing
+
+```bash
+cd terraform-modules/nightly-safehouse-storage
+bash tests/test_module.sh
+```

--- a/terraform-modules/nightly-nightly-safehouse-storage/main.tf
+++ b/terraform-modules/nightly-nightly-safehouse-storage/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "random" {}
+provider "null" {}
+provider "local" {}
+
+resource "random_pet" "name" {
+  length = 2
+}
+
+resource "null_resource" "safehouse_dir" {
+  triggers = {
+    name = random_pet.name.id
+  }
+
+  provisioner "local-exec" {
+    command = "mkdir -p ${path.module}/safehouse_${random_pet.name.id}"
+  }
+}
+
+resource "local_file" "version_file" {
+  depends_on = [null_resource.safehouse_dir]
+
+  filename = "${path.module}/safehouse_${random_pet.name.id}/version.txt"
+  content  = var.version
+}

--- a/terraform-modules/nightly-nightly-safehouse-storage/outputs.tf
+++ b/terraform-modules/nightly-nightly-safehouse-storage/outputs.tf
@@ -1,0 +1,9 @@
+output "safehouse_name" {
+  description = "Random pet name used for the safehouse directory"
+  value       = random_pet.name.id
+}
+
+output "safehouse_path" {
+  description = "Absolute path to the safehouse directory"
+  value       = "${path.module}/safehouse_${random_pet.name.id}"
+}

--- a/terraform-modules/nightly-nightly-safehouse-storage/tests/test_module.sh
+++ b/terraform-modules/nightly-nightly-safehouse-storage/tests/test_module.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Initialize Terraform without remote backend
+terraform init -backend=false > /dev/null
+
+# Validate configuration
+terraform validate
+
+# Apply with auto-approve (creates the safehouse directory locally)
+terraform apply -auto-approve -input=false > /dev/null
+
+# Capture outputs
+SAFEHOUSE_PATH=$(terraform output -raw safehouse_path)
+
+# Verify the directory exists
+if [[ ! -d "$SAFEHOUSE_PATH" ]]; then
+  echo "FAIL: Safehouse directory not created"
+  exit 1
+fi
+
+# Verify version.txt exists and contains the expected version
+if [[ ! -f "$SAFEHOUSE_PATH/version.txt" ]]; then
+  echo "FAIL: version.txt not found"
+  exit 1
+fi
+
+EXPECTED_VERSION="1"
+ACTUAL_VERSION=$(cat "$SAFEHOUSE_PATH/version.txt")
+if [[ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]]; then
+  echo "FAIL: version mismatch (expected $EXPECTED_VERSION, got $ACTUAL_VERSION)"
+  exit 1
+fi
+
+echo "PASS: Safehouse storage module works as expected"
+
+# Cleanup resources
+terraform destroy -auto-approve -input=false > /dev/null

--- a/terraform-modules/nightly-nightly-safehouse-storage/variables.tf
+++ b/terraform-modules/nightly-nightly-safehouse-storage/variables.tf
@@ -1,0 +1,5 @@
+variable "version" {
+  description = "Version string written to version.txt"
+  type        = string
+  default     = "1"
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-safehouse-storage
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-safehouse-storage`
- **Files Created**: 5
- **Description**: Terraform module that creates a whimsical “safehouse” local storage directory with a random pet name and a version file.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-safehouse-storage`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-safehouse-storage/README.md`
- Run tests located in `terraform-modules/nightly-nightly-safehouse-storage/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.