### PR TITLE
feat(groq): Terraform module that provisions an S3 bucket configured as a post‑apocalyptic safe‑house with versioning, encryption, and a 30‑day expiration lifecycle rule.

### DIFF
--- a/terraform-modules/nightly-nightly-postapoc-s3-safehous-2/README.md
+++ b/terraform-modules/nightly-nightly-postapoc-s3-safehous-2/README.md
@@ -1,0 +1,31 @@
+# nightly-postapoc-s3-safehouse
+
+Creates an S3 bucket configured as a post‑apocalyptic safe‑house: versioning enabled, server‑side encryption with AES‑256, and a lifecycle rule that expires objects after 30 days. The module is provider‑agnostic; it uses the AWS provider but can be run with a mock or LocalStack for testing.
+
+## Usage
+
+```hcl
+module "safehouse" {
+  source = "github.com/yourorg/polsala//terraform-modules/nightly-postapoc-s3-safehouse"
+
+  bucket_name = "my-safe-house-bucket"
+}
+```
+
+## Inputs
+
+- `bucket_name` (string, required): Name of the S3 bucket.
+
+## Outputs
+
+- `bucket_arn` – ARN of the created bucket.
+- `bucket_id` – ID of the bucket.
+
+## Testing
+
+Run the test script:
+
+```sh
+cd tests
+./validate.sh
+```

--- a/terraform-modules/nightly-nightly-postapoc-s3-safehous-2/src/main.tf
+++ b/terraform-modules/nightly-nightly-postapoc-s3-safehous-2/src/main.tf
@@ -1,0 +1,41 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+resource "aws_s3_bucket" "safehouse" {
+  bucket = var.bucket_name
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "expire-after-30-days"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
+
+  tags = {
+    Purpose = "PostApocSafeHouse"
+  }
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.safehouse.arn
+}
+
+output "bucket_id" {
+  value = aws_s3_bucket.safehouse.id
+}

--- a/terraform-modules/nightly-nightly-postapoc-s3-safehous-2/tests/validate.sh
+++ b/terraform-modules/nightly-nightly-postapoc-s3-safehous-2/tests/validate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -e
+
+# Create a temporary test workspace
+WORKDIR=$(mktemp -d)
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# Write a minimal configuration that uses the module
+cat > "$WORKDIR/main.tf" <<'EOF'
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id   = true
+  # Dummy credentials to avoid real AWS calls
+  access_key                  = "mock"
+  secret_key                  = "mock"
+  s3_use_path_style           = true
+  endpoints {
+    s3 = "http://localhost:4566"
+  }
+}
+
+module "safehouse" {
+  source      = "../../src"
+  bucket_name = "test-safehouse-bucket"
+}
+EOF
+
+# Initialize and validate
+cd "$WORKDIR"
+terraform init -backend=false -input=false > /dev/null
+terraform validate -no-color
+
+echo "✅ Terraform validation passed"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-postapoc-s3-safehouse
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-postapoc-s3-safehous-2`
- **Files Created**: 3
- **Description**: Terraform module that provisions an S3 bucket configured as a post‑apocalyptic safe‑house with versioning, encryption, and a 30‑day expiration lifecycle rule.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-postapoc-s3-safehous-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-postapoc-s3-safehous-2/README.md`
- Run tests located in `terraform-modules/nightly-nightly-postapoc-s3-safehous-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.