### PR TITLE
feat(groq): Terraform module that provisions an AWS S3 bucket with versioning and server‑side encryption, fully testable offline.

### DIFF
--- a/terraform-modules/nightly-nightly-s3-bucket-creator/README.md
+++ b/terraform-modules/nightly-nightly-s3-bucket-creator/README.md
@@ -1,0 +1,31 @@
+# nightly-s3-bucket-creator
+
+Creates an AWS S3 bucket with versioning and server‑side encryption. Simple Terraform module.
+
+## Usage
+
+```hcl
+module "my_bucket" {
+  source      = "github.com/yourorg/polsala/ApocalypsAI//terraform-modules/nightly-s3-bucket-creator"
+  bucket_name = "my-unique-bucket"
+}
+```
+
+## Variables
+
+- `bucket_name` (string) – Name of the bucket (must be globally unique).
+- `aws_region` (string) – AWS region (default: `us-east-1`).
+
+## Outputs
+
+- `bucket_arn` – ARN of the created bucket.
+
+## Testing
+
+Run the test script from the module root:
+
+```bash
+bash tests/test_main.sh
+```
+
+The script validates the configuration and runs a dry‑run plan without requiring real AWS credentials.

--- a/terraform-modules/nightly-nightly-s3-bucket-creator/src/main.tf
+++ b/terraform-modules/nightly-nightly-s3-bucket-creator/src/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                       = var.aws_region
+  skip_credentials_validation  = true
+  skip_metadata_api_check      = true
+  # No real credentials needed for offline testing
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  tags = {
+    ManagedBy = "nightly-s3-bucket-creator"
+  }
+}

--- a/terraform-modules/nightly-nightly-s3-bucket-creator/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-s3-bucket-creator/src/outputs.tf
@@ -1,0 +1,4 @@
+output "bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = aws_s3_bucket.this.arn
+}

--- a/terraform-modules/nightly-nightly-s3-bucket-creator/src/variables.tf
+++ b/terraform-modules/nightly-nightly-s3-bucket-creator/src/variables.tf
@@ -1,0 +1,10 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}

--- a/terraform-modules/nightly-nightly-s3-bucket-creator/tests/test_main.sh
+++ b/terraform-modules/nightly-nightly-s3-bucket-creator/tests/test_main.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mock rationale: Ensure Terraform configuration validates and plans without real AWS credentials.
+# Initialize Terraform with a local (no‑backend) configuration.
+terraform init -backend=false -input=false > /dev/null
+
+# Validate the configuration syntax.
+terraform validate
+
+# Run a dry‑run plan using a unique bucket name to avoid name collisions.
+terraform plan -input=false -var="bucket_name=test-bucket-$(date +%s)" -out=plan.out > /dev/null
+
+echo "All Terraform checks passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-s3-bucket-creator
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-s3-bucket-creator`
- **Files Created**: 5
- **Description**: Terraform module that provisions an AWS S3 bucket with versioning and server‑side encryption, fully testable offline.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-s3-bucket-creator`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-s3-bucket-creator/README.md`
- Run tests located in `terraform-modules/nightly-nightly-s3-bucket-creator/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.