### PR TITLE
feat(groq): A concurrent HTTP server that echoes back request details for debugging.

### DIFF
--- a/go-utils/nightly-nightly-echo-server/README.md
+++ b/go-utils/nightly-nightly-echo-server/README.md
@@ -1,0 +1,18 @@
+Nightly Echo Server
+
+A lightweight concurrent HTTP server that echoes back request details.
+Useful for debugging HTTP clients and inspecting traffic.
+
+Usage:
+  go run src/main.go
+  # Server listens on :8080
+
+  curl -X POST http://localhost:8080 -d "hello world"
+
+Response:
+  {
+    "method":"POST",
+    "url":"/",
+    "headers":{...},
+    "body":"hello world"
+  }

--- a/go-utils/nightly-nightly-echo-server/go.mod
+++ b/go-utils/nightly-nightly-echo-server/go.mod
@@ -1,0 +1,3 @@
+module nightly-echo-server
+
+go 1.20

--- a/go-utils/nightly-nightly-echo-server/src/main.go
+++ b/go-utils/nightly-nightly-echo-server/src/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+    "encoding/json"
+    "io/ioutil"
+    "log"
+    "net/http"
+    "os"
+)
+
+type EchoResponse struct {
+    Method  string            `json:"method"`
+    URL     string            `json:"url"`
+    Headers map[string]string `json:"headers"`
+    Body    string            `json:"body"`
+}
+
+func echoHandler(w http.ResponseWriter, r *http.Request) {
+    bodyBytes, err := ioutil.ReadAll(r.Body)
+    if err != nil {
+        http.Error(w, "failed to read body", http.StatusInternalServerError)
+        return
+    }
+    defer r.Body.Close()
+
+    headers := make(map[string]string)
+    for k, v := range r.Header {
+        headers[k] = v[0]
+    }
+
+    resp := EchoResponse{
+        Method:  r.Method,
+        URL:     r.URL.Path,
+        Headers: headers,
+        Body:    string(bodyBytes),
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(resp)
+}
+
+func main() {
+    port := os.Getenv("PORT")
+    if port == "" {
+        port = "8080"
+    }
+    http.HandleFunc("/", echoHandler)
+    log.Printf("Starting echo server on :%s\n", port)
+    if err := http.ListenAndServe(":"+port, nil); err != nil {
+        log.Fatalf("Server failed: %v", err)
+    }
+}

--- a/go-utils/nightly-nightly-echo-server/tests/test_main.go
+++ b/go-utils/nightly-nightly-echo-server/tests/test_main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "io/ioutil"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+func TestEchoHandler(t *testing.T) {
+    ts := httptest.NewServer(http.HandlerFunc(echoHandler))
+    defer ts.Close()
+
+    // Test GET
+    resp, err := http.Get(ts.URL)
+    if err != nil {
+        t.Fatalf("GET request failed: %v", err)
+    }
+    defer resp.Body.Close()
+    if resp.StatusCode != http.StatusOK {
+        t.Fatalf("Expected status 200, got %d", resp.StatusCode)
+    }
+    bodyBytes, _ := ioutil.ReadAll(resp.Body)
+    var echoResp EchoResponse
+    if err := json.Unmarshal(bodyBytes, &echoResp); err != nil {
+        t.Fatalf("Failed to unmarshal response: %v", err)
+    }
+    if echoResp.Method != "GET" || echoResp.URL != "/" {
+        t.Errorf("Unexpected echo response: %+v", echoResp)
+    }
+
+    // Test POST
+    payload := []byte("hello world")
+    resp, err = http.Post(ts.URL, "text/plain", bytes.NewReader(payload))
+    if err != nil {
+        t.Fatalf("POST request failed: %v", err)
+    }
+    defer resp.Body.Close()
+    bodyBytes, _ = ioutil.ReadAll(resp.Body)
+    if err := json.Unmarshal(bodyBytes, &echoResp); err != nil {
+        t.Fatalf("Failed to unmarshal POST response: %v", err)
+    }
+    if echoResp.Method != "POST" || echoResp.Body != string(payload) {
+        t.Errorf("Unexpected POST echo response: %+v", echoResp)
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-echo-server
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-echo-server`
- **Files Created**: 4
- **Description**: A concurrent HTTP server that echoes back request details for debugging.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-echo-server`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-echo-server/README.md`
- Run tests located in `go-utils/nightly-nightly-echo-server/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.