### PR TITLE
feat(groq): A whimsical Bash utility that automatically compresses and purges old log files based on age thresholds.

### DIFF
--- a/bash-utils/nightly-nightly-bash-log-rotator/README.md
+++ b/bash-utils/nightly-nightly-bash-log-rotator/README.md
@@ -1,0 +1,26 @@
+# nightly-bash-log-rotator
+
+Utility to automatically compress and purge old log files.
+
+## Usage
+
+```sh
+./src/main.sh [-d DIR] [-a AGE] [-r RETENTION] [-n]
+```
+
+- `-d DIR` Directory containing logs (default: current directory)
+- `-a AGE` Days old to compress (default: 7)
+- `-r RETENTION` Days old to delete after compression (default: 30)
+- `-n` Dry‑run (show actions without modifying)
+
+## Description
+
+The script finds files older than *AGE* days, compresses them with `gzip`, then removes compressed files older than *RETENTION* days.
+
+## Example
+
+```sh
+./src/main.sh -d /var/log/myapp -a 5 -r 20
+```
+
+This will compress log files older than 5 days in `/var/log/myapp` and delete any `*.gz` files older than 20 days.

--- a/bash-utils/nightly-nightly-bash-log-rotator/src/main.sh
+++ b/bash-utils/nightly-nightly-bash-log-rotator/src/main.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default parameters
+DIR="."
+AGE=7
+RETENTION=30
+DRY_RUN=0
+
+# Parse options
+while getopts "d:a:r:n" opt; do
+  case $opt in
+    d) DIR="$OPTARG" ;;
+    a) AGE="$OPTARG" ;;
+    r) RETENTION="$OPTARG" ;;
+    n) DRY_RUN=1 ;;
+    *) echo "Invalid option"; exit 1 ;;
+  esac
+done
+
+log() {
+  echo "[log-rotator] $*"
+}
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[dry-run] $*"
+  else
+    eval "$@"
+  fi
+}
+
+# Compress old files (excluding already compressed ones)
+log "Compressing files older than $AGE days in $DIR"
+run "find \"$DIR\" -type f -mtime +$AGE ! -name \"*.gz\" -print -exec gzip {} \\;"
+
+# Delete compressed files older than retention period
+log "Deleting compressed files older than $RETENTION days in $DIR"
+run "find \"$DIR\" -type f -name \"*.gz\" -mtime +$RETENTION -print -delete"
+
+log "Done."

--- a/bash-utils/nightly-nightly-bash-log-rotator/tests/test_main.sh
+++ b/bash-utils/nightly-nightly-bash-log-rotator/tests/test_main.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Helper to create a file with a specific age (in days)
+create_file() {
+  local dir="$1"
+  local name="$2"
+  local age_days="$3"
+  local path="$dir/$name"
+  touch "$path"
+  # Set modification time to "age_days" ago
+  local timestamp=$(date -d "-$age_days days" +"%Y%m%d%H%M.%S")
+  touch -t "$timestamp" "$path"
+}
+
+# Test 1: Normal operation (compress and delete)
+TMPDIR=$(mktemp -d)
+# Files: old enough to compress, recent, already compressed and old enough to delete
+create_file "$TMPDIR" "old.log" 3   # >2 days old, should be compressed
+create_file "$TMPDIR" "recent.log" 1   # <2 days old, should stay untouched
+create_file "$TMPDIR" "very_old.log.gz" 6   # >5 days old compressed, should be deleted
+
+# Run the rotator: compress files older than 2 days, delete compressed >5 days
+bash ./src/main.sh -d "$TMPDIR" -a 2 -r 5
+
+# Assertions
+if [ ! -f "$TMPDIR/old.log.gz" ]; then
+  echo "FAIL: old.log was not compressed"
+  exit 1
+fi
+if [ -f "$TMPDIR/recent.log" ]; then
+  echo "PASS: recent.log untouched"
+else
+  echo "FAIL: recent.log missing"
+  exit 1
+fi
+if [ -e "$TMPDIR/very_old.log.gz" ]; then
+  echo "FAIL: very_old.log.gz was not deleted"
+  exit 1
+else
+  echo "PASS: very_old.log.gz correctly deleted"
+fi
+
+# Test 2: Dry‑run mode (no changes should happen)
+TMPDIR2=$(mktemp -d)
+create_file "$TMPDIR2" "dry.log" 4
+bash ./src/main.sh -d "$TMPDIR2" -a 2 -r 5 -n
+# In dry‑run, the original file must remain unchanged and not be compressed
+if [ -f "$TMPDIR2/dry.log" ] && [ ! -f "$TMPDIR2/dry.log.gz" ]; then
+  echo "PASS: dry‑run left files untouched"
+else
+  echo "FAIL: dry‑run modified files"
+  exit 1
+fi
+
+# Cleanup
+rm -rf "$TMPDIR" "$TMPDIR2"
+
+echo "All tests passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-bash-log-rotator
- **Provider**: groq
- **Location**: `bash-utils/nightly-nightly-bash-log-rotator`
- **Files Created**: 3
- **Description**: A whimsical Bash utility that automatically compresses and purges old log files based on age thresholds.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `bash-utils/nightly-nightly-bash-log-rotator`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `bash-utils/nightly-nightly-bash-log-rotator/README.md`
- Run tests located in `bash-utils/nightly-nightly-bash-log-rotator/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.