### PR TITLE
feat(groq): A whimsical Rust CLI that generates random post‑apocalyptic cryptid sighting clues for games or writing prompts.

### DIFF
--- a/rust-utils/nightly-nightly-cryptid-clue-generat/Cargo.toml
+++ b/rust-utils/nightly-nightly-cryptid-clue-generat/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cryptid_clue_generator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = "0.8"

--- a/rust-utils/nightly-nightly-cryptid-clue-generat/README.md
+++ b/rust-utils/nightly-nightly-cryptid-clue-generat/README.md
@@ -1,0 +1,30 @@
+# Cryptid Clue Generator
+
+A whimsical Rust CLI that generates a random post‑apocalyptic cryptid sighting clue. Useful for tabletop RPGs, writing prompts, or just fun.
+
+## Build
+
+```sh
+cargo build --release
+```
+
+## Usage
+
+```sh
+cargo run -- [SEED]
+```
+
+*Optional* `SEED` (a `u64`) makes the output deterministic.
+
+### Example
+
+```sh
+$ cargo run -- 42
+A haunting Chupacabra spotted near the flooded subway.
+```
+
+## Testing
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-cryptid-clue-generat/src/main.rs
+++ b/rust-utils/nightly-nightly-cryptid-clue-generat/src/main.rs
@@ -1,0 +1,52 @@
+use rand::Rng;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand::rngs::{StdRng, ThreadRng};
+
+fn generate_clue(seed: Option<u64>) -> String {
+    // Choose RNG: deterministic if a seed is supplied, otherwise thread‑local RNG.
+    let mut rng: Box<dyn RngCore> = match seed {
+        Some(s) => Box::new(StdRng::seed_from_u64(s)),
+        None => Box::new(rand::thread_rng()),
+    };
+
+    let cryptids = ["Mothman", "Chupacabra", "Jersey Devil", "Loch Ness Monster"];
+    let adjectives = ["lurking", "haunting", "roaming", "cackling"];
+    let locations = [
+        "the abandoned mall",
+        "the ruined highway",
+        "the flooded subway",
+        "the deserted bunker",
+    ];
+
+    let c = cryptids[rng.gen_range(0..cryptids.len())];
+    let a = adjectives[rng.gen_range(0..adjectives.len())];
+    let l = locations[rng.gen_range(0..locations.len())];
+
+    format!("A {} {} spotted near {}.", a, c, l)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let seed = if args.len() > 1 {
+        args[1].parse::<u64>().ok()
+    } else {
+        None
+    };
+    println!("{}", generate_clue(seed));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_clue_deterministic() {
+        // With a fixed seed the output should be reproducible.
+        let clue = generate_clue(Some(0));
+        // Basic sanity checks – the format is fixed, so we can assert parts exist.
+        assert!(clue.starts_with("A "));
+        assert!(clue.contains("spotted near"));
+        assert!(clue.ends_with('.'));
+    }
+}

--- a/rust-utils/nightly-nightly-cryptid-clue-generat/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-cryptid-clue-generat/tests/test_main.rs
@@ -1,0 +1,15 @@
+// Integration test to verify the binary runs without panicking.
+// No external resources are required; this test simply invokes the binary.
+
+#[test]
+fn run_binary() {
+    // Mock rationale: we invoke the compiled binary with a deterministic seed.
+    // The test passes if the process exits successfully.
+    let output = std::process::Command::new("cargo")
+        .args(&["run", "--quiet", "--", "123"])
+        .output()
+        .expect("failed to execute cargo run");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("spotted near"));
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-cryptid-clue-generator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-cryptid-clue-generat`
- **Files Created**: 4
- **Description**: A whimsical Rust CLI that generates random post‑apocalyptic cryptid sighting clues for games or writing prompts.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-cryptid-clue-generat`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-cryptid-clue-generat/README.md`
- Run tests located in `rust-utils/nightly-nightly-cryptid-clue-generat/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.