### PR TITLE
feat(groq): Terraform module that provisions a versioned, encrypted S3 bucket with lifecycle rules for post‑apocalyptic data hoarding.

### DIFF
--- a/terraform-modules/nightly-nightly-secure-s3-bucket/terraform-modules/secure-s3-bucket/README.md
+++ b/terraform-modules/nightly-nightly-secure-s3-bucket/terraform-modules/secure-s3-bucket/README.md
@@ -1,0 +1,41 @@
+# Secure S3 Bucket Module
+
+This Terraform module creates an S3 bucket with:
+
+- Server‑side encryption (AES‑256)
+- Versioning enabled
+- Lifecycle rule to delete non‑current versions after 30 days
+- Randomized bucket name using `random_pet` to avoid naming collisions
+
+## Usage
+
+```hcl
+module "secure_bucket" {
+  source = "./terraform-modules/secure-s3-bucket"
+
+  bucket_prefix = "apocalypse"
+  tags = {
+    Environment = "production"
+    Owner       = "survivors"
+  }
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| bucket_prefix | Prefix for the bucket name | string | `"apocalypse"` |
+| tags | Tags to apply to the bucket | map(string) | `{}` |
+| aws_region | AWS region for the provider (used in tests) | string | `"us-east-1"` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| bucket_id | The name of the created bucket |
+| bucket_arn | ARN of the bucket |
+
+## Testing
+
+Run `./tests/run.sh` to execute `terraform init` and `terraform validate` in a temporary directory. The test uses dummy AWS credentials and does not make network calls.

--- a/terraform-modules/nightly-nightly-secure-s3-bucket/terraform-modules/secure-s3-bucket/src/main.tf
+++ b/terraform-modules/nightly-nightly-secure-s3-bucket/terraform-modules/secure-s3-bucket/src/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  # In tests we use the "us-east-1" region with dummy credentials.
+  region = var.aws_region
+}
+
+resource "random_pet" "bucket_name" {
+  length    = 2
+  separator = "-"
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = "${var.bucket_prefix}-${random_pet.bucket_name.id}"
+  tags   = var.tags
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "expire-noncurrent"
+    enabled = true
+
+    noncurrent_version_expiration {
+      days = 30
+    }
+  }
+}

--- a/terraform-modules/nightly-nightly-secure-s3-bucket/terraform-modules/secure-s3-bucket/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-secure-s3-bucket/terraform-modules/secure-s3-bucket/src/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_id" {
+  description = "The name of the created bucket"
+  value       = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the bucket"
+  value       = aws_s3_bucket.this.arn
+}

--- a/terraform-modules/nightly-nightly-secure-s3-bucket/terraform-modules/secure-s3-bucket/src/variables.tf
+++ b/terraform-modules/nightly-nightly-secure-s3-bucket/terraform-modules/secure-s3-bucket/src/variables.tf
@@ -1,0 +1,17 @@
+variable "bucket_prefix" {
+  description = "Prefix for the bucket name"
+  type        = string
+  default     = "apocalypse"
+}
+
+variable "tags" {
+  description = "Tags to apply to the bucket"
+  type        = map(string)
+  default     = {}
+}
+
+variable "aws_region" {
+  description = "AWS region for the provider"
+  type        = string
+  default     = "us-east-1"
+}

--- a/terraform-modules/nightly-nightly-secure-s3-bucket/terraform-modules/secure-s3-bucket/tests/run.sh
+++ b/terraform-modules/nightly-nightly-secure-s3-bucket/terraform-modules/secure-s3-bucket/tests/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a temporary working directory
+TMPDIR=$(mktemp -d)
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+# Copy module files
+cp -r "$(dirname "$0")/../src" "$TMPDIR/module"
+
+# Write a minimal root configuration that consumes the module
+cat > "$TMPDIR/main.tf" <<'EOF'
+module "test_bucket" {
+  source        = "./module"
+  bucket_prefix = "test"
+  tags = {
+    Purpose = "unit-test"
+  }
+  aws_region = "us-east-1"
+}
+EOF
+
+cd "$TMPDIR"
+# Initialise Terraform without a backend (offline only)
+terraform init -backend=false > /dev/null
+# Validate configuration – should succeed without contacting AWS
+terraform validate
+
+echo "Tests passed"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-secure-s3-bucket
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-secure-s3-bucket`
- **Files Created**: 5
- **Description**: Terraform module that provisions a versioned, encrypted S3 bucket with lifecycle rules for post‑apocalyptic data hoarding.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-secure-s3-bucket`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-secure-s3-bucket/README.md`
- Run tests located in `terraform-modules/nightly-nightly-secure-s3-bucket/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.