### PR TITLE
feat(groq): Prints system uptime with a whimsical emoji indicating how long the system has been up

### DIFF
--- a/bash-utils/nightly-nightly-uptime-emoji-report-2/README.md
+++ b/bash-utils/nightly-nightly-uptime-emoji-report-2/README.md
@@ -1,0 +1,21 @@
+# nightly-uptime-emoji-report
+
+Utility that prints system uptime with a whimsical emoji indicating how long the system has been up.
+
+## Usage
+
+```sh
+./src/uptime_report.sh
+```
+
+You can override the uptime source for testing:
+
+```sh
+UPTIME_FILE=tests/mock_uptime.txt ./src/uptime_report.sh
+```
+
+## Emoji mapping
+
+- **< 1 day**: 🌱 (seedling)
+- **1‑7 days**: 🌿 (herb)
+- **> 7 days**: 🌳 (tree)

--- a/bash-utils/nightly-nightly-uptime-emoji-report-2/src/uptime_report.sh
+++ b/bash-utils/nightly-nightly-uptime-emoji-report-2/src/uptime_report.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine the source of uptime information. By default this is /proc/uptime,
+# but it can be overridden with the UPTIME_FILE environment variable (useful for testing).
+UPTIME_FILE="${UPTIME_FILE:-/proc/uptime}"
+
+if [[ ! -r "$UPTIME_FILE" ]]; then
+  echo "Cannot read uptime file: $UPTIME_FILE" >&2
+  exit 1
+fi
+
+# Extract the first field (seconds) and truncate to an integer.
+uptime_seconds=$(awk '{print int($1)}' "$UPTIME_FILE")
+# Convert seconds to whole days.
+uptime_days=$(( uptime_seconds / 86400 ))
+
+# Choose an emoji based on the number of days.
+if (( uptime_days < 1 )); then
+  emoji="🌱"
+elif (( uptime_days < 7 )); then
+  emoji="🌿"
+else
+  emoji="🌳"
+fi
+
+# Print a friendly message.
+printf "Uptime: %d days %s\n" "$uptime_days" "$emoji"

--- a/bash-utils/nightly-nightly-uptime-emoji-report-2/tests/test_uptime_report.sh
+++ b/bash-utils/nightly-nightly-uptime-emoji-report-2/tests/test_uptime_report.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Helper to run the script with a mocked uptime file.
+run_script() {
+  local mock_path="$1"
+  UPTIME_FILE="$mock_path" ./src/uptime_report.sh
+}
+
+# Expected output mapping for various uptime values (seconds).
+declare -A cases
+cases["0"]="Uptime: 0 days 🌱"
+cases["43200"]="Uptime: 0 days 🌱"   # 12 hours
+cases["90000"]="Uptime: 1 days 🌿"   # 25 hours
+cases["604800"]="Uptime: 7 days 🌳"  # exactly 7 days (>=7 triggers tree)
+cases["1209600"]="Uptime: 14 days 🌳"
+
+passed=0
+total=0
+
+for seconds in "${!cases[@]}"; do
+  ((total++))
+  mock_file=$(mktemp)
+  # /proc/uptime format: "seconds idle_seconds"
+  echo "$seconds 0.00" > "$mock_file"
+  output=$(run_script "$mock_file")
+  rm -f "$mock_file"
+  expected="${cases[$seconds]}"
+  if [[ "$output" == "$expected" ]]; then
+    ((passed++))
+  else
+    echo "FAIL for $seconds seconds: expected '$expected', got '$output'"
+  fi
+done
+
+echo "$passed/$total tests passed"
+exit 0


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-uptime-emoji-report
- **Provider**: groq
- **Location**: `bash-utils/nightly-nightly-uptime-emoji-report-2`
- **Files Created**: 3
- **Description**: Prints system uptime with a whimsical emoji indicating how long the system has been up

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `bash-utils/nightly-nightly-uptime-emoji-report-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `bash-utils/nightly-nightly-uptime-emoji-report-2/README.md`
- Run tests located in `bash-utils/nightly-nightly-uptime-emoji-report-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.