### PR TITLE
feat(groq): Terraform module that creates a versioned, encrypted S3 bucket with a 30‑day lifecycle expiration for post‑apocalyptic data storage.

### DIFF
--- a/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
@@ -1,0 +1,28 @@
+# Nightly Safehouse S3
+
+A whimsical Terraform module that provisions a secure S3 bucket for post‑apocalyptic data hoarding. The bucket has versioning, server‑side encryption, and a lifecycle rule that expires objects after 30 days.
+
+## Usage
+
+```hcl
+module "safehouse" {
+  source      = "./"
+  bucket_name = "my‑post‑apoc‑vault"
+}
+```
+
+Run `terraform init && terraform apply` to create the bucket (requires AWS credentials).
+
+## Features
+
+- Versioning enabled
+- AES‑256 encryption
+- Lifecycle rule: delete objects older than 30 days
+- Outputs the bucket ARN
+
+## Testing
+
+```sh
+cd tests
+./test_module.sh
+```

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/main.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/main.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "safehouse" {
+  bucket = var.bucket_name
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "expire-old-objects"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
+
+  tags = {
+    Purpose = "PostApocalypticSafehouse"
+  }
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/outputs.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/outputs.tf
@@ -1,0 +1,4 @@
+output "bucket_arn" {
+  description = "ARN of the created S3 bucket"
+  value       = aws_s3_bucket.safehouse.arn
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/tests/test_module.sh
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/tests/test_module.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+# Initialize Terraform without remote backend (offline safe)
+terraform init -backend=false > /dev/null
+
+# Validate configuration syntax
+terraform validate
+
+# Generate a plan and capture output
+plan_output=$(terraform plan -no-color -input=false)
+
+# Check that the plan includes the expected S3 bucket resource
+if echo "$plan_output" | grep -q "aws_s3_bucket.safehouse"; then
+  echo "Test passed: bucket resource found in plan."
+else
+  echo "Test failed: bucket resource not found."
+  exit 1
+fi

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/variables.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/variables.tf
@@ -1,0 +1,4 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket to create"
+  type        = string
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-safehouse-s3
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-safehouse-s3-8`
- **Files Created**: 5
- **Description**: Terraform module that creates a versioned, encrypted S3 bucket with a 30‑day lifecycle expiration for post‑apocalyptic data storage.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-safehouse-s3-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-safehouse-s3-8/README.md`
- Run tests located in `terraform-modules/nightly-nightly-safehouse-s3-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.