### PR TITLE
feat(gemini): An Ansible playbook to deploy and maintain a whimsical digital garden gnome on your servers.

### DIFF
--- a/ansible-playbooks/nightly-nightly-digital-gnome-keeper/README.md
+++ b/ansible-playbooks/nightly-nightly-digital-gnome-keeper/README.md
@@ -1,0 +1,89 @@
+# Nightly Digital Gnome Keeper
+
+An Ansible playbook to deploy and maintain a whimsical digital garden gnome on your servers. This utility ensures a friendly ASCII art gnome resides in a designated "digital garden" directory and can optionally greet you daily via a cron job.
+
+## Features
+
+*   **Gnome Deployment**: Places a charming ASCII art gnome file on your target systems.
+*   **Habitat Management**: Creates and manages the `/opt/digital_garden/gnome` directory with appropriate permissions.
+*   **Daily Greetings (Optional)**: Configures a cron job to log a daily greeting from your gnome.
+*   **Idempotent**: Running the playbook multiple times will result in the same desired state without unintended side effects.
+
+## Prerequisites
+
+*   Ansible installed on your control machine.
+*   SSH access to your target servers (or `connection: local` for local deployment).
+*   Python 3 on target servers (for Ansible's `raw` module if needed, though not strictly for this playbook).
+
+## Usage
+
+1.  **Create an Inventory File**:
+    Create an `inventory.ini` file specifying your target hosts.
+
+    ```ini
+    [garden_servers]
+    your_server_ip_or_hostname ansible_user=your_ssh_user ansible_become=yes
+    # Add more servers as needed
+    ```
+
+    For local testing, you can use:
+    ```ini
+    [garden_servers]
+    localhost ansible_connection=local ansible_become=yes
+    ```
+
+2.  **Run the Playbook**:
+    Execute the playbook using `ansible-playbook`.
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/gnome_keeper.yml
+    ```
+
+    To disable the cron job, you can pass a variable:
+    ```bash
+    ansible-playbook -i src/inventory.ini src/gnome_keeper.yml -e "enable_gnome_cron=false"
+    ```
+
+## Configuration
+
+The playbook uses the following variables, which can be overridden via `--extra-vars` (`-e`) or in your inventory:
+
+*   `gnome_base_dir`: The base directory for the digital garden. Default: `/opt/digital_garden`
+*   `gnome_name`: The filename for the gnome. Default: `gnome_buddy.txt`
+*   `gnome_owner`: The owner of the gnome files. Default: `root`
+*   `gnome_group`: The group of the gnome files. Default: `root`
+*   `gnome_dir_mode`: Permissions for the gnome directory. Default: `0755`
+*   `gnome_file_mode`: Permissions for the gnome file. Default: `0644`
+*   `enable_gnome_cron`: Whether to enable the daily cron greeting. Default: `true`
+*   `gnome_cron_log_file`: Path to the log file for gnome greetings. Default: `/var/log/gnome_greetings.log`
+
+## Example Output (after running playbook)
+
+```
+# On your server, check the directory:
+ls -l /opt/digital_garden/gnome/
+# Expected: -rw-r--r-- 1 root root <size> <date> gnome_buddy.txt
+
+# View the gnome:
+cat /opt/digital_garden/gnome/gnome_buddy.txt
+
+# If cron is enabled, check cron jobs:
+sudo crontab -l | grep "gnome_buddy.txt"
+# Expected: 0 8 * * * cat /opt/digital_garden/gnome/gnome_buddy.txt >> /var/log/gnome_greetings.log 2>&1
+
+# Check the log file after a day:
+cat /var/log/gnome_greetings.log
+# Expected: (gnome art)
+```
+
+## Testing
+
+The `tests/run_tests.sh` script orchestrates the testing process. It first cleans up any previous deployments, then runs the main `gnome_keeper.yml` playbook, verifies the deployed state using `tests/verify.yml`, and finally cleans up again.
+
+To run the tests:
+
+```bash
+bash tests/run_tests.sh
+```
+
+This will execute the playbook against `localhost` using `ansible_connection=local`, ensuring deterministic and offline testing without requiring remote infrastructure.

--- a/ansible-playbooks/nightly-nightly-digital-gnome-keeper/src/files/gnome.txt
+++ b/ansible-playbooks/nightly-nightly-digital-gnome-keeper/src/files/gnome.txt
@@ -1,0 +1,16 @@
+  _  _
+ / \/ \
+| () ()|
+ \ /\ /
+  \__/
+  (oo)
+  |--|
+  |  |
+  |__|
+  /  \
+ /____\
+(______)
+  ||||
+  ||||
+  `--'
+Hello, friend! Your digital garden gnome is watching over your server.

--- a/ansible-playbooks/nightly-nightly-digital-gnome-keeper/src/gnome_keeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-gnome-keeper/src/gnome_keeper.yml
@@ -1,0 +1,43 @@
+---
+- name: Deploy and maintain the Digital Garden Gnome
+  hosts: garden_servers
+  become: yes # Requires root privileges for /opt and cron
+  vars:
+    gnome_base_dir: "/opt/digital_garden"
+    gnome_name: "gnome_buddy.txt"
+    gnome_owner: "root"
+    gnome_group: "root"
+    gnome_dir_mode: "0755"
+    gnome_file_mode: "0644"
+    enable_gnome_cron: true
+    gnome_cron_log_file: "/var/log/gnome_greetings.log"
+
+  tasks:
+    - name: Ensure gnome base directory exists
+      ansible.builtin.file:
+        path: "{{ gnome_base_dir }}/gnome"
+        state: directory
+        owner: "{{ gnome_owner }}"
+        group: "{{ gnome_group }}"
+        mode: "{{ gnome_dir_mode }}"
+
+    - name: Copy the digital gnome file
+      ansible.builtin.copy:
+        src: files/gnome.txt
+        dest: "{{ gnome_base_dir }}/gnome/{{ gnome_name }}"
+        owner: "{{ gnome_owner }}"
+        group: "{{ gnome_group }}"
+        mode: "{{ gnome_file_mode }}"
+
+    - name: Configure daily gnome greeting cron job
+      ansible.builtin.cron:
+        name: "digital garden gnome greeting"
+        minute: "0"
+        hour: "8"
+        day: "*"
+        month: "*"
+        weekday: "*"
+        job: "cat {{ gnome_base_dir }}/gnome/{{ gnome_name }} >> {{ gnome_cron_log_file }} 2>&1"
+        user: "{{ gnome_owner }}" # Run cron as the gnome owner
+        state: "{{ 'present' if enable_gnome_cron else 'absent' }}"
+      when: enable_gnome_cron is defined and enable_gnome_cron | bool

--- a/ansible-playbooks/nightly-nightly-digital-gnome-keeper/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-digital-gnome-keeper/src/inventory.ini
@@ -1,0 +1,2 @@
+[garden_servers]
+localhost ansible_connection=local ansible_become=yes

--- a/ansible-playbooks/nightly-nightly-digital-gnome-keeper/tests/cleanup.yml
+++ b/ansible-playbooks/nightly-nightly-digital-gnome-keeper/tests/cleanup.yml
@@ -1,0 +1,20 @@
+---
+- name: Clean up Digital Garden Gnome artifacts
+  hosts: garden_servers
+  become: yes
+  vars:
+    gnome_base_dir: "/opt/digital_garden"
+  tasks:
+    - name: Ensure gnome base directory is absent
+      ansible.builtin.file:
+        path: "{{ gnome_base_dir }}"
+        state: absent
+      ignore_errors: yes
+      # Mock rationale: Ensures a clean, deterministic starting state for the test.
+
+    - name: Remove cron job
+      ansible.builtin.cron:
+        name: "digital garden gnome greeting"
+        state: absent
+      ignore_errors: yes
+      # Mock rationale: Ensures a clean, deterministic starting state for the test.

--- a/ansible-playbooks/nightly-nightly-digital-gnome-keeper/tests/inventory_test.ini
+++ b/ansible-playbooks/nightly-nightly-digital-gnome-keeper/tests/inventory_test.ini
@@ -1,0 +1,2 @@
+[garden_servers]
+localhost ansible_connection=local ansible_become=yes

--- a/ansible-playbooks/nightly-nightly-digital-gnome-keeper/tests/run_tests.sh
+++ b/ansible-playbooks/nightly-nightly-digital-gnome-keeper/tests/run_tests.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "--- Running Digital Garden Gnome Keeper Tests ---"
+
+# Define inventory for tests
+TEST_INVENTORY="tests/inventory_test.ini"
+MAIN_PLAYBOOK="src/gnome_keeper.yml"
+CLEANUP_PLAYBOOK="tests/cleanup.yml"
+VERIFY_PLAYBOOK="tests/verify.yml"
+
+# Check if ansible-playbook is available
+if ! command -v ansible-playbook &> /dev/null
+then
+    echo "Error: ansible-playbook command not found. Please install Ansible."
+    exit 1
+fi
+
+echo "1. Cleaning up previous test artifacts..."
+ansible-playbook -i "${TEST_INVENTORY}" "${CLEANUP_PLAYBOOK}"
+
+echo "2. Running the main Digital Garden Gnome Keeper playbook..."
+ansible-playbook -i "${TEST_INVENTORY}" "${MAIN_PLAYBOOK}"
+
+echo "3. Verifying the deployed state..."
+ansible-playbook -i "${TEST_INVENTORY}" "${VERIFY_PLAYBOOK}"
+
+echo "4. Cleaning up test artifacts after verification..."
+ansible-playbook -i "${TEST_INVENTORY}" "${CLEANUP_PLAYBOOK}"
+
+echo "--- All tests passed! ---"

--- a/ansible-playbooks/nightly-nightly-digital-gnome-keeper/tests/verify.yml
+++ b/ansible-playbooks/nightly-nightly-digital-gnome-keeper/tests/verify.yml
@@ -1,0 +1,75 @@
+---
+- name: Verify Digital Garden Gnome Keeper Playbook state
+  hosts: garden_servers
+  become: yes
+  vars:
+    gnome_base_dir: "/opt/digital_garden"
+    gnome_name: "gnome_buddy.txt"
+    gnome_owner: "root"
+    gnome_group: "root"
+    gnome_dir_mode: "0755"
+    gnome_file_mode: "0644"
+    gnome_cron_log_file: "/var/log/gnome_greetings.log"
+    # Mock rationale: These variables are set to match the defaults in the main playbook
+    # to ensure deterministic testing of the expected state.
+
+  tasks:
+    - name: Verify gnome directory exists and has correct permissions
+      ansible.builtin.stat:
+        path: "{{ gnome_base_dir }}/gnome"
+      register: gnome_dir_stat
+      # Mock rationale: Using ansible.builtin.stat to check local filesystem state.
+      # This is deterministic as it checks the state created by the playbook.
+
+    - name: Assert gnome directory properties
+      ansible.builtin.assert:
+        that:
+          - gnome_dir_stat.stat.exists is true
+          - gnome_dir_stat.stat.isdir is true
+          - gnome_dir_stat.stat.mode == "{{ gnome_dir_mode }}"
+          - gnome_dir_stat.stat.pw_name == "{{ gnome_owner }}"
+          - gnome_dir_stat.stat.gr_name == "{{ gnome_group }}"
+        msg: "Gnome directory {{ gnome_base_dir }}/gnome does not exist or has incorrect properties."
+
+    - name: Verify gnome file exists and has correct permissions
+      ansible.builtin.stat:
+        path: "{{ gnome_base_dir }}/gnome/{{ gnome_name }}"
+      register: gnome_file_stat
+      # Mock rationale: Using ansible.builtin.stat to check local filesystem state.
+      # This is deterministic as it checks the state created by the playbook.
+
+    - name: Assert gnome file properties
+      ansible.builtin.assert:
+        that:
+          - gnome_file_stat.stat.exists is true
+          - gnome_file_stat.stat.isreg is true
+          - gnome_file_stat.stat.mode == "{{ gnome_file_mode }}"
+          - gnome_file_stat.stat.pw_name == "{{ gnome_owner }}"
+          - gnome_file_stat.stat.gr_name == "{{ gnome_group }}"
+        msg: "Gnome file {{ gnome_base_dir }}/gnome/{{ gnome_name }} does not exist or has incorrect properties."
+
+    - name: Verify gnome file content (simple check)
+      ansible.builtin.slurp:
+        src: "{{ gnome_base_dir }}/gnome/{{ gnome_name }}"
+      register: gnome_content
+      # Mock rationale: Using ansible.builtin.slurp to read local file content.
+      # This is deterministic as it checks the content copied by the playbook.
+
+    - name: Assert gnome file content contains expected string
+      ansible.builtin.assert:
+        that:
+          - "'Hello, friend!' in (gnome_content['content'] | b64decode)"
+        msg: "Gnome file content does not contain expected greeting."
+
+    - name: Verify cron job is present
+      ansible.builtin.command: "crontab -l"
+      register: crontab_output
+      changed_when: false # This command does not change system state
+      # Mock rationale: Using ansible.builtin.command to check local cron table.
+      # This is deterministic as it checks the state created by the playbook.
+
+    - name: Assert cron job entry exists
+      ansible.builtin.assert:
+        that:
+          - "'cat {{ gnome_base_dir }}/gnome/{{ gnome_name }} >> {{ gnome_cron_log_file }} 2>&1' in crontab_output.stdout"
+        msg: "Gnome cron job not found in crontab."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-digital-gnome-keeper
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-digital-gnome-keeper`
- **Files Created**: 8
- **Description**: An Ansible playbook to deploy and maintain a whimsical digital garden gnome on your servers.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-digital-gnome-keeper`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-digital-gnome-keeper/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-digital-gnome-keeper/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.