### PR TITLE
feat(groq): A lightweight concurrent HTTP status checker that reports the health of a list of URLs.

### DIFF
--- a/go-utils/nightly-nightly-http-checker/README.md
+++ b/go-utils/nightly-nightly-http-checker/README.md
@@ -1,0 +1,27 @@
+Nightly HTTP Checker
+====================
+
+A lightweight concurrent HTTP status checker that reports the health of a list of URLs.
+
+Usage
+-----
+
+```bash
+# Provide a file with one URL per line
+go run ./src/main.go urls.txt
+
+# Or pipe URLs via stdin
+cat urls.txt | go run ./src/main.go
+```
+
+The utility prints each URL followed by its HTTP status code or an error message.
+
+Options
+-------
+
+- `-c N` – number of concurrent workers (default 10).
+
+Testing
+-------
+
+Run `go test ./...` to execute the test suite.

--- a/go-utils/nightly-nightly-http-checker/go.mod
+++ b/go-utils/nightly-nightly-http-checker/go.mod
@@ -1,0 +1,3 @@
+module nightly-http-checker
+
+go 1.20

--- a/go-utils/nightly-nightly-http-checker/src/main.go
+++ b/go-utils/nightly-nightly-http-checker/src/main.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+type Result struct {
+	URL    string
+	Status string
+}
+
+func CheckURLs(urls []string, concurrency int) ([]Result, error) {
+	results := make([]Result, len(urls))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, concurrency)
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	for i, url := range urls {
+		wg.Add(1)
+		go func(idx int, u string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			resp, err := client.Get(u)
+			if err != nil {
+				results[idx] = Result{URL: u, Status: fmt.Sprintf("error: %v", err)}
+				return
+			}
+			defer resp.Body.Close()
+			results[idx] = Result{URL: u, Status: fmt.Sprintf("%d %s", resp.StatusCode, http.StatusText(resp.StatusCode))}
+		}(i, url)
+	}
+	wg.Wait()
+	return results, nil
+}
+
+func readURLsFromFile(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	var urls []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line != "" {
+			urls = append(urls, line)
+		}
+	}
+	return urls, scanner.Err()
+}
+
+func readURLsFromStdin() ([]string, error) {
+	var urls []string
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line != "" {
+			urls = append(urls, line)
+		}
+	}
+	return urls, scanner.Err()
+}
+
+func main() {
+	var filePath string
+	var concurrency int
+	flag.StringVar(&filePath, "f", "", "Path to file containing URLs (one per line). If omitted, reads from stdin.")
+	flag.IntVar(&concurrency, "c", 10, "Number of concurrent workers.")
+	flag.Parse()
+
+	var urls []string
+	var err error
+	if filePath != "" {
+		urls, err = readURLsFromFile(filePath)
+	} else {
+		urls, err = readURLsFromStdin()
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading URLs: %v\n", err)
+		os.Exit(1)
+	}
+	if len(urls) == 0 {
+		fmt.Fprintln(os.Stderr, "No URLs provided.")
+		os.Exit(1)
+	}
+
+	results, _ := CheckURLs(urls, concurrency)
+	for _, r := range results {
+		fmt.Printf("%s -> %s\n", r.URL, r.Status)
+	}
+}

--- a/go-utils/nightly-nightly-http-checker/tests/test_main.go
+++ b/go-utils/nightly-nightly-http-checker/tests/test_main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckURLs(t *testing.T) {
+	// Setup test servers
+	server200 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server200.Close()
+
+	server404 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server404.Close()
+
+	// Invalid URL
+	badURL := "http://invalid.host"
+
+	urls := []string{server200.URL, server404.URL, badURL}
+	results, err := CheckURLs(urls, 2)
+	if err != nil {
+		t.Fatalf("CheckURLs returned error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("Expected 3 results, got %d", len(results))
+	}
+
+	// Verify statuses
+	for _, r := range results {
+		switch r.URL {
+		case server200.URL:
+			if r.Status != "200 OK" {
+				t.Errorf("Expected 200 OK, got %s", r.Status)
+			}
+		case server404.URL:
+			if r.Status != "404 Not Found" {
+				t.Errorf("Expected 404 Not Found, got %s", r.Status)
+			}
+		case badURL:
+			if r.Status == "" || r.Status[:6] != "error:" {
+				t.Errorf("Expected error status for bad URL, got %s", r.Status)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-http-checker
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-http-checker`
- **Files Created**: 4
- **Description**: A lightweight concurrent HTTP status checker that reports the health of a list of URLs.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-http-checker`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-http-checker/README.md`
- Run tests located in `go-utils/nightly-nightly-http-checker/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.