### PR TITLE
feat(groq): An Ansible playbook that creates a deterministic 'Gnome of the Day' motivational quote file.

### DIFF
--- a/ansible-playbooks/nightly-nightly-gnome-of-the-day/README.md
+++ b/ansible-playbooks/nightly-nightly-gnome-of-the-day/README.md
@@ -1,0 +1,19 @@
+# Nightly Gnome of the Day
+
+An Ansible playbook that creates a whimsical "Gnome of the Day" text file with a motivational quote. The quote is selected deterministically based on the current day of month, ensuring reproducible results for testing.
+
+## Usage
+
+```bash
+ansible-playbook -i inventory.ini src/playbook.yml
+```
+
+It will generate `/tmp/gnome_of_the_day.txt` containing the selected quote.
+
+## Files
+
+- `src/playbook.yml` – main playbook.
+- `vars/quotes.yml` – list of gnome quotes.
+- `templates/quote.j2` – Jinja2 template for the output file.
+- `inventory.ini` – simple localhost inventory.
+- `tests/test_playbook.sh` – automated test.

--- a/ansible-playbooks/nightly-nightly-gnome-of-the-day/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-gnome-of-the-day/inventory.ini
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-gnome-of-the-day/src/playbook.yml
+++ b/ansible-playbooks/nightly-nightly-gnome-of-the-day/src/playbook.yml
@@ -1,0 +1,18 @@
+- name: Generate Gnome of the Day
+  hosts: all
+  gather_facts: true
+  vars_files:
+    - ../vars/quotes.yml
+  vars:
+    day_of_month: "{{ ansible_date_time.day | int }}"
+  tasks:
+    - name: Determine quote index
+      set_fact:
+        quote_index: "{{ (day_of_month) % (gnome_quotes | length) }}"
+
+    - name: Render quote file
+      template:
+        src: ../templates/quote.j2
+        dest: /tmp/gnome_of_the_day.txt
+      vars:
+        selected_quote: "{{ gnome_quotes[quote_index] }}"

--- a/ansible-playbooks/nightly-nightly-gnome-of-the-day/templates/quote.j2
+++ b/ansible-playbooks/nightly-nightly-gnome-of-the-day/templates/quote.j2
@@ -1,0 +1,1 @@
+{{ selected_quote }}

--- a/ansible-playbooks/nightly-nightly-gnome-of-the-day/tests/test_playbook.sh
+++ b/ansible-playbooks/nightly-nightly-gnome-of-the-day/tests/test_playbook.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+# Run the playbook with a deterministic day (1)
+ansible-playbook -i inventory.ini src/playbook.yml -e "day_of_month=1"
+
+# Verify the file was created
+if [ ! -f /tmp/gnome_of_the_day.txt ]; then
+  echo "File not created"
+  exit 1
+fi
+
+content=$(cat /tmp/gnome_of_the_day.txt)
+expected="A gnome a day keeps the void at bay."
+
+if [ "$content" != "$expected" ]; then
+  echo "Unexpected content: $content"
+  exit 1
+fi
+
+echo "Test passed"

--- a/ansible-playbooks/nightly-nightly-gnome-of-the-day/vars/quotes.yml
+++ b/ansible-playbooks/nightly-nightly-gnome-of-the-day/vars/quotes.yml
@@ -1,0 +1,6 @@
+gnome_quotes:
+  - "Keep your garden tidy, even in the apocalypse."
+  - "A gnome a day keeps the void at bay."
+  - "Dig deep, the treasure is beneath the soil."
+  - "Even a tiny gnome can move a mountain of sand."
+  - "Plant hope, harvest resilience."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-gnome-of-the-day
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-gnome-of-the-day`
- **Files Created**: 6
- **Description**: An Ansible playbook that creates a deterministic 'Gnome of the Day' motivational quote file.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-gnome-of-the-day`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-gnome-of-the-day/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-gnome-of-the-day/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.