### PR TITLE
feat(groq): GitHub Action that automatically adds labels to pull requests based on title keywords.

### DIFF
--- a/github-actions/nightly-nightly-pr-labeler-8/README.md
+++ b/github-actions/nightly-nightly-pr-labeler-8/README.md
@@ -1,0 +1,52 @@
+# Nightly PR Labeler
+
+A tiny GitHub Action that scans the title of a pull request and automatically adds labels based on configurable keyword‑to‑label mappings.
+
+## Features
+
+- Zero‑configuration default mapping (bug → `bug`, feat → `feature`, docs → `documentation`).
+- Custom mapping via the `mapping` input (JSON string).
+- Works with the standard `GITHUB_TOKEN` provided to actions.
+- Fully unit‑tested core logic.
+
+## Inputs
+
+| Name    | Description                                            | Required | Default |
+|---------|--------------------------------------------------------|----------|---------|
+| `token` | GitHub token with `repo` scope (usually `secrets.GITHUB_TOKEN`). | Yes      | – |
+| `mapping` | JSON string mapping **keyword** → **label**. Example: `{\"bug\":\"bug\",\"feat\":\"feature\",\"docs\":\"documentation\"}` | No | `{\"bug\":\"bug\",\"feat\":\"feature\",\"docs\":\"documentation\"}` |
+
+## Example Workflow
+
+```yaml
+name: Auto‑label PRs
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Apply labels
+        uses: ./
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          mapping: '{"bug":"bug","feat":"feature","docs":"documentation"}'
+```
+
+## How It Works
+
+The action reads the PR title from the event payload, lower‑cases it, and checks whether any of the configured keywords appear as substrings. All matching labels are added in a single API call.
+
+## Testing
+
+Run the bundled tests locally with Node:
+
+```bash
+npm install
+node tests/test_index.js
+```
+
+All tests should pass, confirming the keyword‑matching logic.

--- a/github-actions/nightly-nightly-pr-labeler-8/action.yml
+++ b/github-actions/nightly-nightly-pr-labeler-8/action.yml
@@ -1,0 +1,13 @@
+name: PR Labeler
+description: Auto‑label pull requests based on title keywords
+inputs:
+  token:
+    description: GITHUB_TOKEN with repo scope
+    required: true
+  mapping:
+    description: JSON string mapping keywords to labels (e.g. {\"bug\":\"bug\",\"feat\":\"feature\"})
+    required: false
+    default: '{"bug":"bug","feat":"feature","docs":"documentation"}'
+runs:
+  using: node12
+  main: src/index.js

--- a/github-actions/nightly-nightly-pr-labeler-8/package.json
+++ b/github-actions/nightly-nightly-pr-labeler-8/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "nightly-pr-labeler",
+  "version": "1.0.0",
+  "description": "GitHub Action that auto‑labels PRs based on title keywords",
+  "main": "src/index.js",
+  "license": "MIT",
+  "dependencies": {
+    "@actions/core": "^1.10.0",
+    "@actions/github": "^5.1.1"
+  }
+}

--- a/github-actions/nightly-nightly-pr-labeler-8/src/index.js
+++ b/github-actions/nightly-nightly-pr-labeler-8/src/index.js
@@ -1,0 +1,59 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+
+/**
+ * Compute which labels should be added based on the PR title.
+ * @param {string} title - Pull request title.
+ * @param {Object} mapping - Keyword → label map.
+ * @returns {string[]} Array of labels to add.
+ */
+function computeLabels(title, mapping) {
+  const lower = title.toLowerCase();
+  const labels = [];
+  for (const [keyword, label] of Object.entries(mapping)) {
+    if (lower.includes(keyword.toLowerCase())) {
+      labels.push(label);
+    }
+  }
+  return labels;
+}
+
+async function run() {
+  try {
+    const token = core.getInput('token', { required: true });
+    const mappingInput = core.getInput('mapping');
+    const mapping = JSON.parse(mappingInput);
+    const context = github.context;
+
+    if (!context.payload.pull_request) {
+      core.setFailed('No pull request payload found.');
+      return;
+    }
+
+    const pr = context.payload.pull_request;
+    const labelsToAdd = computeLabels(pr.title, mapping);
+
+    if (labelsToAdd.length === 0) {
+      core.info('No matching labels found for this PR title.');
+      return;
+    }
+
+    const octokit = github.getOctokit(token);
+    await octokit.rest.issues.addLabels({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: pr.number,
+      labels: labelsToAdd,
+    });
+    core.info(`Added labels: ${labelsToAdd.join(', ')}`);
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+}
+
+// Export for unit testing
+module.exports = { computeLabels, run };
+
+if (require.main === module) {
+  run();
+}

--- a/github-actions/nightly-nightly-pr-labeler-8/tests/test_index.js
+++ b/github-actions/nightly-nightly-pr-labeler-8/tests/test_index.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const { computeLabels } = require('../src/index');
+
+function testComputeLabels() {
+  const mapping = { bug: 'bug', feat: 'feature', docs: 'documentation' };
+
+  const title1 = 'Fix critical bug in parser';
+  const res1 = computeLabels(title1, mapping);
+  assert.deepStrictEqual(res1, ['bug']);
+
+  const title2 = 'Add new feat for user login';
+  const res2 = computeLabels(title2, mapping);
+  assert.deepStrictEqual(res2, ['feature']);
+
+  const title3 = 'Docs: update README and changelog';
+  const res3 = computeLabels(title3, mapping);
+  assert.deepStrictEqual(res3, ['documentation']);
+
+  const title4 = 'Refactor code without keywords';
+  const res4 = computeLabels(title4, mapping);
+  assert.deepStrictEqual(res4, []);
+
+  console.log('All computeLabels tests passed');
+}
+
+testComputeLabels();


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-pr-labeler
- **Provider**: groq
- **Location**: `github-actions/nightly-nightly-pr-labeler-8`
- **Files Created**: 5
- **Description**: GitHub Action that automatically adds labels to pull requests based on title keywords.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `github-actions/nightly-nightly-pr-labeler-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `github-actions/nightly-nightly-pr-labeler-8/README.md`
- Run tests located in `github-actions/nightly-nightly-pr-labeler-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.