### PR TITLE
feat(groq): A lightweight Go CLI that lints Dockerfiles for common best‑practice violations.

### DIFF
--- a/go-utils/nightly-nightly-dockerfile-linter/README.md
+++ b/go-utils/nightly-nightly-dockerfile-linter/README.md
@@ -1,0 +1,24 @@
+# nightly-dockerfile-linter
+
+A lightweight Go CLI that lints Dockerfiles for common best‑practice violations.
+
+Usage
+
+go run src/main.go path/to/Dockerfile
+
+or
+
+cat Dockerfile | go run src/main.go
+
+The tool prints a list of issues or OK if none are found.
+
+Lint Rules
+
+- Dockerfile must contain a FROM instruction.
+- Dockerfile must contain a CMD or ENTRYPOINT instruction.
+- RUN apt-get update should be followed by apt-get install -y in the same line or next line.
+- No ADD instructions; use COPY instead.
+
+License
+
+MIT

--- a/go-utils/nightly-nightly-dockerfile-linter/src/main.go
+++ b/go-utils/nightly-nightly-dockerfile-linter/src/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "io"
+    "os"
+    "strings"
+)
+
+func indexOf(slice []string, val string) int {
+    for i, v := range slice {
+        if v == val {
+            return i
+        }
+    }
+    return -1
+}
+
+func lintDockerfile(r io.Reader) []string {
+    scanner := bufio.NewScanner(r)
+    var lines []string
+    for scanner.Scan() {
+        lines = append(lines, scanner.Text())
+    }
+    var issues []string
+    hasFrom := false
+    hasCmdOrEntrypoint := false
+    hasAdd := false
+    for _, line := range lines {
+        trimmed := strings.TrimSpace(line)
+        if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+            continue
+        }
+        upper := strings.ToUpper(trimmed)
+        if strings.HasPrefix(upper, "FROM") {
+            hasFrom = true
+        }
+        if strings.HasPrefix(upper, "CMD") || strings.HasPrefix(upper, "ENTRYPOINT") {
+            hasCmdOrEntrypoint = true
+        }
+        if strings.HasPrefix(upper, "ADD") {
+            hasAdd = true
+        }
+        if strings.HasPrefix(upper, "RUN") && strings.Contains(strings.ToLower(trimmed), "apt-get update") {
+            if !strings.Contains(strings.ToLower(trimmed), "apt-get install -y") {
+                idx := indexOf(lines, line)
+                if idx+1 < len(lines) {
+                    next := strings.ToLower(strings.TrimSpace(lines[idx+1]))
+                    if !strings.Contains(next, "apt-get install -y") {
+                        issues = append(issues, "RUN apt-get update without apt-get install -y")
+                    }
+                } else {
+                    issues = append(issues, "RUN apt-get update without apt-get install -y")
+                }
+            }
+        }
+    }
+    if !hasFrom {
+        issues = append(issues, "Missing FROM instruction")
+    }
+    if !hasCmdOrEntrypoint {
+        issues = append(issues, "Missing CMD or ENTRYPOINT instruction")
+    }
+    if hasAdd {
+        issues = append(issues, "ADD instruction found; use COPY instead")
+    }
+    return issues
+}
+
+func main() {
+    var reader io.Reader
+    if len(os.Args) > 1 {
+        file, err := os.Open(os.Args[1])
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "Error opening file: %v\\n", err)
+            os.Exit(1)
+        }
+        defer file.Close()
+        reader = file
+    } else {
+        reader = os.Stdin
+    }
+    issues := lintDockerfile(reader)
+    if len(issues) == 0 {
+        fmt.Println("OK")
+    } else {
+        for _, issue := range issues {
+            fmt.Println(issue)
+        }
+        os.Exit(1)
+    }
+}

--- a/go-utils/nightly-nightly-dockerfile-linter/tests/test_main.go
+++ b/go-utils/nightly-nightly-dockerfile-linter/tests/test_main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+    "strings"
+    "testing"
+)
+
+func TestLintDockerfile_OK(t *testing.T) {
+    dockerfile := `
+FROM ubuntu:20.04
+RUN apt-get update && apt-get install -y curl
+CMD ["bash"]
+`
+    issues := lintDockerfile(strings.NewReader(dockerfile))
+    if len(issues) != 0 {
+        t.Fatalf("Expected no issues, got %v", issues)
+    }
+}
+
+func TestLintDockerfile_MissingFrom(t *testing.T) {
+    dockerfile := `
+RUN apt-get update && apt-get install -y curl
+CMD ["bash"]
+`
+    issues := lintDockerfile(strings.NewReader(dockerfile))
+    if !contains(issues, "Missing FROM instruction") {
+        t.Fatalf("Expected missing FROM issue, got %v", issues)
+    }
+}
+
+func TestLintDockerfile_MissingCmd(t *testing.T) {
+    dockerfile := `
+FROM ubuntu:20.04
+RUN apt-get update && apt-get install -y curl
+`
+    issues := lintDockerfile(strings.NewReader(dockerfile))
+    if !contains(issues, "Missing CMD or ENTRYPOINT instruction") {
+        t.Fatalf("Expected missing CMD/ENTRYPOINT issue, got %v", issues)
+    }
+}
+
+func TestLintDockerfile_AddInstruction(t *testing.T) {
+    dockerfile := `
+FROM ubuntu:20.04
+ADD . /app
+CMD ["bash"]
+`
+    issues := lintDockerfile(strings.NewReader(dockerfile))
+    if !contains(issues, "ADD instruction found; use COPY instead") {
+        t.Fatalf("Expected ADD issue, got %v", issues)
+    }
+}
+
+func TestLintDockerfile_AptGetUpdateWithoutInstall(t *testing.T) {
+    dockerfile := `
+FROM ubuntu:20.04
+RUN apt-get update
+CMD ["bash"]
+`
+    issues := lintDockerfile(strings.NewReader(dockerfile))
+    if !contains(issues, "RUN apt-get update without apt-get install -y") {
+        t.Fatalf("Expected apt-get update without install issue, got %v", issues)
+    }
+}
+
+func contains(slice []string, item string) bool {
+    for _, v := range slice {
+        if v == item {
+            return true
+        }
+    }
+    return false
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-dockerfile-linter
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-dockerfile-linter`
- **Files Created**: 3
- **Description**: A lightweight Go CLI that lints Dockerfiles for common best‑practice violations.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-dockerfile-linter`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-dockerfile-linter/README.md`
- Run tests located in `go-utils/nightly-nightly-dockerfile-linter/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.