### PR TITLE
feat(openrouter): A whimsical tool that checks if two code files are quantum-entangled (identical) using Go's concurrency features

### DIFF
--- a/go-utils/nightly-nightly-quantum-entanglement/README.md
+++ b/go-utils/nightly-nightly-quantum-entanglement/README.md
@@ -1,0 +1,83 @@
+# Nightly Quantum Entanglement Checker
+
+Ever wondered if your code files are quantum-entangled across the multiverse? This whimsical-yet-useful utility checks if two files are identical using Go's concurrency features, complete with quantum-themed output!
+
+## Features
+
+- **Quantum-themed output**: Get results with quantum physics terminology
+- **Concurrent processing**: Uses Go's goroutines for efficient file comparison
+- **Checksum verification**: Generates SHA-256 hashes for both files
+- **Entanglement probability**: Displays a fun "quantum entanglement probability" score
+- **Superposition states**: Shows file states in quantum terms
+
+## Installation
+
+### Prerequisites
+- Go 1.20 or later
+
+### Build from source
+
+```bash
+# Clone or download this utility
+# Navigate to the directory
+# Build the binary
+go build -o quantum-entanglement-checker
+
+# Run the utility
+./quantum-entanglement-checker <file1> <file2>
+```
+
+## Usage
+
+```bash
+# Basic usage
+./quantum-entanglement-checker file1.txt file2.txt
+
+# Check if two Go files are entangled
+./quantum-entanglement-checker main.go backup.go
+
+# Compare configuration files
+./quantum-entanglement-checker config.json config.backup.json
+```
+
+## Example Output
+
+```
+🔬 Quantum Entanglement Analysis Report 🔬
+==========================================
+
+File 1: file1.txt
+  📄 Schrödinger State: Collapsed (Classical)
+  🔗 Quantum Signature: a1b2c3d4e5f6...
+  ⚖️  Wave Function: Stable
+
+File 2: file2.txt
+  📄 Schrödinger State: Collapsed (Classical)
+  🔗 Quantum Signature: a1b2c3d4e5f6...
+  ⚖️  Wave Function: Stable
+
+🔬 Entanglement Analysis:
+  🌀 Quantum Correlation: 100.00%
+  🌀 Entanglement Status: ✨ QUANTUM ENTANGLEMENT DETECTED ✨
+  🌀 Coherence Level: Perfect
+
+💡 Interpretation:
+  These files exist in a perfectly entangled quantum state.
+  Any measurement on one will instantaneously affect the other!
+```
+
+## How It Works
+
+1. **Concurrent Hashing**: Two goroutines hash each file simultaneously
+2. **Quantum State Analysis**: Analyzes file properties using quantum metaphors
+3. **Entanglement Calculation**: Compares hashes and calculates entanglement probability
+4. **Superposition Reporting**: Displays results with quantum physics terminology
+
+## License
+
+MIT License - see LICENSE file for details.
+
+---
+
+*Note: This tool uses actual cryptographic hashing, not actual quantum mechanics.
+Any resemblance to real quantum physics is purely for entertainment purposes.*

--- a/go-utils/nightly-nightly-quantum-entanglement/src/main.go
+++ b/go-utils/nightly-nightly-quantum-entanglement/src/main.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// QuantumFile represents a file with quantum properties
+type QuantumFile struct {
+	Path       string
+	Size       int64
+	Hash       string
+	Exists     bool
+	State      string
+	WaveFunc   string
+}
+
+// QuantumEntanglementResult represents the entanglement analysis
+type QuantumEntanglementResult struct {
+	File1              QuantumFile
+	File2              QuantumFile
+	EntanglementScore  float64
+	IsEntangled        bool
+	CoherenceLevel     string
+}
+
+// hashFile concurrently computes the SHA-256 hash of a file
+func hashFile(filePath string, wg *sync.WaitGroup, resultChan chan<- QuantumFile) {
+	defer wg.Done()
+
+	qf := QuantumFile{
+		Path:   filePath,
+		Exists: false,
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		resultChan <- qf
+		return
+	}
+	defer file.Close()
+
+	// Get file info
+	info, err := file.Stat()
+	if err != nil {
+		resultChan <- qf
+		return
+	}
+
+	qf.Exists = true
+	qf.Size = info.Size()
+
+	// Compute hash
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		resultChan <- qf
+		return
+	}
+
+	qf.Hash = hex.EncodeToString(hasher.Sum(nil))
+	qf.State = "Collapsed (Classical)"
+	qf.WaveFunc = "Stable"
+
+	resultChan <- qf
+}
+
+// calculateEntanglementScore calculates the entanglement probability
+func calculateEntanglementScore(qf1, qf2 QuantumFile) (float64, bool, string) {
+	if !qf1.Exists || !qf2.Exists {
+		return 0.0, false, "Undefined"
+	}
+
+	if qf1.Hash == qf2.Hash {
+		return 100.0, true, "Perfect"
+	}
+
+	// Calculate similarity based on size difference
+	var larger, smaller int64
+	if qf1.Size > qf2.Size {
+		larger, smaller = qf1.Size, qf2.Size
+	} else {
+		larger, smaller = qf2.Size, qf1.Size
+	}
+
+	if larger == 0 {
+		return 0.0, false, "No Coherence"
+	}
+
+	diffRatio := float64(larger-smaller) / float64(larger)
+	similarity := (1.0 - diffRatio) * 50.0 // Max 50% for size similarity
+
+	// Add some "quantum noise" for hash difference
+	similarity += 10.0 // Base quantum uncertainty
+
+	coherence := "Low"
+	if similarity > 75.0 {
+		coherence = "High"
+	} else if similarity > 50.0 {
+		coherence = "Medium"
+	}
+
+	return similarity, false, coherence
+}
+
+// formatFileSize formats file size in human-readable format
+func formatFileSize(size int64) string {
+	const (
+		KB = 1 << 10
+		MB = 1 << 20
+		GB = 1 << 30
+	)
+
+	if size < KB {
+		return fmt.Sprintf("%d B", size)
+	} else if size < MB {
+		return fmt.Sprintf("%.2f KB", float64(size)/KB)
+	} else if size < GB {
+		return fmt.Sprintf("%.2f MB", float64(size)/MB)
+	}
+	return fmt.Sprintf("%.2f GB", float64(size)/GB)
+}
+
+// printHeader prints the quantum analysis header
+func printHeader() {
+	fmt.Println("🔬 Quantum Entanglement Analysis Report 🔬")
+	fmt.Println("=" + strings.Repeat("=", 48))
+	fmt.Println()
+}
+
+// printFileAnalysis prints the analysis for a single file
+func printFileAnalysis(qf QuantumFile) {
+	filename := filepath.Base(qf.Path)
+	fmt.Printf("File: %s\n", filename)
+	
+	if !qf.Exists {
+		fmt.Printf("  📄 Schrödinger State: Non-existent (Quantum Void)\n")
+		fmt.Printf("  🔗 Quantum Signature: Unavailable\n")
+		fmt.Printf("  ⚖️  Wave Function: Collapsed\n")
+	} else {
+		fmt.Printf("  📄 Schrödinger State: %s\n", qf.State)
+		fmt.Printf("  🔗 Quantum Signature: %s\n", shortenHash(qf.Hash))
+		fmt.Printf("  ⚖️  Wave Function: %s\n", qf.WaveFunc)
+		fmt.Printf("  📏 File Size: %s\n", formatFileSize(qf.Size))
+	}
+	fmt.Println()
+}
+
+// printEntanglementAnalysis prints the entanglement analysis
+func printEntanglementAnalysis(result QuantumEntanglementResult) {
+	fmt.Println("🔬 Entanglement Analysis:")
+	fmt.Printf("  🌀 Quantum Correlation: %.2f%%\n", result.EntanglementScore)
+	
+	if result.IsEntangled {
+		fmt.Printf("  🌀 Entanglement Status: ✨ QUANTUM ENTANGLEMENT DETECTED ✨\n")
+	} else {
+		fmt.Printf("  🌀 Entanglement Status: No Entanglement Detected\n")
+	}
+	
+	fmt.Printf("  🌀 Coherence Level: %s\n", result.CoherenceLevel)
+	fmt.Println()
+}
+
+// printInterpretation prints the quantum interpretation
+func printInterpretation(result QuantumEntanglementResult) {
+	fmt.Println("💡 Interpretation:")
+	
+	if result.IsEntangled {
+		fmt.Println("  These files exist in a perfectly entangled quantum state.")
+		fmt.Println("  Any measurement on one will instantaneously affect the other!")
+		fmt.Println("  Spooky action at a distance confirmed! 👻")
+	} else {
+		if result.EntanglementScore > 50 {
+			fmt.Println("  These files show partial quantum correlation.")
+			fmt.Println("  They may share some quantum properties but are not fully entangled.")
+		} else {
+			fmt.Println("  These files appear to be in separate quantum states.")
+			fmt.Println("  No significant quantum correlation detected.")
+		}
+	}
+	fmt.Println()
+}
+
+// shortenHash shortens a hash for display purposes
+func shortenHash(hash string) string {
+	if len(hash) > 12 {
+		return hash[:6] + "..." + hash[len(hash)-6:]
+	}
+	return hash
+}
+
+// validateFiles validates that files exist and are readable
+func validateFiles(path1, path2 string) error {
+	for i, path := range []string{path1, path2} {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return fmt.Errorf("file %d (%s) does not exist", i+1, path)
+		} else if err != nil {
+			return fmt.Errorf("cannot access file %d (%s): %v", i+1, path, err)
+		}
+	}
+	return nil
+}
+
+func main() {
+	// Check command line arguments
+	if len(os.Args) != 3 {
+		fmt.Println("Usage: quantum-entanglement-checker <file1> <file2>")
+		fmt.Println()
+		fmt.Println("Example:")
+		fmt.Println("  quantum-entanglement-checker file1.txt file2.txt")
+		os.Exit(1)
+	}
+
+	file1 := os.Args[1]
+	file2 := os.Args[2]
+
+	// Validate files
+	if err := validateFiles(file1, file2); err != nil {
+		fmt.Printf("❌ Validation Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print header
+	printHeader()
+
+	// Perform concurrent hashing
+	var wg sync.WaitGroup
+	resultChan := make(chan QuantumFile, 2)
+
+	wg.Add(2)
+	go hashFile(file1, &wg, resultChan)
+	go hashFile(file2, &wg, resultChan)
+
+	// Wait for completion
+	wg.Wait()
+	close(resultChan)
+
+	// Collect results
+	var qf1, qf2 QuantumFile
+	for result := range resultChan {
+		if result.Path == file1 {
+			qf1 = result
+		} else {
+			qf2 = result
+		}
+	}
+
+	// Print file analyses
+	printFileAnalysis(qf1)
+	printFileAnalysis(qf2)
+
+	// Calculate entanglement
+	entanglementScore, isEntangled, coherenceLevel := calculateEntanglementScore(qf1, qf2)
+	result := QuantumEntanglementResult{
+		File1:             qf1,
+		File2:             qf2,
+		EntanglementScore: entanglementScore,
+		IsEntangled:       isEntangled,
+		CoherenceLevel:    coherenceLevel,
+	}
+
+	// Print entanglement analysis
+	printEntanglementAnalysis(result)
+
+	// Print interpretation
+	printInterpretation(result)
+
+	// Print footer with timestamp
+	fmt.Printf("⏱️  Analysis completed at %s\n", time.Now().Format("2006-01-02 15:04:05"))
+	fmt.Println()
+	fmt.Println("🌌 Remember: All measurements are relative to the observer's frame of reference.")
+}

--- a/go-utils/nightly-nightly-quantum-entanglement/tests/test_main.go
+++ b/go-utils/nightly-nightly-quantum-entanglement/tests/test_main.go
@@ -1,0 +1,411 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestHashFile tests the concurrent file hashing functionality
+func TestHashFile(t *testing.T) {
+	// Create temporary test files
+	tempDir, err := os.MkdirTemp("", "quantum_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Test file 1
+	testFile1 := filepath.Join(tempDir, "test1.txt")
+	content1 := "Hello, Quantum World!"
+	if err := os.WriteFile(testFile1, []byte(content1), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test file 2 (identical content)
+	testFile2 := filepath.Join(tempDir, "test2.txt")
+	if err := os.WriteFile(testFile2, []byte(content1), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test file 3 (different content)
+	testFile3 := filepath.Join(tempDir, "test3.txt")
+	content3 := "Hello, Classical World!"
+	if err := os.WriteFile(testFile3, []byte(content3), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test hashing identical files
+	var wg sync.WaitGroup
+	resultChan := make(chan QuantumFile, 2)
+
+	wg.Add(2)
+	go hashFile(testFile1, &wg, resultChan)
+	go hashFile(testFile2, &wg, resultChan)
+
+	wg.Wait()
+	close(resultChan)
+
+	var results []QuantumFile
+	for result := range resultChan {
+		results = append(results, result)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+	}
+
+	// Both files should exist and have the same hash
+	for _, result := range results {
+		if !result.Exists {
+			t.Error("Expected file to exist")
+		}
+		if result.Hash == "" {
+			t.Error("Expected non-empty hash")
+		}
+		if result.Size != int64(len(content1)) {
+			t.Errorf("Expected size %d, got %d", len(content1), result.Size)
+		}
+	}
+
+	// Check that hashes are identical
+	if results[0].Hash != results[1].Hash {
+		t.Error("Expected identical hashes for identical files")
+	}
+}
+
+// TestCalculateEntanglementScore tests the entanglement calculation logic
+func TestCalculateEntanglementScore(t *testing.T) {
+	tests := []struct {
+		name        string
+		qf1, qf2    QuantumFile
+		expScore    float64
+		expEntangled bool
+		expCoherence string
+	}{
+		{
+			name: "Identical files",
+			qf1: QuantumFile{
+				Exists: true,
+				Hash:   "abc123",
+				Size:   100,
+			},
+			qf2: QuantumFile{
+				Exists: true,
+				Hash:   "abc123",
+				Size:   100,
+			},
+			expScore:    100.0,
+			expEntangled: true,
+			expCoherence: "Perfect",
+		},
+		{
+			name: "Different files, same size",
+			qf1: QuantumFile{
+				Exists: true,
+				Hash:   "abc123",
+				Size:   100,
+			},
+			qf2: QuantumFile{
+				Exists: true,
+				Hash:   "def456",
+				Size:   100,
+			},
+			expScore:    60.0, // 50% size similarity + 10% quantum noise
+			expEntangled: false,
+			expCoherence: "High",
+		},
+		{
+			name: "Different files, different sizes",
+			qf1: QuantumFile{
+				Exists: true,
+				Hash:   "abc123",
+				Size:   100,
+			},
+			qf2: QuantumFile{
+				Exists: true,
+				Hash:   "def456",
+				Size:   200,
+			},
+			expScore:    35.0, // 25% size similarity + 10% quantum noise
+			expEntangled: false,
+			expCoherence: "Low",
+		},
+		{
+			name: "One file doesn't exist",
+			qf1: QuantumFile{
+				Exists: false,
+				Hash:   "",
+				Size:   0,
+			},
+			qf2: QuantumFile{
+				Exists: true,
+				Hash:   "abc123",
+				Size:   100,
+			},
+			expScore:    0.0,
+			expEntangled: false,
+			expCoherence: "Undefined",
+		},
+		{
+			name: "Both files don't exist",
+			qf1: QuantumFile{
+				Exists: false,
+				Hash:   "",
+				Size:   0,
+			},
+			qf2: QuantumFile{
+				Exists: false,
+				Hash:   "",
+				Size:   0,
+			},
+			expScore:    0.0,
+			expEntangled: false,
+			expCoherence: "Undefined",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score, entangled, coherence := calculateEntanglementScore(tt.qf1, tt.qf2)
+			
+			if score != tt.expScore {
+				t.Errorf("Expected score %.2f, got %.2f", tt.expScore, score)
+			}
+			if entangled != tt.expEntangled {
+				t.Errorf("Expected entangled %v, got %v", tt.expEntangled, entangled)
+			}
+			if coherence != tt.expCoherence {
+				t.Errorf("Expected coherence %s, got %s", tt.expCoherence, coherence)
+			}
+		})
+	}
+}
+
+// TestFormatFileSize tests the file size formatting function
+func TestFormatFileSize(t *testing.T) {
+	tests := []struct {
+		size     int64
+		expected string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.00 KB"},
+		{1536, "1.50 KB"},
+		{1048576, "1.00 MB"},
+		{1572864, "1.50 MB"},
+		{1073741824, "1.00 GB"},
+	}
+
+	for _, tt := range tests {
+		result := formatFileSize(tt.size)
+		if result != tt.expected {
+			t.Errorf("Expected %s, got %s for size %d", tt.expected, result, tt.size)
+		}
+	}
+}
+
+// TestShortenHash tests the hash shortening function
+func TestShortenHash(t *testing.T) {
+	tests := []struct {
+		hash     string
+		expected string
+	}{
+		{"", ""},
+		{"abc", "abc"},
+		{"abcdef", "abcdef"},
+		{"a1b2c3d4e5f6g7h8i9j0", "a1b2c3...g7h8i9j0"},
+		{"0123456789abcdef0123456789abcdef0123456789abcdef", "012345...89abcdef"},
+	}
+
+	for _, tt := range tests {
+		result := shortenHash(tt.hash)
+		if result != tt.expected {
+			t.Errorf("Expected %s, got %s for hash %s", tt.expected, result, tt.hash)
+		}
+	}
+}
+
+// TestValidateFiles tests file validation
+func TestValidateFiles(t *testing.T) {
+	// Create temporary directory and files
+	tempDir, err := os.MkdirTemp("", "validate_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create test files
+	testFile1 := filepath.Join(tempDir, "test1.txt")
+	testFile2 := filepath.Join(tempDir, "test2.txt")
+	if err := os.WriteFile(testFile1, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(testFile2, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test valid files
+	err = validateFiles(testFile1, testFile2)
+	if err != nil {
+		t.Errorf("Expected no error for valid files, got %v", err)
+	}
+
+	// Test non-existent file
+	nonExistent := filepath.Join(tempDir, "nonexistent.txt")
+	err = validateFiles(testFile1, nonExistent)
+	if err == nil {
+		t.Error("Expected error for non-existent file")
+	} else if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("Expected 'does not exist' error, got %v", err)
+	}
+}
+
+// BenchmarkHashFile benchmarks the concurrent file hashing
+func BenchmarkHashFile(b *testing.B) {
+	// Create a temporary file with test data
+	tempDir, err := os.MkdirTemp("", "benchmark_test")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a 1MB test file
+	testFile := filepath.Join(tempDir, "benchmark.txt")
+	testData := make([]byte, 1024*1024) // 1MB
+	for i := range testData {
+		testData[i] = byte(i % 256)
+	}
+	if err := os.WriteFile(testFile, testData, 0644); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+		resultChan := make(chan QuantumFile, 1)
+		
+		wg.Add(1)
+		go hashFile(testFile, &wg, resultChan)
+		
+		wg.Wait()
+		close(resultChan)
+		
+		<-resultChan // Consume the result
+	}
+}
+
+// BenchmarkCalculateEntanglementScore benchmarks the entanglement calculation
+func BenchmarkCalculateEntanglementScore(b *testing.B) {
+	qf1 := QuantumFile{
+		Exists: true,
+		Hash:   "abc123def456",
+		Size:   1024,
+	}
+	qf2 := QuantumFile{
+		Exists: true,
+		Hash:   "def456abc123",
+		Size:   2048,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		calculateEntanglementScore(qf1, qf2)
+	}
+}
+
+// TestHashAccuracy tests that the hash function produces correct SHA-256 hashes
+func TestHashAccuracy(t *testing.T) {
+	// Create temporary test file
+	tempDir, err := os.MkdirTemp("", "hash_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	testFile := filepath.Join(tempDir, "test.txt")
+	testContent := "Quantum entanglement test content"
+	if err := os.WriteFile(testFile, []byte(testContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Compute expected hash manually
+	expectedHasher := sha256.New()
+	io.WriteString(expectedHasher, testContent)
+	expectedHash := hex.EncodeToString(expectedHasher.Sum(nil))
+
+	// Get hash from our function
+	var wg sync.WaitGroup
+	resultChan := make(chan QuantumFile, 1)
+	
+	wg.Add(1)
+	go hashFile(testFile, &wg, resultChan)
+	
+	wg.Wait()
+	close(resultChan)
+	
+	result := <-resultChan
+	
+	if result.Hash != expectedHash {
+		t.Errorf("Expected hash %s, got %s", expectedHash, result.Hash)
+	}
+	
+	if result.Size != int64(len(testContent)) {
+		t.Errorf("Expected size %d, got %d", len(testContent), result.Size)
+	}
+}
+
+// TestConcurrentHashingOrder tests that concurrent hashing works regardless of order
+func TestConcurrentHashingOrder(t *testing.T) {
+	// Create temporary directory
+	tempDir, err := os.MkdirTemp("", "concurrent_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create two identical files
+	testFile1 := filepath.Join(tempDir, "test1.txt")
+	testFile2 := filepath.Join(tempDir, "test2.txt")
+	content := "Concurrent test content"
+	if err := os.WriteFile(testFile1, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(testFile2, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run multiple times to test for race conditions
+	for i := 0; i < 10; i++ {
+		var wg sync.WaitGroup
+		resultChan := make(chan QuantumFile, 2)
+		
+		wg.Add(2)
+		go hashFile(testFile1, &wg, resultChan)
+		go hashFile(testFile2, &wg, resultChan)
+		
+		wg.Wait()
+		close(resultChan)
+		
+		var results []QuantumFile
+		for result := range resultChan {
+			results = append(results, result)
+		}
+		
+		if len(results) != 2 {
+			t.Errorf("Iteration %d: Expected 2 results, got %d", i+1, len(results))
+			continue
+		}
+		
+		// Both should have identical hashes
+		if results[0].Hash != results[1].Hash {
+			t.Errorf("Iteration %d: Expected identical hashes, got %s and %s", 
+				i+1, results[0].Hash, results[1].Hash)
+		}
+	}
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-quantum-entanglement-checker
- **Provider**: openrouter
- **Location**: `go-utils/nightly-nightly-quantum-entanglement`
- **Files Created**: 3
- **Description**: A whimsical tool that checks if two code files are quantum-entangled (identical) using Go's concurrency features

## Rationale
- Automated proposal from the OpenRouter generator delivering a fresh community utility.
- This utility was generated using the **openrouter** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-quantum-entanglement`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-quantum-entanglement/README.md`
- Run tests located in `go-utils/nightly-nightly-quantum-entanglement/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.