### PR TITLE
feat(groq): An Ansible playbook that hunts down spooky “.ghost” files on target hosts, archives them into a tarball, and leaves a tidy report.

### DIFF
--- a/ansible-playbooks/nightly-nightly-ansible-ghost-buster/README.md
+++ b/ansible-playbooks/nightly-nightly-ansible-ghost-buster/README.md
@@ -1,0 +1,48 @@
+# nightly-ansible-ghost-buster
+
+## Overview
+
+`nightly-ansible-ghost-buster` is a whimsical yet practical Ansible playbook that searches for files with the **`.ghost`** extension (the kind of files that haunt your filesystem), archives them into `/tmp/ghosts.tar.gz`, and prints a short report.
+
+The playbook is completely self‑contained and runs against any inventory you provide – the default example uses the local machine.
+
+## Features
+
+- Recursively finds `*.ghost` files in a configurable directory.
+- Archives all discovered ghost files into a single tarball (`/tmp/ghosts.tar.gz`).
+- Emits a concise debug message reporting how many ghosts were captured.
+- Includes a tiny test harness that creates dummy ghost files, runs the playbook, and verifies the archive was produced.
+
+## Quick Start
+
+```bash
+# Clone the repository (or copy this folder) and cd into it
+cd ansible-playbooks/nightly-ansible-ghost-buster
+
+# Run the bundled test (requires ansible and bash)
+./tests/run_test.sh
+```
+
+If the test passes you will see something like:
+
+```
+PLAY [Ghost Buster] *****************************************************************
+...
+ok: [localhost] => {
+    "msg": "Archived 2 ghost files."
+}
+
+PLAY RECAP ***********************************************************************
+localhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+
+TEST SUCCESS: Ghost archive created at /tmp/ghosts.tar.gz
+```
+
+## Customisation
+
+- **search_path** – Change the directory to scan by editing the `search_path` variable in `playbook.yml` or by passing `-e search_path=/my/dir` on the command line.
+- **archive_dest** – The destination of the tarball can be overridden similarly.
+
+## License
+
+MIT – feel free to adapt, share, and haunt responsibly!

--- a/ansible-playbooks/nightly-nightly-ansible-ghost-buster/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-ansible-ghost-buster/inventory.ini
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-ansible-ghost-buster/playbook.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-ghost-buster/playbook.yml
@@ -1,0 +1,30 @@
+---
+- name: Ghost Buster
+  hosts: all
+  gather_facts: false
+  vars:
+    # Directory to search for .ghost files – change as needed
+    search_path: "/tmp/ghost_test_dir"
+    # Destination of the archive (can be overridden via extra vars)
+    archive_dest: "/tmp/ghosts.tar.gz"
+  tasks:
+    - name: Find .ghost files
+      find:
+        paths: "{{ search_path }}"
+        patterns: "*.ghost"
+        recurse: true
+      register: ghost_files
+
+    - name: Archive ghost files if any were found
+      archive:
+        path: "{{ item.path }}"
+        dest: "{{ archive_dest }}"
+        format: gz
+        mode: "0644"
+      loop: "{{ ghost_files.files }}"
+      when: ghost_files.matched > 0
+      register: archive_result
+
+    - name: Report how many ghosts were captured
+      debug:
+        msg: "Archived {{ ghost_files.matched }} ghost file(s)."

--- a/ansible-playbooks/nightly-nightly-ansible-ghost-buster/tests/cleanup.sh
+++ b/ansible-playbooks/nightly-nightly-ansible-ghost-buster/tests/cleanup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Mock rationale: tidy up the environment so repeated runs are idempotent
+set -e
+rm -rf "/tmp/ghost_test_dir" "/tmp/ghosts.tar.gz"

--- a/ansible-playbooks/nightly-nightly-ansible-ghost-buster/tests/run_test.sh
+++ b/ansible-playbooks/nightly-nightly-ansible-ghost-buster/tests/run_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Mock rationale: deterministic end‑to‑end test using only local resources
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Step 1: prepare test files
+"${SCRIPT_DIR}/setup.sh"
+
+# Step 2: run the playbook against the local inventory
+ansible-playbook -i "${SCRIPT_DIR}/../inventory.ini" "${SCRIPT_DIR}/../playbook.yml"
+
+# Step 3: verify that the archive was created and contains the expected files
+if [[ -f "/tmp/ghosts.tar.gz" ]]; then
+  # List contents of the tarball (quietly) and ensure both ghost files are present
+  if tar -tzf "/tmp/ghosts.tar.gz" | grep -q "spooky1.ghost" && tar -tzf "/tmp/ghosts.tar.gz" | grep -q "spooky2.ghost"; then
+    echo "TEST SUCCESS: Ghost archive created at /tmp/ghosts.tar.gz"
+  else
+    echo "TEST FAILURE: Archive missing expected ghost files" >&2
+    exit 1
+  fi
+else
+  echo "TEST FAILURE: Archive /tmp/ghosts.tar.gz was not created" >&2
+  exit 1
+fi
+
+# Step 4: clean up
+"${SCRIPT_DIR}/cleanup.sh"

--- a/ansible-playbooks/nightly-nightly-ansible-ghost-buster/tests/setup.sh
+++ b/ansible-playbooks/nightly-nightly-ansible-ghost-buster/tests/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Mock rationale: set up a deterministic environment with known ghost files
+set -e
+TEST_DIR="/tmp/ghost_test_dir"
+ARCHIVE="/tmp/ghosts.tar.gz"
+
+# Clean any leftovers from previous runs
+rm -rf "${TEST_DIR}" "${ARCHIVE}"
+mkdir -p "${TEST_DIR}"
+# Create two dummy ghost files
+echo "boo" > "${TEST_DIR}/spooky1.ghost"
+echo "eek" > "${TEST_DIR}/spooky2.ghost"
+# Also create a non‑ghost file to ensure it is ignored
+echo "not a ghost" > "${TEST_DIR}/normal.txt"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansible-ghost-buster
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-ansible-ghost-buster`
- **Files Created**: 6
- **Description**: An Ansible playbook that hunts down spooky “.ghost” files on target hosts, archives them into a tarball, and leaves a tidy report.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-ansible-ghost-buster`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-ansible-ghost-buster/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-ansible-ghost-buster/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.