### PR TITLE
feat(groq): A whimsical Go CLI that measures and reports the round‑trip time to a host, echoing the latency like a ghostly echo.

### DIFF
--- a/go-utils/nightly-nightly-ghost-echo-lag/README.md
+++ b/go-utils/nightly-nightly-ghost-echo-lag/README.md
@@ -1,0 +1,50 @@
+Nightly Ghost Echo Lag
+======================
+
+A whimsical Go CLI that measures and reports the round‑trip time to a host, echoing the latency like a ghostly echo.
+
+Features
+--------
+
+* Connects to a TCP host and measures RTT.
+* Prints RTT in milliseconds with a playful message.
+* Simple flags: `-host`, `-port`.
+
+Installation
+------------
+
+```bash
+go install github.com/polsala/ApocalypsAI/utils/nightly-ghost-echo-lag@latest
+```
+
+Usage
+-----
+
+```bash
+# Measure RTT to localhost on port 80
+nightly-ghost-echo-lag -host localhost -port 80
+
+# Measure RTT to example.com on port 443
+nightly-ghost-echo-lag -host example.com -port 443
+```
+
+Output
+------
+
+```
+Ghostly echo: RTT = 12 ms
+```
+
+Testing
+-------
+
+Run the tests with:
+
+```bash
+go test ./...
+```
+
+License
+-------
+
+MIT

--- a/go-utils/nightly-nightly-ghost-echo-lag/src/main.go
+++ b/go-utils/nightly-nightly-ghost-echo-lag/src/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+    "flag"
+    "fmt"
+    "net"
+    "time"
+)
+
+func measureRTT(host string, port int) (time.Duration, error) {
+    addr := fmt.Sprintf("%s:%d", host, port)
+    start := time.Now()
+    conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+    if err != nil {
+        return 0, err
+    }
+    defer conn.Close()
+    rtt := time.Since(start)
+    return rtt, nil
+}
+
+func main() {
+    host := flag.String("host", "localhost", "host to ping")
+    port := flag.Int("port", 80, "port to connect")
+    flag.Parse()
+
+    rtt, err := measureRTT(*host, *port)
+    if err != nil {
+        fmt.Printf("Ghostly echo: failed to connect to %s:%d: %v\n", *host, *port, err)
+        return
+    }
+    fmt.Printf("Ghostly echo: RTT = %d ms\n", rtt.Milliseconds())
+}

--- a/go-utils/nightly-nightly-ghost-echo-lag/tests/test_main.go
+++ b/go-utils/nightly-nightly-ghost-echo-lag/tests/test_main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+    "net"
+    "testing"
+)
+
+func TestMeasureRTT(t *testing.T) {
+    // Start a local TCP listener
+    ln, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        t.Fatalf("failed to start listener: %v", err)
+    }
+    defer ln.Close()
+    addr := ln.Addr().(*net.TCPAddr)
+    // Run measureRTT
+    rtt, err := measureRTT(addr.IP.String(), addr.Port)
+    if err != nil {
+        t.Fatalf("measureRTT returned error: %v", err)
+    }
+    if rtt <= 0 {
+        t.Fatalf("expected positive RTT, got %v", rtt)
+    }
+}
+
+func TestMeasureRTTError(t *testing.T) {
+    _, err := measureRTT("10.255.255.1", 80)
+    if err == nil {
+        t.Fatalf("expected error for unreachable host")
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ghost-echo-lag
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-ghost-echo-lag`
- **Files Created**: 3
- **Description**: A whimsical Go CLI that measures and reports the round‑trip time to a host, echoing the latency like a ghostly echo.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-ghost-echo-lag`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-ghost-echo-lag/README.md`
- Run tests located in `go-utils/nightly-nightly-ghost-echo-lag/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.