### PR TITLE
feat(openrouter): A whimsical tool that checks if two code files are quantum-entangled by comparing their hashes with a probabilistic twist.

### DIFF
--- a/rust-utils/nightly-nightly-quantum-entanglement-12/README.md
+++ b/rust-utils/nightly-nightly-quantum-entanglement-12/README.md
@@ -1,0 +1,62 @@
+# Nightly Quantum Entanglement Checker
+
+Ever wondered if your code files are quantum-entangled across the multiverse? This whimsical-yet-useful tool checks if two files share the same quantum state (hash) with a probabilistic twist!
+
+## Features
+
+- 🚀 Fast Rust implementation with SHA-256 hashing
+- 🌀 Quantum metaphor with "probability waves" and "entanglement"
+- 🎲 Probabilistic output that adds quantum uncertainty
+- 📊 Detailed comparison report
+- 🧪 Comprehensive test suite
+
+## Installation
+
+```bash
+cargo build --release
+```
+
+## Usage
+
+```bash
+# Check if two files are quantum-entangled
+cargo run --release -- --file1 path/to/file1.txt --file2 path/to/file2.txt
+
+# With custom probability threshold (0.0-1.0)
+cargo run --release -- --file1 path/to/file1.txt --file2 path/to/file2.txt --threshold 0.8
+
+# Verbose output with quantum state details
+cargo run --release -- --file1 path/to/file1.txt --file2 path/to/file2.txt --verbose
+```
+
+## Example Output
+
+```
+🔬 Quantum Entanglement Analysis
+================================
+
+File 1: src/main.rs
+  📏 Size: 1,234 bytes
+  🌀 Quantum State: a1b2c3d4e5f6...
+  ⚡ Energy Level: High
+
+File 2: src/main_copy.rs
+  📏 Size: 1,234 bytes
+  🌀 Quantum State: a1b2c3d4e5f6...
+  ⚡ Energy Level: High
+
+🔮 Entanglement Probability: 99.7%
+✅ Quantum States Match!
+🎉 Files are quantum-entangled!
+```
+
+## Quantum Mechanics Explained
+
+In our quantum universe:
+- **Quantum State** = SHA-256 hash of the file
+- **Energy Level** = File size category (Low/Medium/High)
+- **Entanglement Probability** = 100% if hashes match, otherwise random (quantum uncertainty!)
+
+## License
+
+MIT License - because quantum physics should be free for everyone!

--- a/rust-utils/nightly-nightly-quantum-entanglement-12/src/main.rs
+++ b/rust-utils/nightly-nightly-quantum-entanglement-12/src/main.rs
@@ -1,0 +1,322 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::process;
+use clap::{Arg, Command};
+use sha2::{Sha256, Digest};
+use rand::Rng;
+
+/// Quantum energy levels based on file size
+#[derive(Debug, Clone)]
+enum QuantumEnergy {
+    Low,
+    Medium,
+    High,
+}
+
+impl QuantumEnergy {
+    fn from_size(size: u64) -> Self {
+        if size < 1024 {
+            QuantumEnergy::Low
+        } else if size < 1024 * 1024 {
+            QuantumEnergy::Medium
+        } else {
+            QuantumEnergy::High
+        }
+    }
+
+    fn to_string(&self) -> &'static str {
+        match self {
+            QuantumEnergy::Low => "Low",
+            QuantumEnergy::Medium => "Medium",
+            QuantumEnergy::High => "High",
+        }
+    }
+}
+
+/// Quantum state representation
+#[derive(Debug)]
+struct QuantumState {
+    hash: String,
+    size: u64,
+    energy: QuantumEnergy,
+}
+
+impl QuantumState {
+    fn new(file_path: &Path) -> Result<Self, String> {
+        let content = fs::read(file_path)
+            .map_err(|e| format!("Failed to read file {}: {}", file_path.display(), e))?;
+        
+        let mut hasher = Sha256::new();
+        hasher.update(&content);
+        let hash = format!("{:x}", hasher.finalize());
+        
+        let size = content.len() as u64;
+        let energy = QuantumEnergy::from_size(size);
+        
+        Ok(QuantumState { hash, size, energy })
+    }
+
+    fn get_hash_prefix(&self) -> String {
+        self.hash[..12].to_string()
+    }
+}
+
+/// Quantum entanglement analysis result
+#[derive(Debug)]
+struct EntanglementResult {
+    probability: f64,
+    entangled: bool,
+    explanation: String,
+}
+
+impl EntanglementResult {
+    fn new(state1: &QuantumState, state2: &QuantumState, threshold: f64) -> Self {
+        if state1.hash == state2.hash {
+            EntanglementResult {
+                probability: 100.0,
+                entangled: true,
+                explanation: "Identical quantum states detected!".to_string(),
+            }
+        } else {
+            // Quantum uncertainty: random probability when hashes differ
+            let mut rng = rand::thread_rng();
+            let probability = rng.gen_range(0.0..100.0);
+            let entangled = probability >= (100.0 - threshold * 100.0);
+            
+            EntanglementResult {
+                probability,
+                entangled,
+                explanation: "Different quantum states, but quantum uncertainty allows for entanglement!".to_string(),
+            }
+        }
+    }
+}
+
+/// Print quantum analysis report
+fn print_quantum_report(
+    file1: &Path,
+    file2: &Path,
+    state1: &QuantumState,
+    state2: &QuantumState,
+    result: &EntanglementResult,
+    verbose: bool,
+) {
+    println!("🔬 Quantum Entanglement Analysis");
+    println!("================================");
+    println!("");
+    
+    println!("File 1: {}", file1.display());
+    println!("  📏 Size: {} bytes", state1.size);
+    println!("  🌀 Quantum State: {}...", state1.get_hash_prefix());
+    println!("  ⚡ Energy Level: {}", state1.energy.to_string());
+    
+    if verbose {
+        println!("  📊 Full Hash: {}", state1.hash);
+    }
+    
+    println!("");
+    
+    println!("File 2: {}", file2.display());
+    println!("  📏 Size: {} bytes", state2.size);
+    println!("  🌀 Quantum State: {}...", state2.get_hash_prefix());
+    println!("  ⚡ Energy Level: {}", state2.energy.to_string());
+    
+    if verbose {
+        println!("  📊 Full Hash: {}", state2.hash);
+    }
+    
+    println!("");
+    println!("🔮 Entanglement Probability: {:.1}%", result.probability);
+    
+    if result.entangled {
+        println!("✅ Quantum States Match!");
+        println!("🎉 Files are quantum-entangled!");
+    } else {
+        println!("❌ Quantum States Differ");
+        println!("🌌 Files are not entangled");
+    }
+    
+    println!("");
+    println!("📝 Explanation: {}");
+}
+
+/// Main function
+fn main() {
+    let matches = Command::new("Quantum Entanglement Checker")
+        .version("1.0.0")
+        .author("ApocalypsAI")
+        .about("Checks if two files are quantum-entangled")
+        .arg(
+            Arg::new("file1")
+                .short('f')
+                .long("file1")
+                .value_name("FILE1")
+                .help("First file to compare")
+                .required(true),
+        )
+        .arg(
+            Arg::new("file2")
+                .short('s')
+                .long("file2")
+                .value_name("FILE2")
+                .help("Second file to compare")
+                .required(true),
+        )
+        .arg(
+            Arg::new("threshold")
+                .short('t')
+                .long("threshold")
+                .value_name("THRESHOLD")
+                .help("Entanglement threshold (0.0-1.0)")
+                .default_value("0.5"),
+        )
+        .arg(
+            Arg::new("verbose")
+                .short('v')
+                .long("verbose")
+                .help("Verbose output with full hashes")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .get_matches();
+
+    let file1_path = matches.get_one::<String>("file1").unwrap();
+    let file2_path = matches.get_one::<String>("file2").unwrap();
+    let threshold_str = matches.get_one::<String>("threshold").unwrap();
+    let verbose = matches.get_flag("verbose");
+
+    let file1 = Path::new(file1_path);
+    let file2 = Path::new(file2_path);
+
+    // Validate threshold
+    let threshold: f64 = threshold_str.parse()
+        .map_err(|_| {
+            eprintln!("❌ Error: Threshold must be a number between 0.0 and 1.0");
+            process::exit(1);
+        })
+        .unwrap_or_else(|e| {
+            eprintln!("❌ Error: {}", e);
+            process::exit(1);
+        });
+
+    if threshold < 0.0 || threshold > 1.0 {
+        eprintln!("❌ Error: Threshold must be between 0.0 and 1.0");
+        process::exit(1);
+    }
+
+    // Check if files exist
+    if !file1.exists() {
+        eprintln!("❌ Error: File {} does not exist", file1.display());
+        process::exit(1);
+    }
+    
+    if !file2.exists() {
+        eprintln!("❌ Error: File {} does not exist", file2.display());
+        process::exit(1);
+    }
+
+    // Get quantum states
+    let state1 = QuantumState::new(file1)
+        .unwrap_or_else(|e| {
+            eprintln!("❌ Error reading {}: {}", file1.display(), e);
+            process::exit(1);
+        });
+
+    let state2 = QuantumState::new(file2)
+        .unwrap_or_else(|e| {
+            eprintln!("❌ Error reading {}: {}", file2.display(), e);
+            process::exit(1);
+        });
+
+    // Analyze entanglement
+    let result = EntanglementResult::new(&state1, &state2, threshold);
+
+    // Print report
+    print_quantum_report(file1, file2, &state1, &state2, &result, verbose);
+
+    // Exit with appropriate code
+    if result.entangled {
+        process::exit(0);
+    } else {
+        process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_quantum_energy_from_size() {
+        assert_eq!(QuantumEnergy::from_size(100), QuantumEnergy::Low);
+        assert_eq!(QuantumEnergy::from_size(5000), QuantumEnergy::Medium);
+        assert_eq!(QuantumEnergy::from_size(2000000), QuantumEnergy::High);
+    }
+
+    #[test]
+    fn test_quantum_state_new() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        writeln!(temp_file, "Hello, quantum world!").unwrap();
+        
+        let state = QuantumState::new(temp_file.path()).unwrap();
+        assert_eq!(state.size, 22); // "Hello, quantum world!\n" is 22 bytes
+        assert_eq!(state.energy, QuantumEnergy::Low);
+        assert_eq!(state.get_hash_prefix().len(), 12);
+    }
+
+    #[test]
+    fn test_entanglement_result_identical() {
+        let mut temp_file1 = NamedTempFile::new().unwrap();
+        let mut temp_file2 = NamedTempFile::new().unwrap();
+        
+        writeln!(temp_file1, "Identical content").unwrap();
+        writeln!(temp_file2, "Identical content").unwrap();
+        
+        let state1 = QuantumState::new(temp_file1.path()).unwrap();
+        let state2 = QuantumState::new(temp_file2.path()).unwrap();
+        
+        let result = EntanglementResult::new(&state1, &state2, 0.5);
+        assert_eq!(result.probability, 100.0);
+        assert!(result.entangled);
+        assert_eq!(result.explanation, "Identical quantum states detected!");
+    }
+
+    #[test]
+    fn test_entanglement_result_different() {
+        let mut temp_file1 = NamedTempFile::new().unwrap();
+        let mut temp_file2 = NamedTempFile::new().unwrap();
+        
+        writeln!(temp_file1, "Different content 1").unwrap();
+        writeln!(temp_file2, "Different content 2").unwrap();
+        
+        let state1 = QuantumState::new(temp_file1.path()).unwrap();
+        let state2 = QuantumState::new(temp_file2.path()).unwrap();
+        
+        let result = EntanglementResult::new(&state1, &state2, 0.5);
+        assert!(result.probability >= 0.0 && result.probability <= 100.0);
+        assert_eq!(result.explanation, "Different quantum states, but quantum uncertainty allows for entanglement!");
+    }
+
+    #[test]
+    fn test_entanglement_result_threshold() {
+        let mut temp_file1 = NamedTempFile::new().unwrap();
+        let mut temp_file2 = NamedTempFile::new().unwrap();
+        
+        writeln!(temp_file1, "Content A").unwrap();
+        writeln!(temp_file2, "Content B").unwrap();
+        
+        let state1 = QuantumState::new(temp_file1.path()).unwrap();
+        let state2 = QuantumState::new(temp_file2.path()).unwrap();
+        
+        // With threshold 1.0, should never be entangled for different content
+        let result = EntanglementResult::new(&state1, &state2, 1.0);
+        assert!(!result.entangled);
+        
+        // With threshold 0.0, should always be entangled
+        let result = EntanglementResult::new(&state1, &state2, 0.0);
+        assert!(result.entangled);
+    }
+}

--- a/rust-utils/nightly-nightly-quantum-entanglement-12/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-quantum-entanglement-12/tests/test_main.rs
@@ -1,0 +1,205 @@
+use nightly_quantum_entanglement_checker::*;
+use std::fs;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_quantum_energy_from_size() {
+    assert_eq!(QuantumEnergy::from_size(100), QuantumEnergy::Low);
+    assert_eq!(QuantumEnergy::from_size(5000), QuantumEnergy::Medium);
+    assert_eq!(QuantumEnergy::from_size(2000000), QuantumEnergy::High);
+}
+
+#[test]
+fn test_quantum_energy_to_string() {
+    assert_eq!(QuantumEnergy::Low.to_string(), "Low");
+    assert_eq!(QuantumEnergy::Medium.to_string(), "Medium");
+    assert_eq!(QuantumEnergy::High.to_string(), "High");
+}
+
+#[test]
+fn test_quantum_state_new() {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    writeln!(temp_file, "Hello, quantum world!").unwrap();
+    
+    let state = QuantumState::new(temp_file.path()).unwrap();
+    assert_eq!(state.size, 22); // "Hello, quantum world!\n" is 22 bytes
+    assert_eq!(state.energy, QuantumEnergy::Low);
+    assert_eq!(state.get_hash_prefix().len(), 12);
+    
+    // Verify hash is valid SHA-256 (64 hex chars)
+    assert_eq!(state.hash.len(), 64);
+}
+
+#[test]
+fn test_quantum_state_different_files() {
+    let mut temp_file1 = NamedTempFile::new().unwrap();
+    let mut temp_file2 = NamedTempFile::new().unwrap();
+    
+    writeln!(temp_file1, "File content 1").unwrap();
+    writeln!(temp_file2, "File content 2").unwrap();
+    
+    let state1 = QuantumState::new(temp_file1.path()).unwrap();
+    let state2 = QuantumState::new(temp_file2.path()).unwrap();
+    
+    // Different content should have different hashes
+    assert_ne!(state1.hash, state2.hash);
+    assert_ne!(state1.get_hash_prefix(), state2.get_hash_prefix());
+}
+
+#[test]
+fn test_quantum_state_same_files() {
+    let mut temp_file1 = NamedTempFile::new().unwrap();
+    let mut temp_file2 = NamedTempFile::new().unwrap();
+    
+    let content = "Identical quantum content";
+    writeln!(temp_file1, "{}").unwrap();
+    writeln!(temp_file2, "{}").unwrap();
+    
+    let state1 = QuantumState::new(temp_file1.path()).unwrap();
+    let state2 = QuantumState::new(temp_file2.path()).unwrap();
+    
+    // Same content should have identical hashes
+    assert_eq!(state1.hash, state2.hash);
+    assert_eq!(state1.get_hash_prefix(), state2.get_hash_prefix());
+    assert_eq!(state1.size, state2.size);
+}
+
+#[test]
+fn test_entanglement_result_identical() {
+    let mut temp_file1 = NamedTempFile::new().unwrap();
+    let mut temp_file2 = NamedTempFile::new().unwrap();
+    
+    writeln!(temp_file1, "Identical content").unwrap();
+    writeln!(temp_file2, "Identical content").unwrap();
+    
+    let state1 = QuantumState::new(temp_file1.path()).unwrap();
+    let state2 = QuantumState::new(temp_file2.path()).unwrap();
+    
+    let result = EntanglementResult::new(&state1, &state2, 0.5);
+    assert_eq!(result.probability, 100.0);
+    assert!(result.entangled);
+    assert_eq!(result.explanation, "Identical quantum states detected!");
+}
+
+#[test]
+fn test_entanglement_result_different() {
+    let mut temp_file1 = NamedTempFile::new().unwrap();
+    let mut temp_file2 = NamedTempFile::new().unwrap();
+    
+    writeln!(temp_file1, "Different content 1").unwrap();
+    writeln!(temp_file2, "Different content 2").unwrap();
+    
+    let state1 = QuantumState::new(temp_file1.path()).unwrap();
+    let state2 = QuantumState::new(temp_file2.path()).unwrap();
+    
+    let result = EntanglementResult::new(&state1, &state2, 0.5);
+    assert!(result.probability >= 0.0 && result.probability <= 100.0);
+    assert_eq!(result.explanation, "Different quantum states, but quantum uncertainty allows for entanglement!");
+}
+
+#[test]
+fn test_entanglement_result_threshold_high() {
+    let mut temp_file1 = NamedTempFile::new().unwrap();
+    let mut temp_file2 = NamedTempFile::new().unwrap();
+    
+    writeln!(temp_file1, "Content A").unwrap();
+    writeln!(temp_file2, "Content B").unwrap();
+    
+    let state1 = QuantumState::new(temp_file1.path()).unwrap();
+    let state2 = QuantumState::new(temp_file2.path()).unwrap();
+    
+    // With threshold 1.0, should never be entangled for different content
+    let result = EntanglementResult::new(&state1, &state2, 1.0);
+    assert!(!result.entangled);
+}
+
+#[test]
+fn test_entanglement_result_threshold_low() {
+    let mut temp_file1 = NamedTempFile::new().unwrap();
+    let mut temp_file2 = NamedTempFile::new().unwrap();
+    
+    writeln!(temp_file1, "Content A").unwrap();
+    writeln!(temp_file2, "Content B").unwrap();
+    
+    let state1 = QuantumState::new(temp_file1.path()).unwrap();
+    let state2 = QuantumState::new(temp_file2.path()).unwrap();
+    
+    // With threshold 0.0, should always be entangled
+    let result = EntanglementResult::new(&state1, &state2, 0.0);
+    assert!(result.entangled);
+}
+
+#[test]
+fn test_quantum_state_empty_file() {
+    let temp_file = NamedTempFile::new().unwrap();
+    
+    let state = QuantumState::new(temp_file.path()).unwrap();
+    assert_eq!(state.size, 0);
+    assert_eq!(state.energy, QuantumEnergy::Low);
+}
+
+#[test]
+fn test_quantum_state_large_file() {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    
+    // Write 2MB of data
+    let large_content = "x".repeat(2 * 1024 * 1024);
+    writeln!(temp_file, "{}").unwrap();
+    
+    let state = QuantumState::new(temp_file.path()).unwrap();
+    assert_eq!(state.size, large_content.len() as u64 + 1); // +1 for newline
+    assert_eq!(state.energy, QuantumEnergy::High);
+}
+
+#[test]
+fn test_quantum_state_error_nonexistent_file() {
+    let result = QuantumState::new(Path::new("nonexistent_file.txt"));
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("Failed to read file"));
+}
+
+#[test]
+fn test_entanglement_result_probability_range() {
+    let mut temp_file1 = NamedTempFile::new().unwrap();
+    let mut temp_file2 = NamedTempFile::new().unwrap();
+    
+    writeln!(temp_file1, "Content 1").unwrap();
+    writeln!(temp_file2, "Content 2").unwrap();
+    
+    let state1 = QuantumState::new(temp_file1.path()).unwrap();
+    let state2 = QuantumState::new(temp_file2.path()).unwrap();
+    
+    // Test multiple times to ensure probability is random
+    let mut probabilities = Vec::new();
+    for _ in 0..10 {
+        let result = EntanglementResult::new(&state1, &state2, 0.5);
+        assert!(result.probability >= 0.0 && result.probability <= 100.0);
+        probabilities.push(result.probability);
+    }
+    
+    // Check that we got different probabilities (quantum uncertainty)
+    let unique_probabilities: std::collections::HashSet<_> = probabilities.iter().cloned().collect();
+    assert!(unique_probabilities.len() > 1, "Expected some variation in probabilities due to quantum uncertainty");
+}
+
+#[test]
+fn test_entanglement_result_deterministic_for_same_content() {
+    // This test verifies that identical content always produces the same result
+    let mut temp_file1 = NamedTempFile::new().unwrap();
+    let mut temp_file2 = NamedTempFile::new().unwrap();
+    
+    writeln!(temp_file1, "Deterministic content").unwrap();
+    writeln!(temp_file2, "Deterministic content").unwrap();
+    
+    let state1 = QuantumState::new(temp_file1.path()).unwrap();
+    let state2 = QuantumState::new(temp_file2.path()).unwrap();
+    
+    // Multiple calls should always return the same result for identical content
+    for _ in 0..10 {
+        let result = EntanglementResult::new(&state1, &state2, 0.5);
+        assert_eq!(result.probability, 100.0);
+        assert!(result.entangled);
+        assert_eq!(result.explanation, "Identical quantum states detected!");
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-quantum-entanglement-checker
- **Provider**: openrouter
- **Location**: `rust-utils/nightly-nightly-quantum-entanglement-12`
- **Files Created**: 3
- **Description**: A whimsical tool that checks if two code files are quantum-entangled by comparing their hashes with a probabilistic twist.

## Rationale
- Automated proposal from the OpenRouter generator delivering a fresh community utility.
- This utility was generated using the **openrouter** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-quantum-entanglement-12`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-quantum-entanglement-12/README.md`
- Run tests located in `rust-utils/nightly-nightly-quantum-entanglement-12/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.