### PR TITLE
feat(groq): Deploys a daily hopeful quote file to a target directory, useful for post‑apocalyptic morale boosts.

### DIFF
--- a/ansible-playbooks/nightly-nightly-hopeful-quote-deploy/README.md
+++ b/ansible-playbooks/nightly-nightly-hopeful-quote-deploy/README.md
@@ -1,0 +1,27 @@
+# Nightly Hopeful Quote Deployer
+
+Deploys a single text file containing a hopeful quote to a specified directory on target hosts. Ideal for adding morale‑boosting messages to servers in a post‑apocalyptic setting.
+
+## Variables
+
+- `quote` (string, required): The quote to write.
+- `dest_dir` (string, default: `/tmp/quotes`): Destination directory.
+- `dest_file` (string, default: `quote.txt`): Filename.
+
+## Usage
+
+```sh
+ansible-playbook -i inventory.ini src/playbook.yml -e "quote='Even in the wasteland, hope blooms.' dest_dir=/opt/morale"
+```
+
+The playbook will ensure the directory exists and write the quote to the file.
+
+## Testing
+
+Run the bundled test playbook:
+
+```sh
+ansible-playbook -i inventory.ini tests/test_playbook.yml
+```
+
+It will execute the deployment with a test quote and verify the file content.

--- a/ansible-playbooks/nightly-nightly-hopeful-quote-deploy/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-hopeful-quote-deploy/inventory.ini
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-hopeful-quote-deploy/src/playbook.yml
+++ b/ansible-playbooks/nightly-nightly-hopeful-quote-deploy/src/playbook.yml
@@ -1,0 +1,19 @@
+- name: Deploy hopeful quote
+  hosts: all
+  gather_facts: false
+  vars:
+    dest_dir: "{{ dest_dir | default('/tmp/quotes') }}"
+    dest_file: "{{ dest_file | default('quote.txt') }}"
+    quote: "{{ quote | default('Even in the wasteland, hope blooms.') }}"
+  tasks:
+    - name: Ensure destination directory exists
+      file:
+        path: "{{ dest_dir }}"
+        state: directory
+        mode: '0755'
+
+    - name: Write quote to file
+      copy:
+        dest: "{{ dest_dir }}/{{ dest_file }}"
+        content: "{{ quote }}"
+        mode: '0644'

--- a/ansible-playbooks/nightly-nightly-hopeful-quote-deploy/tests/test_playbook.yml
+++ b/ansible-playbooks/nightly-nightly-hopeful-quote-deploy/tests/test_playbook.yml
@@ -1,0 +1,39 @@
+- name: Test hopeful quote deployment
+  hosts: local
+  gather_facts: false
+  vars:
+    test_quote: "Test quote for CI."
+    test_dir: "/tmp/ansible_test_quotes"
+    test_file: "test.txt"
+  tasks:
+    - name: Include main playbook with test vars
+      import_playbook: "../src/playbook.yml"
+      vars:
+        quote: "{{ test_quote }}"
+        dest_dir: "{{ test_dir }}"
+        dest_file: "{{ test_file }}"
+
+    - name: Verify file exists
+      stat:
+        path: "{{ test_dir }}/{{ test_file }}"
+      register: file_stat
+
+    - name: Assert file was created
+      assert:
+        that:
+          - file_stat.stat.exists
+          - file_stat.stat.isreg
+
+    - name: Read file content
+      slurp:
+        src: "{{ test_dir }}/{{ test_file }}"
+      register: file_content
+
+    - name: Decode content
+      set_fact:
+        decoded_content: "{{ file_content.content | b64decode }}"
+
+    - name: Assert content matches
+      assert:
+        that:
+          - decoded_content == test_quote


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-hopeful-quote-deployer
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-hopeful-quote-deploy`
- **Files Created**: 4
- **Description**: Deploys a daily hopeful quote file to a target directory, useful for post‑apocalyptic morale boosts.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-hopeful-quote-deploy`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-hopeful-quote-deploy/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-hopeful-quote-deploy/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.