### PR TITLE
feat(groq): Generates a random ASCII map for post‑apocalypse scavenging with optional reproducible seed

### DIFF
--- a/rust-utils/nightly-nightly-scavenger-map-3/Cargo.toml
+++ b/rust-utils/nightly-nightly-scavenger-map-3/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "nightly-scavenger-map"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = "0.8"

--- a/rust-utils/nightly-nightly-scavenger-map-3/README.md
+++ b/rust-utils/nightly-nightly-scavenger-map-3/README.md
@@ -1,0 +1,43 @@
+# Nightly Scavenger Map
+
+**Utility:** `nightly-scavenger-map`
+
+Generate a whimsical, random ASCII map that can be used for post‑apocalypse scavenging games, tabletop sessions, or just for fun.
+
+## Features
+- Adjustable width and height.
+- Optional `--seed` flag for deterministic maps (great for testing or sharing the same map).
+- Simple symbols:
+  - `.` – empty ground
+  - `W` – water source
+  - `F` – food cache
+  - `M` – medical supplies
+  - `T` – tools / equipment
+
+## Installation
+```sh
+# Clone the repository (or copy the generated folder) and build with Cargo
+cargo build --release
+```
+
+## Usage
+```sh
+# Basic usage – random map each run
+cargo run --release -- <width> <height>
+
+# Example: 20 columns by 10 rows
+cargo run --release -- 20 10
+
+# Reproducible map with a seed
+cargo run --release -- 20 10 --seed 12345
+```
+
+## Testing
+```sh
+cargo test
+```
+
+The test suite checks that the map dimensions are correct and that only the allowed symbols appear.
+
+## License
+MIT – see the LICENSE file in the repository.

--- a/rust-utils/nightly-nightly-scavenger-map-3/src/lib.rs
+++ b/rust-utils/nightly-nightly-scavenger-map-3/src/lib.rs
@@ -1,0 +1,19 @@
+pub fn generate_map(width: usize, height: usize, seed: u64) -> String {
+    use rand::{Rng, SeedableRng};
+    use rand::rngs::StdRng;
+
+    let mut rng = StdRng::seed_from_u64(seed);
+    let symbols = ['.', 'W', 'F', 'M', 'T'];
+    let mut lines = Vec::with_capacity(height);
+
+    for _ in 0..height {
+        let line: String = (0..width)
+            .map(|_| {
+                let idx = rng.gen_range(0..symbols.len());
+                symbols[idx]
+            })
+            .collect();
+        lines.push(line);
+    }
+    lines.join("\n")
+}

--- a/rust-utils/nightly-nightly-scavenger-map-3/src/main.rs
+++ b/rust-utils/nightly-nightly-scavenger-map-3/src/main.rs
@@ -1,0 +1,50 @@
+use std::env;
+use nightly_scavenger_map::generate_map;
+
+fn print_usage() {
+    eprintln!("Usage: nightly-scavenger-map <width> <height> [--seed <u64>]");
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        print_usage();
+        std::process::exit(1);
+    }
+
+    let width: usize = match args[1].parse() {
+        Ok(w) => w,
+        Err(_) => {
+            eprintln!("Invalid width");
+            std::process::exit(1);
+        }
+    };
+    let height: usize = match args[2].parse() {
+        Ok(h) => h,
+        Err(_) => {
+            eprintln!("Invalid height");
+            std::process::exit(1);
+        }
+    };
+
+    // Default seed – random each run
+    let mut seed: u64 = rand::random();
+    let mut i = 3;
+    while i < args.len() {
+        if args[i] == "--seed" && i + 1 < args.len() {
+            seed = match args[i + 1].parse() {
+                Ok(s) => s,
+                Err(_) => {
+                    eprintln!("Invalid seed");
+                    std::process::exit(1);
+                }
+            };
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+
+    let map = generate_map(width, height, seed);
+    println!("{}", map);
+}

--- a/rust-utils/nightly-nightly-scavenger-map-3/tests/integration_test.rs
+++ b/rust-utils/nightly-nightly-scavenger-map-3/tests/integration_test.rs
@@ -1,0 +1,21 @@
+#[cfg(test)]
+mod tests {
+    use nightly_scavenger_map::generate_map;
+
+    #[test]
+    fn deterministic_dimensions_and_symbols() {
+        // Mock rationale: fixed seed ensures reproducible output for testing
+        let width = 7;
+        let height = 4;
+        let seed = 123456789;
+        let map = generate_map(width, height, seed);
+        let lines: Vec<&str> = map.split('\n').collect();
+        assert_eq!(lines.len(), height, "Map should have {} rows", height);
+        for line in lines {
+            assert_eq!(line.chars().count(), width, "Each row should have {} columns", width);
+            for ch in line.chars() {
+                assert!(matches!(ch, '.' | 'W' | 'F' | 'M' | 'T'), "Invalid symbol '{}' found", ch);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-scavenger-map
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-scavenger-map-3`
- **Files Created**: 5
- **Description**: Generates a random ASCII map for post‑apocalypse scavenging with optional reproducible seed

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-scavenger-map-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-scavenger-map-3/README.md`
- Run tests located in `rust-utils/nightly-nightly-scavenger-map-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.