### PR TITLE
feat(groq): CLI tool to compute remaining amount of a radioactive substance after a given time using its half-life.

### DIFF
--- a/typescript-utils/nightly-nightly-radioactive-decay-ti/README.md
+++ b/typescript-utils/nightly-nightly-radioactive-decay-ti/README.md
@@ -1,0 +1,28 @@
+# Nightly Radioactive Decay Timer
+
+Utility to calculate the remaining quantity of a radioactive substance after a given elapsed time using its half‑life.
+
+## Installation
+
+```sh
+npm install -g nightly-radioactive-decay-timer
+```
+
+## Usage
+
+```sh
+nrdt --initial 100 --half-life 30 --time 90
+# Output: Remaining amount: 12.5
+```
+
+## Options
+
+- `--initial <number>`: Initial amount (default `1`).
+- `--half-life <number>`: Half‑life period (must be positive, same units as `--time`).
+- `--time <number>`: Elapsed time.
+
+The tool prints the remaining amount to stdout. Errors are printed to stderr and cause a non‑zero exit code.
+
+## License
+
+MIT

--- a/typescript-utils/nightly-nightly-radioactive-decay-ti/jest.config.js
+++ b/typescript-utils/nightly-nightly-radioactive-decay-ti/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+};

--- a/typescript-utils/nightly-nightly-radioactive-decay-ti/package.json
+++ b/typescript-utils/nightly-nightly-radioactive-decay-ti/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "nightly-radioactive-decay-timer",
+  "version": "0.1.0",
+  "bin": {
+    "nrdt": "./dist/index.js"
+  },
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/typescript-utils/nightly-nightly-radioactive-decay-ti/src/index.ts
+++ b/typescript-utils/nightly-nightly-radioactive-decay-ti/src/index.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { argv } from 'process';
+
+function parseArgs(args: string[]): { initial: number; halfLife: number; time: number } {
+  const result: any = { initial: 1, halfLife: 1, time: 0 };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--initial' && i + 1 < args.length) {
+      result.initial = Number(args[++i]);
+    } else if (arg === '--half-life' && i + 1 < args.length) {
+      result.halfLife = Number(args[++i]);
+    } else if (arg === '--time' && i + 1 < args.length) {
+      result.time = Number(args[++i]);
+    }
+  }
+  return result;
+}
+
+export function remainingAmount(initial: number, halfLife: number, time: number): number {
+  if (halfLife <= 0) throw new Error('Half-life must be positive');
+  const decayFactor = Math.pow(0.5, time / halfLife);
+  return initial * decayFactor;
+}
+
+if (require.main === module) {
+  const { initial, halfLife, time } = parseArgs(argv.slice(2));
+  try {
+    const remaining = remainingAmount(initial, halfLife, time);
+    console.log(`Remaining amount: ${remaining}`);
+  } catch (e: any) {
+    console.error(`Error: ${e.message}`);
+    process.exit(1);
+  }
+}

--- a/typescript-utils/nightly-nightly-radioactive-decay-ti/tests/decay.test.ts
+++ b/typescript-utils/nightly-nightly-radioactive-decay-ti/tests/decay.test.ts
@@ -1,0 +1,17 @@
+import { remainingAmount } from '../src/index';
+
+test('no decay when time is zero', () => {
+  expect(remainingAmount(100, 10, 0)).toBeCloseTo(100);
+});
+
+test('half‑life decay', () => {
+  expect(remainingAmount(100, 10, 10)).toBeCloseTo(50);
+});
+
+test('multiple half‑lives', () => {
+  expect(remainingAmount(80, 5, 15)).toBeCloseTo(10);
+});
+
+test('throws on non‑positive half‑life', () => {
+  expect(() => remainingAmount(10, 0, 5)).toThrow('Half-life must be positive');
+});

--- a/typescript-utils/nightly-nightly-radioactive-decay-ti/tsconfig.json
+++ b/typescript-utils/nightly-nightly-radioactive-decay-ti/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-radioactive-decay-timer
- **Provider**: groq
- **Location**: `typescript-utils/nightly-nightly-radioactive-decay-ti`
- **Files Created**: 6
- **Description**: CLI tool to compute remaining amount of a radioactive substance after a given time using its half-life.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `typescript-utils/nightly-nightly-radioactive-decay-ti`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `typescript-utils/nightly-nightly-radioactive-decay-ti/README.md`
- Run tests located in `typescript-utils/nightly-nightly-radioactive-decay-ti/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.