### PR TITLE
feat(groq): Dockerized CLI that generates a deterministic post‑apocalyptic haiku based on input text.

### DIFF
--- a/docker-tools/nightly-nightly-docker-ghost-haiku/Dockerfile
+++ b/docker-tools/nightly-nightly-docker-ghost-haiku/Dockerfile
@@ -1,0 +1,10 @@
+# Build stage
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY src/main.go .
+RUN go build -o ghost-haiku .
+
+# Runtime stage
+FROM alpine:3.18
+COPY --from=builder /app/ghost-haiku /usr/local/bin/ghost-haiku
+ENTRYPOINT ["ghost-haiku"]

--- a/docker-tools/nightly-nightly-docker-ghost-haiku/README.md
+++ b/docker-tools/nightly-nightly-docker-ghost-haiku/README.md
@@ -1,0 +1,33 @@
+# nightly-docker-ghost-haiku
+
+A whimsical Docker container that reads any text from stdin and returns a post‑apocalyptic haiku. The haiku is chosen deterministically by hashing the input, so the same input always yields the same poem.
+
+## Build
+
+```sh
+docker build -t ghost-haiku .
+```
+
+## Run
+
+```sh
+echo "your prompt" | docker run -i ghost-haiku
+```
+
+Example:
+
+```sh
+echo "test" | docker run -i ghost-haiku
+```
+
+Outputs:
+
+```
+Moonlight cracks the stone
+Shadows dance on cracked glass
+Tomorrow sings soft
+```
+
+## How it works
+
+The Go program reads stdin, sums the byte values, takes the remainder modulo the number of haikus, and prints the selected haiku.

--- a/docker-tools/nightly-nightly-docker-ghost-haiku/src/main.go
+++ b/docker-tools/nightly-nightly-docker-ghost-haiku/src/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "io"
+    "os"
+)
+
+var haikus = []string{
+    "Silent ruins whisper\nEchoes of forgotten suns\nNight embraces all",
+    "Dusty wind caresses\nBroken gears of old machines\nHope flickers anew",
+    "Ashes drift like snow\nStars hide behind iron clouds\nDreams survive the gloom",
+    "Moonlight cracks the stone\nShadows dance on cracked glass\nTomorrow sings soft",
+    "Cinders paint the sky\nRivers of fire flow onward\nLife burns in the dark",
+}
+
+func main() {
+    // Read all input from stdin
+    data, err := io.ReadAll(bufio.NewReader(os.Stdin))
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "error reading stdin")
+        os.Exit(1)
+    }
+
+    // Compute simple hash: sum of bytes
+    sum := 0
+    for _, b := range data {
+        sum += int(b)
+    }
+
+    // Choose haiku deterministically
+    idx := 0
+    if len(haikus) > 0 {
+        idx = sum % len(haikus)
+    }
+
+    fmt.Println(haikus[idx])
+}

--- a/docker-tools/nightly-nightly-docker-ghost-haiku/tests/test_ghost_haiku.sh
+++ b/docker-tools/nightly-nightly-docker-ghost-haiku/tests/test_ghost_haiku.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+# Build the Docker image (quiet output)
+docker build -t ghost-haiku . > /dev/null
+
+# Run container with known input
+output=$(echo -n "test" | docker run -i --rm ghost-haiku)
+
+expected="Moonlight cracks the stone\nShadows dance on cracked glass\nTomorrow sings soft"
+
+if [ "$output" = "$expected" ]; then
+  echo "PASS"
+  exit 0
+else
+  echo "FAIL"
+  echo "Expected:"
+  echo "$expected"
+  echo "Got:"
+  echo "$output"
+  exit 1
+fi


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-docker-ghost-haiku
- **Provider**: groq
- **Location**: `docker-tools/nightly-nightly-docker-ghost-haiku`
- **Files Created**: 4
- **Description**: Dockerized CLI that generates a deterministic post‑apocalyptic haiku based on input text.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `docker-tools/nightly-nightly-docker-ghost-haiku`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `docker-tools/nightly-nightly-docker-ghost-haiku/README.md`
- Run tests located in `docker-tools/nightly-nightly-docker-ghost-haiku/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.