### PR TITLE
feat(groq): A tiny Rust CLI that prints the 256‑color ANSI palette or selected colors as colored blocks.

### DIFF
--- a/rust-utils/nightly-nightly-ansi-palette-swatch/Cargo.toml
+++ b/rust-utils/nightly-nightly-ansi-palette-swatch/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ansi-palette-swatch"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-ansi-palette-swatch/README.md
+++ b/rust-utils/nightly-nightly-ansi-palette-swatch/README.md
@@ -1,0 +1,10 @@
+ANSI Palette Swatch CLI
+A tiny Rust command-line tool that displays the 256‑color ANSI palette in your terminal.
+
+Usage:
+  Run without arguments to print a 16×16 grid of all colors.
+  Provide one or more numbers (0‑255) to print only those colors.
+
+Example:
+  $ ansi-palette-swatch 196 46
+  (outputs the two colored numbers)

--- a/rust-utils/nightly-nightly-ansi-palette-swatch/src/main.rs
+++ b/rust-utils/nightly-nightly-ansi-palette-swatch/src/main.rs
@@ -1,0 +1,31 @@
+use std::env;
+
+fn color_block(num: u8) -> String {
+    // Returns a string with the color number and a colored block.
+    // Using ANSI 256‑color foreground.
+    format!("\x1b[38;5;{}m{:>3}\x1b[0m", num, num)
+}
+
+fn print_grid() {
+    for row in 0..16 {
+        for col in 0..16 {
+            let num = row * 16 + col;
+            print!("{} ", color_block(num as u8));
+        }
+        println!();
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+    if args.is_empty() {
+        print_grid();
+    } else {
+        for arg in args {
+            match arg.parse::<u8>() {
+                Ok(num) => println!("{}", color_block(num)),
+                Err(_) => eprintln!("Invalid color number: {}", arg),
+            }
+        }
+    }
+}

--- a/rust-utils/nightly-nightly-ansi-palette-swatch/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-ansi-palette-swatch/tests/test_main.rs
@@ -1,0 +1,19 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_color_block_format() {
+        let s = color_block(5);
+        assert_eq!(s, "\x1b[38;5;5m  5\x1b[0m");
+    }
+
+    #[test]
+    fn test_color_block_range() {
+        // Ensure the function works for the extremes of the 0‑255 range.
+        let low = color_block(0);
+        let high = color_block(255);
+        assert_eq!(low, "\x1b[38;5;0m  0\x1b[0m");
+        assert_eq!(high, "\x1b[38;5;255m255\x1b[0m");
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansi-palette-swatch
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-ansi-palette-swatch`
- **Files Created**: 4
- **Description**: A tiny Rust CLI that prints the 256‑color ANSI palette or selected colors as colored blocks.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-ansi-palette-swatch`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-ansi-palette-swatch/README.md`
- Run tests located in `rust-utils/nightly-nightly-ansi-palette-swatch/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.