### PR TITLE
feat(gemini): An Ansible playbook to sweep away digital dust bunnies (old temporary files and caches) from your servers, keeping them spick and span.

### DIFF
--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/README.md
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/README.md
@@ -1,0 +1,74 @@
+# Nightly Digital Dust Bunny Sweeper
+
+## Overview
+
+The `nightly-digital-dust-bunny-sweeper` is an Ansible playbook designed to keep your servers tidy by automatically identifying and removing old, temporary files and caches – affectionately dubbed "digital dust bunnies." It helps reclaim disk space and maintain system hygiene across your infrastructure.
+
+## Features
+
+*   **Configurable Paths**: Specify which directories to scan for old files.
+*   **Age-Based Cleanup**: Define how old a file must be before it's considered a "dust bunny" and swept away.
+*   **Idempotent**: Running the playbook multiple times will only remove files that meet the criteria.
+*   **Check Mode Support**: Safely preview what files *would* be removed without making actual changes.
+
+## Requirements
+
+*   Ansible (version 2.9 or newer recommended)
+*   SSH access to target servers with appropriate permissions to read and delete files in the specified `cleanup_paths`.
+
+## Usage
+
+1.  **Define your Inventory**: Create or update `src/inventory.ini` with the hosts you want to clean.
+
+    ```ini
+    # src/inventory.ini
+    [servers]
+    webserver1.example.com
+    dbserver.example.com
+
+    [all:vars]
+    ansible_user=your_ssh_user
+    ansible_ssh_private_key_file=~/.ssh/id_rsa
+    # Or use ansible_password if not using keys
+    ```
+
+2.  **Configure Cleanup Variables**: Edit `src/vars/main.yml` to specify the directories to clean and the age threshold.
+
+    ```yaml
+    # src/vars/main.yml
+    cleanup_age_days: 30 # Files older than 30 days will be removed
+    cleanup_paths:
+      - /tmp
+      - /var/tmp
+      - /var/log/old_app_logs
+      - /home/*/cache
+    ```
+
+3.  **Run in Check Mode (Recommended First!)**: Always run with `--check` first to see what changes the playbook *would* make.
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/playbook.yml --check --diff
+    ```
+
+    Review the output carefully. It will show you which files are identified as dust bunnies and would be removed.
+
+4.  **Execute the Cleanup**: Once you are confident with the `--check` output, run the playbook without `--check` to perform the actual cleanup.
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/playbook.yml
+    ```
+
+## Variables
+
+*   `cleanup_age_days` (default: `30`): Integer. Files older than this many days will be removed.
+*   `cleanup_paths` (default: `['/tmp', '/var/tmp']`): List of strings. Directories to scan for old files. Supports glob patterns (e.g., `/home/*/cache`).
+
+## Testing
+
+To run the automated tests for this utility, navigate to the utility's root directory and execute the test playbook:
+
+```bash
+ansible-playbook tests/test_dust_bunny_sweeper.yml
+```
+
+This test creates a temporary directory, populates it with files of varying ages, runs the main playbook in `--check` mode against this controlled environment, and asserts that only the expected "old" files are marked for removal.

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/dust_bunny_sweeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/dust_bunny_sweeper.yml
@@ -1,0 +1,34 @@
+# src/dust_bunny_sweeper.yml
+- name: Find old files (dust bunnies)
+  ansible.builtin.find:
+    paths: "{{ item }}"
+    age: "{{ cleanup_age_days }}d"
+    file_type: file
+    recurse: yes
+  loop: "{{ cleanup_paths }}"
+  register: old_files_found
+  # Mock rationale: The 'find' module operates on the local filesystem.
+  # For testing, we'll create a controlled temporary filesystem with known
+  # old and new files, ensuring deterministic results without external dependencies.
+
+- name: Report found dust bunnies
+  ansible.builtin.debug:
+    msg: "Found {{ item.path }} (last modified {{ item.mtime }}) - ready for sweeping!"
+  loop: "{{ old_files_found.results | map(attribute='files') | flatten }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when: item.files is defined and item.files | length > 0
+  # Mock rationale: This task just prints information based on the 'find' module's output.
+  # The 'find' module's output is controlled by our test setup.
+
+- name: Remove old files (sweep dust bunnies)
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ old_files_found.results | map(attribute='files') | flatten }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when: item.files is defined and item.files | length > 0
+  # Mock rationale: The 'file' module operates on the local filesystem.
+  # In test mode (--check), it reports what *would* be removed without actual deletion.
+  # Our test playbook will run in --check mode to verify intended actions.

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/inventory.ini
@@ -1,0 +1,10 @@
+# src/inventory.ini
+[servers]
+server1.example.com
+server2.example.com
+
+[all:vars]
+ansible_user=your_ssh_user
+ansible_ssh_private_key_file=~/.ssh/id_rsa
+# ansible_become=yes
+# ansible_become_user=root

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/playbook.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/playbook.yml
@@ -1,0 +1,8 @@
+---
+- name: Nightly Digital Dust Bunny Sweeper
+  hosts: all
+  gather_facts: no
+  vars_files:
+    - vars/main.yml
+  tasks:
+    - import_tasks: dust_bunny_sweeper.yml

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/vars/main.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/vars/main.yml
@@ -1,0 +1,7 @@
+# src/vars/main.yml
+cleanup_age_days: 30 # Files older than 30 days will be removed
+cleanup_paths:
+  - /tmp
+  - /var/tmp
+  - /var/log/old_app_logs
+  - /home/*/cache

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/test_dust_bunny_sweeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/test_dust_bunny_sweeper.yml
@@ -1,0 +1,87 @@
+---
+- name: Test Nightly Digital Dust Bunny Sweeper
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  vars:
+    test_base_dir: "{{ lookup('env', 'HOME') }}/.ansible_test_dust_bunnies"
+    test_target_dir: "{{ test_base_dir }}/temp_files"
+    cleanup_age_days: 1 # Set a short age for testing
+    cleanup_paths:
+      - "{{ test_target_dir }}"
+  tasks:
+    - name: Ensure test base directory exists
+      ansible.builtin.file:
+        path: "{{ test_base_dir }}"
+        state: directory
+        mode: '0755'
+
+    - name: Ensure test target directory exists
+      ansible.builtin.file:
+        path: "{{ test_target_dir }}"
+        state: directory
+        mode: '0755'
+
+    - name: Create inventory for test run
+      ansible.builtin.copy:
+        content: |
+          [localhost]
+          localhost ansible_connection=local
+        dest: "{{ test_base_dir }}/inventory_test.ini"
+      # Mock rationale: Creates a minimal inventory file for the nested ansible-playbook
+      # command to ensure it can target 'localhost' within the test environment.
+
+    - name: Create old file (dust bunny)
+      ansible.builtin.copy:
+        content: "This is an old file."
+        dest: "{{ test_target_dir }}/old_dust_bunny.txt"
+      register: old_file_created
+
+    - name: Set mtime for old file
+      ansible.builtin.command: touch -d "2 days ago" "{{ test_target_dir }}/old_dust_bunny.txt"
+      changed_when: false
+      # Mock rationale: Manually setting the modification time of a file
+      # ensures that the 'find' module will deterministically identify it as 'old'
+      # based on the 'cleanup_age_days' variable, without relying on real-time
+      # system clock changes or external file system state.
+
+    - name: Create new file (not a dust bunny)
+      ansible.builtin.copy:
+        content: "This is a new file."
+        dest: "{{ test_target_dir }}/new_shiny_file.txt"
+      register: new_file_created
+
+    - name: Run the dust bunny sweeper in check mode
+      ansible.builtin.command: >
+        ansible-playbook -i "{{ test_base_dir }}/inventory_test.ini"
+        "{{ playbook_dir }}/../src/playbook.yml"
+        --check
+        -e "cleanup_age_days={{ cleanup_age_days }}"
+        -e "cleanup_paths={{ cleanup_paths | to_json }}"
+      args:
+        chdir: "{{ test_base_dir }}" # Run from base dir to find inventory
+      register: playbook_output
+      changed_when: false
+      # Mock rationale: Running the playbook with '--check' mode prevents actual file deletion,
+      # allowing us to assert on the *intended* actions. The temporary directory and
+      # controlled file modification times ensure the 'find' and 'file' modules
+      # behave predictably for the test.
+
+    - name: Assert old file would be removed
+      ansible.builtin.assert:
+        that:
+          - "'old_dust_bunny.txt' in playbook_output.stdout"
+          - "'changed=1' in playbook_output.stdout" # Indicates a change would occur
+          - "'new_shiny_file.txt' not in playbook_output.stdout"
+          - "'new_shiny_file.txt' not in playbook_output.stderr"
+        fail_msg: "Expected old_dust_bunny.txt to be marked for removal and new_shiny_file.txt to be ignored. Output: {{ playbook_output.stdout }}"
+      # Mock rationale: This assertion checks the captured output of the playbook run.
+      # Since the playbook was run in check mode against a controlled test environment,
+      # the output is deterministic and reflects the expected behavior of the utility.
+
+    - name: Clean up test base directory
+      ansible.builtin.file:
+        path: "{{ test_base_dir }}"
+        state: absent
+      # Mock rationale: Ensures the test environment is cleaned up, leaving no
+      # residual files and making the test idempotent.


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-digital-dust-bunny-sweeper
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8`
- **Files Created**: 6
- **Description**: An Ansible playbook to sweep away digital dust bunnies (old temporary files and caches) from your servers, keeping them spick and span.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.