### PR TITLE
feat(groq): Concurrently measures TCP latency to multiple hosts and reports sorted results

### DIFF
--- a/go-utils/nightly-nightly-concurrent-ping-swee-5/README.md
+++ b/go-utils/nightly-nightly-concurrent-ping-swee-5/README.md
@@ -1,0 +1,49 @@
+# nightly-concurrent-ping-sweeper
+
+A whimsical yet useful Go utility that pings multiple hosts concurrently by opening a short‑lived TCP connection to port 80, measures the round‑trip latency, and prints the results sorted from fastest to slowest.
+
+## Features
+
+- **Concurrent**: launches a goroutine per host, making full use of Go's lightweight concurrency.
+- **Deterministic output**: prints each host with its measured latency (or error) in a tidy table.
+- **Testable**: the networking layer is abstracted so unit tests can mock latency values without real network traffic.
+
+## Installation
+
+```bash
+# Clone the repository (or copy the generated folder) and build
+git clone https://github.com/polsala/ApocalypsAI.git
+cd utils/go-utils/nightly-concurrent-ping-sweeper
+go build -o ping-sweeper ./src/main.go
+```
+
+## Usage
+
+```bash
+# Pass a list of hostnames or IP addresses as arguments
+./ping-sweeper example.com google.com 8.8.8.8
+```
+
+Output example:
+
+```
+example.com    45.2ms
+google.com     78.9ms
+8.8.8.8       112.3ms
+```
+
+If a host cannot be reached, the error is shown instead of a latency:
+
+```
+nonexistent.tld    error: dial tcp: lookup nonexistent.tld: no such host
+```
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+go test ./tests
+```
+
+The tests use a mock dialer, so they run offline and deterministically.

--- a/go-utils/nightly-nightly-concurrent-ping-swee-5/src/main.go
+++ b/go-utils/nightly-nightly-concurrent-ping-swee-5/src/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+    "fmt"
+    "net"
+    "os"
+    "sort"
+    "sync"
+    "time"
+)
+
+type pingResult struct {
+    Host    string
+    Latency time.Duration
+    Err     error
+}
+
+// dialerFunc abstracts the network call for easier testing.
+var dialerFunc = realDial
+
+// realDial attempts a TCP connection to host:80 with a 2‑second timeout and returns the elapsed time.
+func realDial(host string) (time.Duration, error) {
+    start := time.Now()
+    conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, "80"), 2*time.Second)
+    if err != nil {
+        return 0, err
+    }
+    conn.Close()
+    return time.Since(start), nil
+}
+
+// pingHost uses dialerFunc to measure latency for a single host.
+func pingHost(host string) pingResult {
+    latency, err := dialerFunc(host)
+    return pingResult{Host: host, Latency: latency, Err: err}
+}
+
+// pingHosts concurrently pings all provided hosts and returns results sorted by latency (fastest first).
+func pingHosts(hosts []string) []pingResult {
+    var wg sync.WaitGroup
+    resultsCh := make(chan pingResult, len(hosts))
+
+    for _, h := range hosts {
+        wg.Add(1)
+        go func(host string) {
+            defer wg.Done()
+            resultsCh <- pingHost(host)
+        }(h)
+    }
+
+    wg.Wait()
+    close(resultsCh)
+
+    var results []pingResult
+    for r := range resultsCh {
+        results = append(results, r)
+    }
+
+    // Sort: successful pings first, ordered by latency; errors after.
+    sort.SliceStable(results, func(i, j int) bool {
+        if results[i].Err != nil && results[j].Err == nil {
+            return false
+        }
+        if results[i].Err == nil && results[j].Err != nil {
+            return true
+        }
+        if results[i].Err != nil && results[j].Err != nil {
+            return results[i].Host < results[j].Host
+        }
+        return results[i].Latency < results[j].Latency
+    })
+    return results
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("Usage: ping-sweeper <host1> <host2> ...")
+        os.Exit(1)
+    }
+    hosts := os.Args[1:]
+    results := pingHosts(hosts)
+    for _, r := range results {
+        if r.Err != nil {
+            fmt.Printf("%s\terror: %v\n", r.Host, r.Err)
+        } else {
+            fmt.Printf("%s\t%v\n", r.Host, r.Latency)
+        }
+    }
+}

--- a/go-utils/nightly-nightly-concurrent-ping-swee-5/tests/main_test.go
+++ b/go-utils/nightly-nightly-concurrent-ping-swee-5/tests/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+    "errors"
+    "reflect"
+    "testing"
+    "time"
+)
+
+// mockDial simulates latency based on host name.
+func mockDial(host string) (time.Duration, error) {
+    switch host {
+    case "fast.example":
+        return 30 * time.Millisecond, nil
+    case "slow.example":
+        return 150 * time.Millisecond, nil
+    case "error.example":
+        return 0, errors.New("mock connection error")
+    default:
+        return 0, errors.New("unknown host")
+    }
+}
+
+func TestPingHosts_Mocked(t *testing.T) {
+    // Replace the global dialer with the mock.
+    originalDialer := dialerFunc
+    dialerFunc = mockDial
+    defer func() { dialerFunc = originalDialer }()
+
+    hosts := []string{"slow.example", "fast.example", "error.example"}
+    results := pingHosts(hosts)
+
+    // Expected order: fast, slow, error.
+    expected := []pingResult{
+        {Host: "fast.example", Latency: 30 * time.Millisecond, Err: nil},
+        {Host: "slow.example", Latency: 150 * time.Millisecond, Err: nil},
+        {Host: "error.example", Latency: 0, Err: errors.New("mock connection error")},
+    }
+
+    // Compare only Host and Err messages; Latency is checked for the first two entries.
+    for i, exp := range expected {
+        got := results[i]
+        if got.Host != exp.Host {
+            t.Fatalf("result %d host mismatch: got %s, want %s", i, got.Host, exp.Host)
+        }
+        if (got.Err == nil) != (exp.Err == nil) {
+            t.Fatalf("result %d error presence mismatch: got %v, want %v", i, got.Err, exp.Err)
+        }
+        if got.Err != nil && exp.Err != nil && got.Err.Error() != exp.Err.Error() {
+            t.Fatalf("result %d error message mismatch: got %s, want %s", i, got.Err.Error(), exp.Err.Error())
+        }
+        if got.Err == nil && got.Latency != exp.Latency {
+            t.Fatalf("result %d latency mismatch: got %v, want %v", i, got.Latency, exp.Latency)
+        }
+    }
+
+    // Ensure the slice length matches.
+    if len(results) != len(expected) {
+        t.Fatalf("unexpected number of results: got %d, want %d", len(results), len(expected))
+    }
+
+    // Verify sorting stability for errors (alphabetical order if multiple errors).
+    // Add a second error host to test.
+    hosts = []string{"error.example", "unknown.example"}
+    results = pingHosts(hosts)
+    if !reflect.DeepEqual([]string{results[0].Host, results[1].Host}, []string{"error.example", "unknown.example"}) {
+        t.Fatalf("error hosts not sorted alphabetically: %v", results)
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-concurrent-ping-sweeper
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-concurrent-ping-swee-5`
- **Files Created**: 3
- **Description**: Concurrently measures TCP latency to multiple hosts and reports sorted results

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-concurrent-ping-swee-5`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-concurrent-ping-swee-5/README.md`
- Run tests located in `go-utils/nightly-nightly-concurrent-ping-swee-5/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.