### PR TITLE
feat(gemini): A Go-based HTTP server that broadcasts the current server time, optionally with a configurable, whimsical temporal drift, for community time synchronization.

### DIFF
--- a/go-utils/nightly-nightly-chrono-sync-beacon-3/README.md
+++ b/go-utils/nightly-nightly-chrono-sync-beacon-3/README.md
@@ -1,0 +1,80 @@
+# Nightly Chrono-Sync Beacon
+
+## Overview
+
+The `nightly-chrono-sync-beacon` is a whimsical-yet-useful Go-based HTTP service designed to provide a community-agreed time signal. In a world where temporal anomalies might cause local clocks to drift, this beacon offers a centralized, albeit sometimes playfully 'drifted', time source. It's perfect for synchronizing distributed systems, performing network health checks, or simply adding a touch of temporal uncertainty to your day.
+
+## Features
+
+- **Current UTC Time**: Provides the precise current UTC time.
+- **Configurable Temporal Drift**: Allows clients to request a time with an intentional millisecond offset, simulating minor temporal distortions.
+- **Simple HTTP API**: Easy to integrate with `curl`, `wget`, or any HTTP client.
+- **Lightweight & Concurrent**: Built with Go's excellent concurrency model for efficient operation.
+
+## Usage
+
+### 1. Build the Utility
+
+Navigate to the `src` directory and build the Go application:
+
+```bash
+cd go-utils/nightly-chrono-sync-beacon/src
+go build -o chrono-sync-beacon .
+```
+
+### 2. Run the Beacon
+
+Execute the compiled binary. By default, it runs on port `8080`.
+
+```bash
+./chrono-sync-beacon
+# Or specify a different port:
+./chrono-sync-beacon -port 8081
+```
+
+### 3. Query the Time
+
+Use `curl` or your preferred HTTP client to get the current time:
+
+```bash
+# Get current UTC time (no drift)
+curl http://localhost:8080/time
+# Expected output (timestamp will vary):
+# {"timestamp":"2023-10-27T10:30:00.123456789Z","message":"Time signal from the Chrono-Sync Beacon. May contain temporal whimsy.","drift_ms":0}
+
+# Get current UTC time with a positive drift of 500 milliseconds
+curl http://localhost:8080/time?drift_ms=500
+# Expected output (timestamp will be ~500ms in the future):
+# {"timestamp":"2023-10-27T10:30:00.623456789Z","message":"Time signal from the Chrono-Sync Beacon. May contain temporal whimsy.","drift_ms":500}
+
+# Get current UTC time with a negative drift of 1000 milliseconds (1 second in the past)
+curl http://localhost:8080/time?drift_ms=-1000
+# Expected output (timestamp will be ~1s in the past):
+# {"timestamp":"2023-10-27T10:29:59.123456789Z","message":"Time signal from the Chrono-Sync Beacon. May contain temporal whimsy.","drift_ms":-1000}
+
+# Check the beacon's operational status
+curl http://localhost:8080/status
+# Expected output:
+# {"message":"Chrono-Sync Beacon is humming along, broadcasting temporal truths (mostly).","status":"Operational","uptime":"..."}
+```
+
+## Development
+
+### Running Tests
+
+To run the automated tests, navigate to the utility's root directory and use `go test`:
+
+```bash
+cd go-utils/nightly-chrono-sync-beacon
+go test ./tests/...
+```
+
+### Configuration
+
+The beacon can be configured via command-line flags:
+
+- `--port <number>`: Specifies the port the server will listen on (default: `8080`).
+
+## Contributing
+
+Feel free to suggest improvements or new whimsical temporal features!

--- a/go-utils/nightly-nightly-chrono-sync-beacon-3/src/main.go
+++ b/go-utils/nightly-nightly-chrono-sync-beacon-3/src/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type TimeResponse struct {
+	Timestamp string `json:"timestamp"`
+	DriftMs   int    `json:"drift_ms,omitempty"`
+	Message   string `json:"message"`
+}
+
+func timeHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	currentTime := time.Now().UTC()
+	driftMs := 0
+
+	driftParam := r.URL.Query().Get("drift_ms")
+	if driftParam != "" {
+		parsedDrift, err := strconv.Atoi(driftParam)
+		if err != nil {
+			http.Error(w, `{"error": "Invalid drift_ms parameter. Must be an integer."}`, http.StatusBadRequest)
+			return
+		}
+		driftMs = parsedDrift
+		currentTime = currentTime.Add(time.Duration(driftMs) * time.Millisecond)
+	}
+
+	response := TimeResponse{
+		Timestamp: currentTime.Format(time.RFC3339Nano),
+		DriftMs:   driftMs,
+		Message:   "Time signal from the Chrono-Sync Beacon. May contain temporal whimsy.",
+	}
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("Error encoding response: %v", err)
+		http.Error(w, `{"error": "Internal server error."}`, http.StatusInternalServerError)
+	}
+}
+
+func statusHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	response := map[string]string{
+		"status":  "Operational",
+		"message": "Chrono-Sync Beacon is humming along, broadcasting temporal truths (mostly).",
+		"uptime":  time.Since(startTime).String(),
+	}
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("Error encoding status response: %v", err)
+		http.Error(w, `{"error": "Internal server error."}`, http.StatusInternalServerError)
+	}
+}
+
+var startTime time.Time
+
+func main() {
+	startTime = time.Now()
+	port := flag.Int("port", 8080, "Port to run the Chrono-Sync Beacon on")
+	flag.Parse()
+
+	http.HandleFunc("/time", timeHandler)
+	http.HandleFunc("/status", statusHandler)
+
+	addr := fmt.Sprintf(":%d", *port)
+	log.Printf("Chrono-Sync Beacon starting on port %s", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}

--- a/go-utils/nightly-nightly-chrono-sync-beacon-3/tests/main_test.go
+++ b/go-utils/nightly-nightly-chrono-sync-beacon-3/tests/main_test.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// Mock rationale: We use httptest.NewRecorder and httptest.NewRequest to create
+// isolated, in-memory HTTP request/response cycles. This allows us to test the
+// handlers' logic and HTTP responses without needing to bind to a real network
+// port or make external network calls. The time.Now() calls are part of the
+// handler's core logic and are implicitly "mocked" by controlling the test
+// execution environment and checking relative time within a small tolerance.
+
+func TestTimeHandlerNoDrift(t *testing.T) {
+	req, err := http.NewRequest("GET", "/time", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(timeHandler)
+
+	// Capture time before handler call to compare
+	expectedTime := time.Now().UTC()
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	var response TimeResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &response)
+	if err != nil {
+		t.Fatalf("could not unmarshal response: %v", err)
+	}
+
+	parsedTime, err := time.Parse(time.RFC3339Nano, response.Timestamp)
+	if err != nil {
+		t.Fatalf("could not parse timestamp: %v", err)
+	}
+
+	// Allow a small margin for execution time difference
+	if parsedTime.Before(expectedTime.Add(-10*time.Millisecond)) || parsedTime.After(expectedTime.Add(10*time.Millisecond)) {
+		t.Errorf("handler returned unexpected timestamp: got %v, expected around %v",
+			parsedTime, expectedTime)
+	}
+	if response.DriftMs != 0 {
+		t.Errorf("handler returned unexpected drift_ms: got %v, want %v",
+			response.DriftMs, 0)
+	}
+	if response.Message == "" {
+		t.Errorf("handler returned empty message")
+	}
+}
+
+func TestTimeHandlerPositiveDrift(t *testing.T) {
+	drift := 1000 // 1 second
+	req, err := http.NewRequest("GET", "/time?drift_ms="+strconv.Itoa(drift), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(timeHandler)
+
+	expectedTimeBase := time.Now().UTC()
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	var response TimeResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &response)
+	if err != nil {
+		t.Fatalf("could not unmarshal response: %v", err)
+	}
+
+	parsedTime, err := time.Parse(time.RFC3339Nano, response.Timestamp)
+	if err != nil {
+		t.Fatalf("could not parse timestamp: %v", err)
+	}
+
+	expectedDriftedTime := expectedTimeBase.Add(time.Duration(drift) * time.Millisecond)
+
+	if parsedTime.Before(expectedDriftedTime.Add(-10*time.Millisecond)) || parsedTime.After(expectedDriftedTime.Add(10*time.Millisecond)) {
+		t.Errorf("handler returned unexpected drifted timestamp: got %v, expected around %v",
+			parsedTime, expectedDriftedTime)
+	}
+	if response.DriftMs != drift {
+		t.Errorf("handler returned unexpected drift_ms: got %v, want %v",
+			response.DriftMs, drift)
+	}
+}
+
+func TestTimeHandlerNegativeDrift(t *testing.T) {
+	drift := -500 // -0.5 seconds
+	req, err := http.NewRequest("GET", "/time?drift_ms="+strconv.Itoa(drift), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(timeHandler)
+
+	expectedTimeBase := time.Now().UTC()
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	var response TimeResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &response)
+	if err != nil {
+		t.Fatalf("could not unmarshal response: %v", err)
+	}
+
+	parsedTime, err := time.Parse(time.RFC3339Nano, response.Timestamp)
+	if err != nil {
+		t.Fatalf("could not parse timestamp: %v", err)
+	}
+
+	expectedDriftedTime := expectedTimeBase.Add(time.Duration(drift) * time.Millisecond)
+
+	if parsedTime.Before(expectedDriftedTime.Add(-10*time.Millisecond)) || parsedTime.After(expectedDriftedTime.Add(10*time.Millisecond)) {
+		t.Errorf("handler returned unexpected drifted timestamp: got %v, expected around %v",
+			parsedTime, expectedDriftedTime)
+	}
+	if response.DriftMs != drift {
+		t.Errorf("handler returned unexpected drift_ms: got %v, want %v",
+			response.DriftMs, drift)
+	}
+}
+
+func TestTimeHandlerInvalidDrift(t *testing.T) {
+	req, err := http.NewRequest("GET", "/time?drift_ms=notanumber", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(timeHandler)
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code for invalid drift: got %v want %v",
+			status, http.StatusBadRequest)
+	}
+
+	expected := `{"error": "Invalid drift_ms parameter. Must be an integer."}` + "\n" // http.Error adds a newline
+	if rr.Body.String() != expected {
+		t.Errorf("handler returned unexpected body for invalid drift: got %q want %q",
+			rr.Body.String(), expected)
+	}
+}
+
+func TestStatusHandler(t *testing.T) {
+	// Initialize startTime for statusHandler, as it's a global variable set in main
+	// For tests, we need to ensure it's set before calling the handler.
+	startTime = time.Now()
+
+	req, err := http.NewRequest("GET", "/status", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(statusHandler)
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	var response map[string]string
+	err = json.Unmarshal(rr.Body.Bytes(), &response)
+	if err != nil {
+		t.Fatalf("could not unmarshal response: %v", err)
+	}
+
+	if response["status"] != "Operational" {
+		t.Errorf("handler returned unexpected status: got %v, want %v",
+			response["status"], "Operational")
+	}
+	if response["message"] == "" {
+		t.Errorf("handler returned empty message")
+	}
+	if _, ok := response["uptime"]; !ok {
+		t.Errorf("handler did not return uptime")
+	}
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-chrono-sync-beacon
- **Provider**: gemini
- **Location**: `go-utils/nightly-nightly-chrono-sync-beacon-3`
- **Files Created**: 3
- **Description**: A Go-based HTTP server that broadcasts the current server time, optionally with a configurable, whimsical temporal drift, for community time synchronization.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-chrono-sync-beacon-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-chrono-sync-beacon-3/README.md`
- Run tests located in `go-utils/nightly-nightly-chrono-sync-beacon-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.