### PR TITLE
feat(groq): CLI tool that prints input text with a rainbow ANSI color gradient, similar to lolcat.

### DIFF
--- a/rust-utils/nightly-nightly-rainbowify-cli/Cargo.toml
+++ b/rust-utils/nightly-nightly-rainbowify-cli/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nightly-rainbowify-cli"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-rainbowify-cli/README.md
+++ b/rust-utils/nightly-nightly-rainbowify-cli/README.md
@@ -1,0 +1,23 @@
+# nightly-rainbowify-cli
+
+Utility that prints text with a rainbow ANSI color gradient, similar to `lolcat`. Useful for adding flair to terminal output.
+
+## Installation
+
+```sh
+cargo install --path .
+```
+
+## Usage
+
+```sh
+# From a pipe
+echo "Hello, world!" | nightly-rainbowify-cli
+
+# Direct argument
+nightly-rainbowify-cli "Apocalypse is near!"
+```
+
+## How it works
+
+The tool cycles through six ANSI colors (red, yellow, green, cyan, blue, magenta) and wraps each character in the appropriate escape sequence.

--- a/rust-utils/nightly-nightly-rainbowify-cli/src/lib.rs
+++ b/rust-utils/nightly-nightly-rainbowify-cli/src/lib.rs
@@ -1,0 +1,20 @@
+pub fn rainbow(text: &str) -> String {
+    let colors = [31, 33, 32, 36, 34, 35];
+    let mut result = String::new();
+    for (i, ch) in text.chars().enumerate() {
+        let color = colors[i % colors.len()];
+        result.push_str(&format!("\x1b[{}m{}\x1b[0m", color, ch));
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_rainbow_basic() {
+        let input = "ABC";
+        let expected = "\x1b[31mA\x1b[0m\x1b[33mB\x1b[0m\x1b[32mC\x1b[0m";
+        assert_eq!(rainbow(input), expected);
+    }
+}

--- a/rust-utils/nightly-nightly-rainbowify-cli/src/main.rs
+++ b/rust-utils/nightly-nightly-rainbowify-cli/src/main.rs
@@ -1,0 +1,18 @@
+use std::io::{self, Read};
+
+mod lib;
+
+fn main() {
+    // Collect arguments after program name
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let input = if !args.is_empty() {
+        args.join(" ")
+    } else {
+        // Read from stdin
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer).expect("Failed to read stdin");
+        buffer.trim_end().to_string()
+    };
+    let output = lib::rainbow(&input);
+    println!("{}", output);
+}

--- a/rust-utils/nightly-nightly-rainbowify-cli/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-rainbowify-cli/tests/test_main.rs
@@ -1,0 +1,11 @@
+use nightly_rainbowify_cli::rainbow;
+
+#[test]
+fn test_rainbow_full_sentence() {
+    let input = "Rust";
+    // Expected colors: R(31), u(33), s(32), t(36)
+    let expected = "\x1b[31mR\x1b[0m\x1b[33mu\x1b[0m\x1b[32ms\x1b[0m\x1b[36mt\x1b[0m";
+    assert_eq!(rainbow(input), expected);
+}
+
+// Mock rationale: No external I/O, deterministic function.


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-rainbowify-cli
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-rainbowify-cli`
- **Files Created**: 5
- **Description**: CLI tool that prints input text with a rainbow ANSI color gradient, similar to lolcat.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-rainbowify-cli`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-rainbowify-cli/README.md`
- Run tests located in `rust-utils/nightly-nightly-rainbowify-cli/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.