### PR TITLE
feat(groq): Terraform module that provisions a secure, versioned S3 bucket for post‑apocalyptic safe‑house data with auto‑expiration.

### DIFF
--- a/terraform-modules/nightly-nightly-terraform-safehouse/README.md
+++ b/terraform-modules/nightly-nightly-terraform-safehouse/README.md
@@ -1,0 +1,42 @@
+# Terraform Safehouse S3 Module
+
+## Overview
+
+Creates an S3 bucket with:
+
+- Randomized name (using random_pet)
+- Server‑side encryption (AES‑256)
+- Versioning enabled
+- Lifecycle rule to delete non‑current versions after 30 days
+- Optional tags
+
+## Usage
+
+```hcl
+module "safehouse_s3" {
+  source = "./"
+  bucket_prefix = "safehouse"
+  tags = {
+    Environment = "post-apocalypse"
+  }
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| bucket_prefix | Prefix for bucket name | string | "safehouse" |
+| tags | Tags to apply to bucket | map(string) | {} |
+| aws_region | AWS region for resources | string | "us-east-1" |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| bucket_id | The name of the created bucket |
+| bucket_arn | ARN of the bucket |
+
+## Testing
+
+Run `./tests/test_main.sh` to validate the module.

--- a/terraform-modules/nightly-nightly-terraform-safehouse/main.tf
+++ b/terraform-modules/nightly-nightly-terraform-safehouse/main.tf
@@ -1,0 +1,62 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  # In tests we use dummy credentials; real usage requires proper config.
+  region = var.aws_region
+}
+
+resource "random_pet" "bucket_name" {
+  length    = 2
+  separator = "-"
+}
+
+resource "aws_s3_bucket" "safehouse" {
+  bucket = "${var.bucket_prefix}-${random_pet.bucket_name.id}"
+  tags   = var.tags
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+resource "aws_s3_bucket_versioning" "safehouse" {
+  bucket = aws_s3_bucket.safehouse.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "safehouse" {
+  bucket = aws_s3_bucket.safehouse.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "safehouse" {
+  bucket = aws_s3_bucket.safehouse.id
+
+  rule {
+    id     = "expire-noncurrent"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      days = 30
+    }
+  }
+}

--- a/terraform-modules/nightly-nightly-terraform-safehouse/outputs.tf
+++ b/terraform-modules/nightly-nightly-terraform-safehouse/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_id" {
+  description = "The name of the created bucket"
+  value       = aws_s3_bucket.safehouse.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the bucket"
+  value       = aws_s3_bucket.safehouse.arn
+}

--- a/terraform-modules/nightly-nightly-terraform-safehouse/tests/test_main.sh
+++ b/terraform-modules/nightly-nightly-terraform-safehouse/tests/test_main.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+# Mock rationale: this script runs Terraform commands locally without contacting AWS.
+# It uses the "-backend=false" flag to avoid remote state and dummy variables.
+
+# Initialize Terraform (no backend)
+terraform init -backend=false > /dev/null
+
+# Validate the configuration syntax
+terraform validate
+
+# Generate a plan with static variables; no actual AWS calls are made because no provider credentials are required for validation only.
+terraform plan -input=false -var="aws_region=us-east-1" -out=plan.out > /dev/null
+
+echo "All Terraform checks passed."

--- a/terraform-modules/nightly-nightly-terraform-safehouse/variables.tf
+++ b/terraform-modules/nightly-nightly-terraform-safehouse/variables.tf
@@ -1,0 +1,17 @@
+variable "bucket_prefix" {
+  description = "Prefix for the bucket name"
+  type        = string
+  default     = "safehouse"
+}
+
+variable "tags" {
+  description = "Tags to apply to the bucket"
+  type        = map(string)
+  default     = {}
+}
+
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-east-1"
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-terraform-safehouse-s3
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-terraform-safehouse`
- **Files Created**: 5
- **Description**: Terraform module that provisions a secure, versioned S3 bucket for post‑apocalyptic safe‑house data with auto‑expiration.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-terraform-safehouse`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-terraform-safehouse/README.md`
- Run tests located in `terraform-modules/nightly-nightly-terraform-safehouse/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.