### PR TITLE
feat(openrouter): A whimsical yet practical log aggregation tool that collects, filters, and colorizes logs from multiple sources into a unified terminal dashboard.

### DIFF
--- a/rust-utils/nightly-nightly-void-siphon-log-aggr/README.md
+++ b/rust-utils/nightly-nightly-void-siphon-log-aggr/README.md
@@ -1,0 +1,41 @@
+# nightly-void-siphon-log-aggregator
+
+A terminal-based log aggregator that siphons logs from multiple sources, filters them by severity, and displays them with ANSI colorization.
+
+## Features
+
+- Aggregate logs from multiple files or stdin
+- Filter by log level (ERROR, WARN, INFO, DEBUG)
+- Colorized terminal output
+- Whimsical void-themed styling
+
+## Usage
+
+```sh
+void-siphon [OPTIONS] [FILES]...
+```
+
+### Examples
+
+```sh
+# Read from multiple files
+void-siphon app.log error.log
+
+# Read from stdin
+cat app.log | void-siphon
+
+# Filter by log level
+void-siphon --level ERROR app.log
+```
+
+## Options
+
+- `-l, --level <LEVEL>`: Filter logs by level (ERROR, WARN, INFO, DEBUG)
+- `-h, --help`: Display help information
+
+## Installation
+
+```sh
+cargo build --release
+./target/release/void-siphon
+```

--- a/rust-utils/nightly-nightly-void-siphon-log-aggr/src/main.rs
+++ b/rust-utils/nightly-nightly-void-siphon-log-aggr/src/main.rs
@@ -1,0 +1,113 @@
+use clap::{Arg, Command};
+use colored::*;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::path::Path;
+
+#[derive(Debug, PartialEq)]
+enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+impl LogLevel {
+    fn from_str(s: &str) -> Option<LogLevel> {
+        match s.to_uppercase().as_str() {
+            "ERROR" => Some(LogLevel::Error),
+            "WARN" => Some(LogLevel::Warn),
+            "INFO" => Some(LogLevel::Info),
+            "DEBUG" => Some(LogLevel::Debug),
+            _ => None,
+        }
+    }
+
+    fn matches(&self, filter: &Option<LogLevel>) -> bool {
+        match filter {
+            None => true,
+            Some(level) => match (self, level) {
+                (LogLevel::Error, LogLevel::Error) => true,
+                (LogLevel::Warn, LogLevel::Error) => false,
+                (LogLevel::Warn, _) => true,
+                (LogLevel::Info, LogLevel::Error) | (LogLevel::Info, LogLevel::Warn) => false,
+                (LogLevel::Info, _) => true,
+                (LogLevel::Debug, LogLevel::Debug) => true,
+                _ => false,
+            },
+        }
+    }
+}
+
+fn read_logs_from_file(path: &str, filter: &Option<LogLevel>) -> io::Result<()> {
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let line = line?;
+        process_line(&line, filter);
+    }
+    Ok(())
+}
+
+fn read_logs_from_stdin(filter: &Option<LogLevel>) {
+    let stdin = io::stdin();
+    let reader = stdin.lock();
+    for line in reader.lines() {
+        let line = line.unwrap();
+        process_line(&line, filter);
+    }
+}
+
+fn process_line(line: &str, filter: &Option<LogLevel>) {
+    let level = if line.contains("ERROR") {
+        LogLevel::Error
+    } else if line.contains("WARN") {
+        LogLevel::Warn
+    } else if line.contains("INFO") {
+        LogLevel::Info
+    } else {
+        LogLevel::Debug
+    };
+
+    if level.matches(filter) {
+        let colored_line = match level {
+            LogLevel::Error => line.red(),
+            LogLevel::Warn => line.yellow(),
+            LogLevel::Info => line.blue(),
+            LogLevel::Debug => line.green(),
+        };
+        println!("{}", colored_line);
+    }
+}
+
+fn main() {
+    let matches = Command::new("Void Siphon Log Aggregator")
+        .version("1.0")
+        .author("ApocalypsAI")
+        .about("Aggregates and colorizes logs from multiple sources")
+        .arg(
+            Arg::new("level")
+                .short('l')
+                .long("level")
+                .value_name("LEVEL")
+                .help("Filter logs by level (ERROR, WARN, INFO, DEBUG)"),
+        )
+        .arg(
+            Arg::new("files")
+                .help("Log files to aggregate")
+                .multiple_values(true),
+        )
+        .get_matches();
+
+    let filter_level = matches.value_of("level").and_then(LogLevel::from_str);
+
+    if let Some(files) = matches.values_of("files") {
+        for file in files {
+            if let Err(e) = read_logs_from_file(file, &filter_level) {
+                eprintln!("Failed to read {}: {}", file, e);
+            }
+        }
+    } else {
+        read_logs_from_stdin(&filter_level);
+    }
+}

--- a/rust-utils/nightly-nightly-void-siphon-log-aggr/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-void-siphon-log-aggr/tests/test_main.rs
@@ -1,0 +1,57 @@
+// Mock rationale: We simulate log lines and verify filtering/colorization logic without real file I/O.
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log_level_parsing() {
+        assert_eq!(LogLevel::from_str("ERROR"), Some(LogLevel::Error));
+        assert_eq!(LogLevel::from_str("error"), Some(LogLevel::Error));
+        assert_eq!(LogLevel::from_str("WARN"), Some(LogLevel::Warn));
+        assert_eq!(LogLevel::from_str("info"), Some(LogLevel::Info));
+        assert_eq!(LogLevel::from_str("debug"), Some(LogLevel::Debug));
+        assert_eq!(LogLevel::from_str("unknown"), None);
+    }
+
+    #[test]
+    fn test_log_level_matching() {
+        let error = LogLevel::Error;
+        let warn = LogLevel::Warn;
+        let info = LogLevel::Info;
+        let debug = LogLevel::Debug;
+
+        // No filter should match everything
+        assert!(error.matches(&None));
+        assert!(warn.matches(&None));
+        assert!(info.matches(&None));
+        assert!(debug.matches(&None));
+
+        // Filter by ERROR
+        let filter_error = Some(LogLevel::Error);
+        assert!(error.matches(&filter_error));
+        assert!(!warn.matches(&filter_error));
+        assert!(!info.matches(&filter_error));
+        assert!(!debug.matches(&filter_error));
+
+        // Filter by WARN
+        let filter_warn = Some(LogLevel::Warn);
+        assert!(error.matches(&filter_warn));
+        assert!(warn.matches(&filter_warn));
+        assert!(!info.matches(&filter_warn));
+        assert!(!debug.matches(&filter_warn));
+
+        // Filter by INFO
+        let filter_info = Some(LogLevel::Info);
+        assert!(error.matches(&filter_info));
+        assert!(warn.matches(&filter_info));
+        assert!(info.matches(&filter_info));
+        assert!(!debug.matches(&filter_info));
+
+        // Filter by DEBUG
+        let filter_debug = Some(LogLevel::Debug);
+        assert!(error.matches(&filter_debug));
+        assert!(warn.matches(&filter_debug));
+        assert!(info.matches(&filter_debug));
+        assert!(debug.matches(&filter_debug));
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-void-siphon-log-aggregator
- **Provider**: openrouter
- **Location**: `rust-utils/nightly-nightly-void-siphon-log-aggr`
- **Files Created**: 3
- **Description**: A whimsical yet practical log aggregation tool that collects, filters, and colorizes logs from multiple sources into a unified terminal dashboard.

## Rationale
- Automated proposal from the OpenRouter generator delivering a fresh community utility.
- This utility was generated using the **openrouter** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-void-siphon-log-aggr`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-void-siphon-log-aggr/README.md`
- Run tests located in `rust-utils/nightly-nightly-void-siphon-log-aggr/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.