### PR TITLE
feat(openrouter): A whimsical CLI tool that checks if two code snippets are 'quantum entangled' by comparing their structure and content in a fun, probabilistic way

### DIFF
--- a/rust-utils/nightly-nightly-quantum-entanglement-8/Cargo.toml
+++ b/rust-utils/nightly-nightly-quantum-entanglement-8/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "quantum-entanglement-checker"
+version = "1.0.0"
+description = "A whimsical CLI tool that checks if two code snippets are 'quantum entangled'"
+authors = ["ApocalypsAI"]
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+clap = { version = "4.0", features = ["derive"] }
+colored = "2.0"
+
+[[bin]]
+name = "quantum-entanglement-checker"
+path = "src/main.rs"
+
+[dev-dependencies]
+test-case = "3.1"

--- a/rust-utils/nightly-nightly-quantum-entanglement-8/README.md
+++ b/rust-utils/nightly-nightly-quantum-entanglement-8/README.md
@@ -1,0 +1,71 @@
+# Nightly Quantum Entanglement Checker
+
+A whimsical CLI tool that checks if two code snippets are 'quantum entangled' by comparing their structure and content in a fun, probabilistic way.
+
+## Features
+
+- **Quantum Metaphor**: Uses quantum physics terminology to describe code similarity
+- **Probabilistic Matching**: Returns a 'quantum probability' score
+- **Multi-language Support**: Works with various programming languages
+- **Entanglement States**: Categorizes matches as 'superposed', 'collapsed', or 'decohered'
+- **CLI Interface**: Simple command-line tool with colorful output
+
+## Installation
+
+```bash
+# Clone the repository
+git clone <repo-url>
+cd <repo-url>
+
+# Build the tool
+cargo build --release
+
+# Or install directly
+cargo install --path .
+```
+
+## Usage
+
+```bash
+# Compare two files
+quantum-entanglement-checker file1.rs file2.rs
+
+# Compare with custom threshold
+quantum-entanglement-checker --threshold 0.8 file1.rs file2.rs
+
+# Verbose output with quantum state details
+quantum-entanglement-checker --verbose file1.rs file2.rs
+
+# Compare specific functions
+quantum-entanglement-checker --function "calculate" file1.rs file2.rs
+```
+
+## Example Output
+
+```
+🔬 Quantum Entanglement Analysis
+================================
+
+File A: src/lib.rs
+File B: src/utils.rs
+
+Entanglement Probability: 73.4%
+Quantum State: Superposed
+
+Particle Correlation: 0.68
+Wave Function Overlap: 0.75
+Decoherence Factor: 0.12
+
+Conclusion: The code exhibits moderate quantum entanglement.
+Recommendation: Observe with caution - collapse may occur during runtime.
+```
+
+## Quantum States Explained
+
+- **Superposed**: Code shows potential similarity but needs observation
+- **Collapsed**: Clear similarity detected with high confidence
+- **Decohered**: No meaningful entanglement found
+
+## License
+
+MIT License - feel free to use in your quantum computing projects!

--- a/rust-utils/nightly-nightly-quantum-entanglement-8/src/analyzer.rs
+++ b/rust-utils/nightly-nightly-quantum-entanglement-8/src/analyzer.rs
@@ -1,0 +1,122 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct CodeMetrics {
+    pub lines: usize,
+    pub functions: Vec<String>,
+    pub keywords: HashMap<String, usize>,
+    pub tokens: Vec<String>,
+    pub complexity: f64,
+}
+
+pub struct CodeAnalyzer;
+
+impl CodeAnalyzer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn analyze(&self, code: &str) -> CodeMetrics {
+        let lines = code.lines().count();
+        let functions = self.extract_functions(code);
+        let keywords = self.extract_keywords(code);
+        let tokens = self.tokenize(code);
+        let complexity = self.calculate_complexity(&tokens);
+
+        CodeMetrics {
+            lines,
+            functions,
+            keywords,
+            tokens,
+            complexity,
+        }
+    }
+
+    fn extract_functions(&self, code: &str) -> Vec<String> {
+        let mut functions = Vec::new();
+        for line in code.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("fn ") {
+                if let Some(name) = self.extract_function_name(trimmed) {
+                    functions.push(name);
+                }
+            }
+        }
+        functions
+    }
+
+    fn extract_function_name(&self, line: &str) -> Option<String> {
+        let after_fn = line.trim_start_matches("fn ").trim();
+        if let Some(open_paren) = after_fn.find('(') {
+            let name = after_fn[..open_paren].trim().to_string();
+            if !name.is_empty() {
+                return Some(name);
+            }
+        }
+        None
+    }
+
+    fn extract_keywords(&self, code: &str) -> HashMap<String, usize> {
+        let keywords = ["fn", "let", "if", "else", "match", "struct", "enum", "impl", "trait", "pub", "mod", "use"];
+        let mut counts = HashMap::new();
+        
+        for word in code.split_whitespace() {
+            let clean_word = word.trim_matches(|c: char| !c.is_alphanumeric());
+            if keywords.contains(&clean_word) {
+                *counts.entry(clean_word.to_string()).or_insert(0) += 1;
+            }
+        }
+        
+        counts
+    }
+
+    fn tokenize(&self, code: &str) -> Vec<String> {
+        code.split_whitespace()
+            .map(|s| s.trim_matches(|c: char| !c.is_alphanumeric()).to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    }
+
+    fn calculate_complexity(&self, tokens: &[String]) -> f64 {
+        let unique_tokens = tokens.iter().collect::<std::collections::HashSet<_>>().len();
+        let total_tokens = tokens.len();
+        
+        if total_tokens == 0 {
+            0.0
+        } else {
+            unique_tokens as f64 / total_tokens as f64
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_functions() {
+        let analyzer = CodeAnalyzer::new();
+        let code = "fn main() {\n    fn helper() {\n    }\n}";
+        let functions = analyzer.extract_functions(code);
+        assert_eq!(functions, vec!["main", "helper"]);
+    }
+
+    #[test]
+    fn test_extract_keywords() {
+        let analyzer = CodeAnalyzer::new();
+        let code = "fn main() { let x = 5; if x > 0 { println!(\"hello\"); } }";
+        let keywords = analyzer.extract_keywords(code);
+        
+        assert_eq!(keywords.get("fn"), Some(&1));
+        assert_eq!(keywords.get("let"), Some(&1));
+        assert_eq!(keywords.get("if"), Some(&1));
+    }
+
+    #[test]
+    fn test_calculate_complexity() {
+        let analyzer = CodeAnalyzer::new();
+        let tokens = vec!["fn".to_string(), "main".to_string(), "fn".to_string(), "helper".to_string()];
+        let complexity = analyzer.calculate_complexity(&tokens);
+        assert_eq!(complexity, 0.75); // 3 unique / 4 total
+    }
+}

--- a/rust-utils/nightly-nightly-quantum-entanglement-8/src/main.rs
+++ b/rust-utils/nightly-nightly-quantum-entanglement-8/src/main.rs
@@ -1,0 +1,155 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::collections::HashMap;
+use clap::{Arg, Command};
+use colored::*;
+
+mod analyzer;
+mod quantum;
+
+use analyzer::CodeAnalyzer;
+use quantum::{QuantumState, QuantumAnalyzer};
+
+fn main() {
+    let matches = Command::new("Quantum Entanglement Checker")
+        .version("1.0.0")
+        .author("ApocalypsAI")
+        .about("Checks if two code snippets are quantum entangled")
+        .arg(
+            Arg::new("file_a")
+                .help("First file to compare")
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            Arg::new("file_b")
+                .help("Second file to compare")
+                .required(true)
+                .index(2),
+        )
+        .arg(
+            Arg::new("threshold")
+                .short('t')
+                .long("threshold")
+                .value_name("PROBABILITY")
+                .help("Entanglement threshold (0.0-1.0)")
+                .default_value("0.5"),
+        )
+        .arg(
+            Arg::new("verbose")
+                .short('v')
+                .long("verbose")
+                .help("Verbose output with quantum details")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("function")
+                .short('f')
+                .long("function")
+                .value_name("NAME")
+                .help("Compare specific function names")
+        )
+        .get_matches();
+
+    let file_a = matches.get_one::<String>("file_a").unwrap();
+    let file_b = matches.get_one::<String>("file_b").unwrap();
+    let threshold: f64 = matches.get_one::<String>("threshold").unwrap().parse().expect("Invalid threshold");
+    let verbose = matches.get_flag("verbose");
+    let function_name = matches.get_one::<String>("function");
+
+    if let Err(e) = run_analysis(file_a, file_b, threshold, verbose, function_name) {
+        eprintln!("{}: {}", "Error".red().bold(), e);
+        std::process::exit(1);
+    }
+}
+
+fn run_analysis(
+    file_a: &str,
+    file_b: &str,
+    threshold: f64,
+    verbose: bool,
+    function_name: Option<&String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("{}
+{}", "🔬 Quantum Entanglement Analysis".cyan().bold(), "=".repeat(32).cyan());
+    println!();
+    
+    // Read files
+    let content_a = fs::read_to_string(file_a)?;
+    let content_b = fs::read_to_string(file_b)?;
+    
+    println!("File A: {}", file_a.bold());
+    println!("File B: {}", file_b.bold());
+    println!();
+
+    // Analyze code
+    let analyzer = CodeAnalyzer::new();
+    let metrics_a = analyzer.analyze(&content_a);
+    let metrics_b = analyzer.analyze(&content_b);
+
+    // Quantum analysis
+    let quantum_analyzer = QuantumAnalyzer::new();
+    let result = quantum_analyzer.analyze(&metrics_a, &metrics_b, function_name);
+
+    // Display results
+    display_results(&result, threshold, verbose);
+    
+    Ok(())
+}
+
+fn display_results(result: &quantum::EntanglementResult, threshold: f64, verbose: bool) {
+    println!("{}: {:.1}%", "Entanglement Probability".yellow().bold(), result.probability * 100.0);
+    
+    let state_color = match result.state {
+        QuantumState::Superposed => "yellow",
+        QuantumState::Collapsed => "green",
+        QuantumState::Decohered => "red",
+    };
+    
+    println!("{}: {}", "Quantum State".cyan().bold(), format!("{:?}", result.state).color(state_color).bold());
+    println!();
+
+    if verbose {
+        println!("{}: {:.2}", "Particle Correlation".magenta().bold(), result.particle_correlation);
+        println!("{}: {:.2}", "Wave Function Overlap".magenta().bold(), result.wave_overlap);
+        println!("{}: {:.2}", "Decoherence Factor".magenta().bold(), result.decoherence);
+        println!();
+    }
+
+    // Conclusion
+    let conclusion = if result.probability >= threshold {
+        format!("The code exhibits {} quantum entanglement.", "moderate".yellow())
+    } else {
+        format!("The code shows {} quantum entanglement.", "weak".red())
+    };
+    
+    println!("{}: {}", "Conclusion".blue().bold(), conclusion);
+    
+    if result.probability >= threshold {
+        println!("{}: {}", "Recommendation".blue().bold(), "Observe with caution - collapse may occur during runtime.".italic());
+    } else {
+        println!("{}: {}", "Recommendation".blue().bold(), "No meaningful entanglement detected - safe to proceed.".italic());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_entanglement() {
+        let content_a = "fn hello() { println!(\"world\"); }";
+        let content_b = "fn hello() { println!(\"world\"); }";
+        
+        let analyzer = CodeAnalyzer::new();
+        let metrics_a = analyzer.analyze(content_a);
+        let metrics_b = analyzer.analyze(content_b);
+        
+        let quantum_analyzer = QuantumAnalyzer::new();
+        let result = quantum_analyzer.analyze(&metrics_a, &metrics_b, None);
+        
+        assert!(result.probability > 0.8);
+        assert_eq!(result.state, QuantumState::Collapsed);
+    }
+}

--- a/rust-utils/nightly-nightly-quantum-entanglement-8/src/quantum.rs
+++ b/rust-utils/nightly-nightly-quantum-entanglement-8/src/quantum.rs
@@ -1,0 +1,226 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum QuantumState {
+    Superposed,
+    Collapsed,
+    Decohered,
+}
+
+#[derive(Debug, Clone)]
+pub struct EntanglementResult {
+    pub probability: f64,
+    pub state: QuantumState,
+    pub particle_correlation: f64,
+    pub wave_overlap: f64,
+    pub decoherence: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct CodeMetrics {
+    pub lines: usize,
+    pub functions: Vec<String>,
+    pub keywords: HashMap<String, usize>,
+    pub tokens: Vec<String>,
+    pub complexity: f64,
+}
+
+pub struct QuantumAnalyzer;
+
+impl QuantumAnalyzer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn analyze(
+        &self,
+        metrics_a: &CodeMetrics,
+        metrics_b: &CodeMetrics,
+        function_filter: Option<&String>,
+    ) -> EntanglementResult {
+        // Calculate various quantum metrics
+        let particle_correlation = self.calculate_particle_correlation(metrics_a, metrics_b);
+        let wave_overlap = self.calculate_wave_overlap(metrics_a, metrics_b);
+        let decoherence = self.calculate_decoherence(metrics_a, metrics_b);
+        
+        // Apply function filter if specified
+        let filtered_correlation = if let Some(func_name) = function_filter {
+            self.apply_function_filter(metrics_a, metrics_b, func_name)
+        } else {
+            particle_correlation
+        };
+
+        // Calculate final probability
+        let probability = self.calculate_entanglement_probability(
+            filtered_correlation,
+            wave_overlap,
+            decoherence,
+        );
+
+        // Determine quantum state
+        let state = self.determine_quantum_state(probability);
+
+        EntanglementResult {
+            probability,
+            state,
+            particle_correlation: filtered_correlation,
+            wave_overlap,
+            decoherence,
+        }
+    }
+
+    fn calculate_particle_correlation(&self, a: &CodeMetrics, b: &CodeMetrics) -> f64 {
+        // Compare function signatures
+        let func_similarity = self.compare_functions(&a.functions, &b.functions);
+        
+        // Compare keyword distributions
+        let keyword_similarity = self.compare_keywords(&a.keywords, &b.keywords);
+        
+        // Compare complexity
+        let complexity_diff = (a.complexity - b.complexity).abs();
+        let complexity_similarity = 1.0 - complexity_diff.min(1.0);
+        
+        // Weighted average
+        (func_similarity * 0.4) + (keyword_similarity * 0.4) + (complexity_similarity * 0.2)
+    }
+
+    fn compare_functions(&self, funcs_a: &[String], funcs_b: &[String]) -> f64 {
+        if funcs_a.is_empty() && funcs_b.is_empty() {
+            return 1.0;
+        }
+        if funcs_a.is_empty() || funcs_b.is_empty() {
+            return 0.0;
+        }
+
+        let set_a: std::collections::HashSet<_> = funcs_a.iter().collect();
+        let set_b: std::collections::HashSet<_> = funcs_b.iter().collect();
+        
+        let intersection = set_a.intersection(&set_b).count();
+        let union = set_a.union(&set_b).count();
+        
+        intersection as f64 / union as f64
+    }
+
+    fn compare_keywords(&self, keywords_a: &HashMap<String, usize>, keywords_b: &HashMap<String, usize>) -> f64 {
+        let all_keys: std::collections::HashSet<_> = keywords_a.keys().chain(keywords_b.keys()).collect();
+        
+        let mut total_similarity = 0.0;
+        let mut key_count = 0;
+        
+        for key in all_keys {
+            let count_a = keywords_a.get(key).copied().unwrap_or(0);
+            let count_b = keywords_b.get(key).copied().unwrap_or(0);
+            
+            let max_count = count_a.max(count_b) as f64;
+            if max_count > 0.0 {
+                let min_count = count_a.min(count_b) as f64;
+                let similarity = min_count / max_count;
+                total_similarity += similarity;
+                key_count += 1;
+            }
+        }
+        
+        if key_count == 0 {
+            0.0
+        } else {
+            total_similarity / key_count as f64
+        }
+    }
+
+    fn calculate_wave_overlap(&self, a: &CodeMetrics, b: &CodeMetrics) -> f64 {
+        // Compare token sequences using a simplified Jaccard similarity
+        let set_a: std::collections::HashSet<_> = a.tokens.iter().collect();
+        let set_b: std::collections::HashSet<_> = b.tokens.iter().collect();
+        
+        let intersection = set_a.intersection(&set_b).count();
+        let union = set_a.union(&set_b).count();
+        
+        if union == 0 {
+            0.0
+        } else {
+            intersection as f64 / union as f64
+        }
+    }
+
+    fn calculate_decoherence(&self, a: &CodeMetrics, b: &CodeMetrics) -> f64 {
+        // Measure how much the code structures differ
+        let line_diff = (a.lines as f64 - b.lines as f64).abs();
+        let max_lines = a.lines.max(b.lines) as f64;
+        
+        let line_decoherence = if max_lines > 0 { line_diff / max_lines } else { 0.0 };
+        
+        // Add complexity difference to decoherence
+        let complexity_diff = (a.complexity - b.complexity).abs();
+        
+        (line_decoherence + complexity_diff) / 2.0
+    }
+
+    fn apply_function_filter(&self, a: &CodeMetrics, b: &CodeMetrics, func_name: &str) -> f64 {
+        // Only consider the specified function for correlation
+        let has_func_a = a.functions.iter().any(|f| f == func_name);
+        let has_func_b = b.functions.iter().any(|f| f == func_name);
+        
+        if has_func_a && has_func_b {
+            1.0
+        } else if !has_func_a && !has_func_b {
+            1.0
+        } else {
+            0.0
+        }
+    }
+
+    fn calculate_entanglement_probability(&self, correlation: f64, wave_overlap: f64, decoherence: f64) -> f64 {
+        // Quantum-inspired probability calculation
+        let base_probability = (correlation + wave_overlap) / 2.0;
+        
+        // Apply decoherence penalty
+        let probability = base_probability * (1.0 - decoherence * 0.5);
+        
+        // Ensure bounds
+        probability.clamp(0.0, 1.0)
+    }
+
+    fn determine_quantum_state(&self, probability: f64) -> QuantumState {
+        if probability >= 0.7 {
+            QuantumState::Collapsed
+        } else if probability >= 0.3 {
+            QuantumState::Superposed
+        } else {
+            QuantumState::Decohered
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compare_functions_identical() {
+        let analyzer = QuantumAnalyzer::new();
+        let funcs_a = vec!["main".to_string(), "helper".to_string()];
+        let funcs_b = vec!["main".to_string(), "helper".to_string()];
+        
+        let similarity = analyzer.compare_functions(&funcs_a, &funcs_b);
+        assert_eq!(similarity, 1.0);
+    }
+
+    #[test]
+    fn test_compare_functions_no_overlap() {
+        let analyzer = QuantumAnalyzer::new();
+        let funcs_a = vec!["main".to_string()];
+        let funcs_b = vec!["helper".to_string()];
+        
+        let similarity = analyzer.compare_functions(&funcs_a, &funcs_b);
+        assert_eq!(similarity, 0.0);
+    }
+
+    #[test]
+    fn test_determine_quantum_state() {
+        let analyzer = QuantumAnalyzer::new();
+        
+        assert_eq!(analyzer.determine_quantum_state(0.8), QuantumState::Collapsed);
+        assert_eq!(analyzer.determine_quantum_state(0.5), QuantumState::Superposed);
+        assert_eq!(analyzer.determine_quantum_state(0.2), QuantumState::Decohered);
+    }
+}

--- a/rust-utils/nightly-nightly-quantum-entanglement-8/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-quantum-entanglement-8/tests/test_main.rs
@@ -1,0 +1,133 @@
+use std::fs;
+use std::process::Command;
+
+#[test]
+fn test_quantum_entanglement_checker() {
+    // Create test files
+    let test_dir = "test_files";
+    fs::create_dir_all(test_dir).unwrap();
+    
+    let file_a = format!("{}/test_a.rs", test_dir);
+    let file_b = format!("{}/test_b.rs", test_dir);
+    
+    // Write identical content
+    fs::write(&file_a, "fn hello() { println!(\"world\"); }\
+fn goodbye() { println!(\"farewell\"); }\
+").unwrap();
+    fs::write(&file_b, "fn hello() { println!(\"world\"); }\
+fn goodbye() { println!(\"farewell\"); }\
+").unwrap();
+    
+    // Run the tool
+    let output = Command::new(env!("CARGO_BIN_EXE_quantum-entanglement-checker"))
+        .arg(&file_a)
+        .arg(&file_b)
+        .output()
+        .expect("Failed to run quantum-entanglement-checker");
+    
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    
+    // Check that probability is high for identical files
+    assert!(stdout.contains("Entanglement Probability:"));
+    assert!(stdout.contains("Quantum State:"));
+    
+    // Clean up
+    fs::remove_dir_all(test_dir).unwrap();
+}
+
+#[test]
+fn test_different_files_low_entanglement() {
+    let test_dir = "test_files_diff";
+    fs::create_dir_all(test_dir).unwrap();
+    
+    let file_a = format!("{}/test_a.rs", test_dir);
+    let file_b = format!("{}/test_b.rs", test_dir);
+    
+    // Write different content
+    fs::write(&file_a, "fn main() { let x = 5; }\
+").unwrap();
+    fs::write(&file_b, "fn helper() { let y = 10; }\
+").unwrap();
+    
+    let output = Command::new(env!("CARGO_BIN_EXE_quantum-entanglement-checker"))
+        .arg(&file_a)
+        .arg(&file_b)
+        .output()
+        .expect("Failed to run quantum-entanglement-checker");
+    
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    
+    // Should show low entanglement
+    assert!(stdout.contains("Entanglement Probability:"));
+    
+    // Clean up
+    fs::remove_dir_all(test_dir).unwrap();
+}
+
+#[test]
+fn test_function_filter() {
+    let test_dir = "test_files_func";
+    fs::create_dir_all(test_dir).unwrap();
+    
+    let file_a = format!("{}/test_a.rs", test_dir);
+    let file_b = format!("{}/test_b.rs", test_dir);
+    
+    // Write content with different functions
+    fs::write(&file_a, "fn main() { }\
+fn helper() { }\
+").unwrap();
+    fs::write(&file_b, "fn main() { }\
+fn other() { }\
+").unwrap();
+    
+    let output = Command::new(env!("CARGO_BIN_EXE_quantum-entanglement-checker"))
+        .arg(&file_a)
+        .arg(&file_b)
+        .arg("--function")
+        .arg("main")
+        .output()
+        .expect("Failed to run quantum-entanglement-checker");
+    
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    
+    // Should show high entanglement for the specific function
+    assert!(stdout.contains("Entanglement Probability:"));
+    
+    // Clean up
+    fs::remove_dir_all(test_dir).unwrap();
+}
+
+#[test]
+fn test_verbose_output() {
+    let test_dir = "test_files_verbose";
+    fs::create_dir_all(test_dir).unwrap();
+    
+    let file_a = format!("{}/test_a.rs", test_dir);
+    let file_b = format!("{}/test_b.rs", test_dir);
+    
+    fs::write(&file_a, "fn test() { }\
+").unwrap();
+    fs::write(&file_b, "fn test() { }\
+").unwrap();
+    
+    let output = Command::new(env!("CARGO_BIN_EXE_quantum-entanglement-checker"))
+        .arg(&file_a)
+        .arg(&file_b)
+        .arg("--verbose")
+        .output()
+        .expect("Failed to run quantum-entanglement-checker");
+    
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    
+    // Should include verbose quantum details
+    assert!(stdout.contains("Particle Correlation:"));
+    assert!(stdout.contains("Wave Function Overlap:"));
+    assert!(stdout.contains("Decoherence Factor:"));
+    
+    // Clean up
+    fs::remove_dir_all(test_dir).unwrap();
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-quantum-entanglement-checker
- **Provider**: openrouter
- **Location**: `rust-utils/nightly-nightly-quantum-entanglement-8`
- **Files Created**: 6
- **Description**: A whimsical CLI tool that checks if two code snippets are 'quantum entangled' by comparing their structure and content in a fun, probabilistic way

## Rationale
- Automated proposal from the OpenRouter generator delivering a fresh community utility.
- This utility was generated using the **openrouter** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-quantum-entanglement-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-quantum-entanglement-8/README.md`
- Run tests located in `rust-utils/nightly-nightly-quantum-entanglement-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.