### PR TITLE
feat(groq): A whimsical concurrent Go TCP server that streams random post‑apocalyptic radio quotes to each connected client.

### DIFF
--- a/go-utils/nightly-nightly-apocalypse-radio-ser/README.md
+++ b/go-utils/nightly-nightly-apocalypse-radio-ser/README.md
@@ -1,0 +1,44 @@
+# Apocalypse Radio Server
+
+**nightly‑apocalypse‑radio‑server** is a tiny Go utility that acts like a retro‑style radio broadcast from the wasteland.  When you run the server, it listens on a TCP port and, for every client that connects, streams a random post‑apocalyptic quote every few seconds.
+
+## Features
+- Concurrent handling of unlimited client connections (goroutine per client).
+- Built‑in list of whimsical quotes; easy to extend.
+- Configurable listen address and broadcast interval via command‑line flags.
+- Zero external dependencies – pure Go standard library.
+
+## Build
+```bash
+# Clone the repository (or copy the generated folder) and build
+cd nightly-apocalypse-radio-server
+go build -o radio-server ./src/main.go
+```
+
+## Run
+```bash
+# Start the server on the default address (0.0.0.0:8080) and 5‑second interval
+./radio-server
+
+# Custom address and interval (e.g., 127.0.0.1:9090, 2‑second interval)
+./radio-server -addr 127.0.0.1:9090 -interval 2s
+```
+
+## Connect
+You can connect with any TCP client (netcat, telnet, custom program):
+```bash
+nc localhost 8080
+```
+You will see a new quote printed every interval until you close the connection.
+
+## Testing
+```bash
+go test ./tests
+```
+The test suite checks the quote‑selection logic and that the server can accept a client and deliver at least one quote.
+
+## Extending
+Add or modify quotes in `src/main.go` – the `quotes` slice is public‑ish and can be edited directly.
+
+---
+*Enjoy the static‑crackle of the wasteland!*

--- a/go-utils/nightly-nightly-apocalypse-radio-ser/src/main.go
+++ b/go-utils/nightly-nightly-apocalypse-radio-ser/src/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+    "bufio"
+    "flag"
+    "fmt"
+    "log"
+    "math/rand"
+    "net"
+    "strings"
+    "time"
+)
+
+// quotes holds a collection of whimsical post‑apocalyptic messages.
+var quotes = []string{
+    "The sun rose over the rusted towers, but the coffee machine stayed dead.",
+    "Remember when Wi‑Fi was a thing? Yeah, me neither.",
+    "Radiation levels are low… for now.",
+    "The last meme died in the desert, but its echo lives on.",
+    "If you hear static, it's just the universe buffering.",
+    "Don't trust the bunker’s thermostat – it has its own agenda.",
+    "Survivors: now offering free hugs for a limited time only.",
+    "The only thing that’s certain is uncertainty.",
+    "Keep calm and ration on.",
+    "Your battery is low, but your spirit is not.",
+}
+
+// getRandomQuote returns a random quote from the quotes slice.
+func getRandomQuote() string {
+    if len(quotes) == 0 {
+        return "..."
+    }
+    idx := rand.Intn(len(quotes))
+    return quotes[idx]
+}
+
+// handleClient streams quotes to a single client until the connection closes.
+func handleClient(conn net.Conn, interval time.Duration) {
+    defer conn.Close()
+    writer := bufio.NewWriter(conn)
+    ticker := time.NewTicker(interval)
+    defer ticker.Stop()
+    for {
+        select {
+        case <-ticker.C:
+            quote := getRandomQuote()
+            // Ensure each quote ends with a newline for client readability.
+            if !strings.HasSuffix(quote, "\n") {
+                quote += "\n"
+            }
+            _, err := writer.WriteString(quote)
+            if err != nil {
+                log.Printf("client write error: %v", err)
+                return
+            }
+            err = writer.Flush()
+            if err != nil {
+                log.Printf("client flush error: %v", err)
+                return
+            }
+        }
+    }
+}
+
+func main() {
+    // Command‑line flags for address and broadcast interval.
+    addr := flag.String("addr", "0.0.0.0:8080", "TCP listen address")
+    intervalStr := flag.String("interval", "5s", "Broadcast interval (e.g., 2s, 500ms)")
+    flag.Parse()
+
+    interval, err := time.ParseDuration(*intervalStr)
+    if err != nil {
+        log.Fatalf("invalid interval: %v", err)
+    }
+
+    // Seed the random number generator.
+    rand.Seed(time.Now().UnixNano())
+
+    listener, err := net.Listen("tcp", *addr)
+    if err != nil {
+        log.Fatalf("failed to listen on %s: %v", *addr, err)
+    }
+    defer listener.Close()
+    log.Printf("Apocalypse Radio Server listening on %s (interval %s)", *addr, interval)
+
+    for {
+        conn, err := listener.Accept()
+        if err != nil {
+            log.Printf("accept error: %v", err)
+            continue
+        }
+        log.Printf("client connected from %s", conn.RemoteAddr())
+        go handleClient(conn, interval)
+    }
+}

--- a/go-utils/nightly-nightly-apocalypse-radio-ser/tests/main_test.go
+++ b/go-utils/nightly-nightly-apocalypse-radio-ser/tests/main_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+    "bufio"
+    "math/rand"
+    "net"
+    "strings"
+    "testing"
+    "time"
+)
+
+// TestGetRandomQuote ensures the function returns a quote that exists in the slice.
+func TestGetRandomQuote(t *testing.T) {
+    // Mock rationale: deterministic seed for reproducibility.
+    rand.Seed(42)
+    quote := getRandomQuote()
+    found := false
+    for _, q := range quotes {
+        if q == quote {
+            found = true
+            break
+        }
+    }
+    if !found {
+        t.Fatalf("quote not found in slice: %s", quote)
+    }
+}
+
+// TestServerClientInteraction starts the server on a random port, connects a client, and reads a single quote.
+func TestServerClientInteraction(t *testing.T) {
+    // Use a short interval to keep the test fast.
+    interval := 10 * time.Millisecond
+    // Start listener on an OS‑assigned port.
+    ln, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        t.Fatalf("failed to listen: %v", err)
+    }
+    defer ln.Close()
+
+    // Run server loop in background.
+    go func() {
+        for {
+            conn, err := ln.Accept()
+            if err != nil {
+                return // listener closed
+            }
+            go handleClient(conn, interval)
+        }
+    }()
+
+    // Connect a client.
+    conn, err := net.Dial("tcp", ln.Addr().String())
+    if err != nil {
+        t.Fatalf("dial error: %v", err)
+    }
+    defer conn.Close()
+
+    // Read the first line (quote).
+    reader := bufio.NewReader(conn)
+    line, err := reader.ReadString('\n')
+    if err != nil {
+        t.Fatalf("read error: %v", err)
+    }
+    line = strings.TrimSpace(line)
+    if line == "" {
+        t.Fatalf("received empty quote")
+    }
+    // Verify the received line is one of the known quotes.
+    found := false
+    for _, q := range quotes {
+        if strings.TrimSpace(q) == line {
+            found = true
+            break
+        }
+    }
+    if !found {
+        t.Fatalf("received unknown quote: %s", line)
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-apocalypse-radio-server
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-apocalypse-radio-ser`
- **Files Created**: 3
- **Description**: A whimsical concurrent Go TCP server that streams random post‑apocalyptic radio quotes to each connected client.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-apocalypse-radio-ser`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-apocalypse-radio-ser/README.md`
- Run tests located in `go-utils/nightly-nightly-apocalypse-radio-ser/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.