### PR TITLE
feat(groq): Terraform module that provisions a versioned, encrypted S3 bucket with a 30‑day lifecycle and a DynamoDB table for post‑apocalyptic supply caches.

### DIFF
--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/README.md
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/README.md
@@ -1,0 +1,48 @@
+# Nightly Apocalypse Safehouse Terraform Module
+
+A whimsical yet practical Terraform module that creates a hardened S3 bucket (versioned, encrypted, with a 30‑day lifecycle) and a DynamoDB table to store supply‑cache metadata. Ideal for post‑apocalyptic projects that still need cloud storage.
+
+## Usage
+
+```hcl
+module "safehouse" {
+  source               = "git::https://github.com/yourorg/apocalypsai.git//terraform-modules/nightly-apocalypse-safehouse"
+  bucket_name          = "my-safehouse-bucket"
+  dynamodb_table_name  = "supply-cache"
+  tags = {
+    Environment = "production"
+    Project     = "apocalypse"
+  }
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| bucket_name | Name of the S3 bucket | string | n/a | yes |
+| dynamodb_table_name | Name of the DynamoDB table | string | n/a | yes |
+| tags | Tags to apply to resources | map(string) | {} | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| bucket_id | ID of the created S3 bucket |
+| bucket_arn | ARN of the S3 bucket |
+| dynamodb_table_name | Name of the DynamoDB table |
+
+## Testing
+
+Run the included test script:
+
+```sh
+cd terraform-modules/nightly-apocalypse-safehouse
+./tests/test_main.sh
+```
+
+The script runs `terraform init -backend=false` and `terraform validate`. It should exit with code 0.
+
+## License
+
+MIT

--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/main.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/main.tf
@@ -1,0 +1,45 @@
+resource "aws_s3_bucket" "safehouse" {
+  bucket = var.bucket_name
+  tags   = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "safehouse" {
+  bucket = aws_s3_bucket.safehouse.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "safehouse" {
+  bucket = aws_s3_bucket.safehouse.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "safehouse" {
+  bucket = aws_s3_bucket.safehouse.id
+  rule {
+    id     = "expire-old-objects"
+    status = "Enabled"
+    expiration {
+      days = 30
+    }
+    filter {}
+  }
+}
+
+resource "aws_dynamodb_table" "supply_cache" {
+  name         = var.dynamodb_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "ItemID"
+
+  attribute {
+    name = "ItemID"
+    type = "S"
+  }
+
+  tags = var.tags
+}

--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/outputs.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_id" {
+  description = "ID of the created S3 bucket"
+  value       = aws_s3_bucket.safehouse.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = aws_s3_bucket.safehouse.arn
+}
+
+output "dynamodb_table_name" {
+  description = "Name of the DynamoDB table"
+  value       = aws_dynamodb_table.supply_cache.name
+}

--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/tests/test_main.sh
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/tests/test_main.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mock rationale: Use local backend and validate syntax only.
+terraform init -backend=false > /dev/null 2>&1
+terraform validate > /dev/null 2>&1
+
+echo "Terraform module validation passed."

--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/variables.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/variables.tf
@@ -1,0 +1,15 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "dynamodb_table_name" {
+  description = "Name of the DynamoDB table"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-apocalypse-safehouse
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-apocalypse-safehouse-6`
- **Files Created**: 5
- **Description**: Terraform module that provisions a versioned, encrypted S3 bucket with a 30‑day lifecycle and a DynamoDB table for post‑apocalyptic supply caches.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-apocalypse-safehouse-6`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-apocalypse-safehouse-6/README.md`
- Run tests located in `terraform-modules/nightly-nightly-apocalypse-safehouse-6/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.