### PR TITLE
feat(groq): A tiny Rust CLI that prints text with a rainbow ANSI color gradient for fun and emphasis in terminals.

### DIFF
--- a/rust-utils/nightly-nightly-ansi-gradient/Cargo.toml
+++ b/rust-utils/nightly-nightly-ansi-gradient/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ansi-gradient"
+version = "0.1.0"
+edition = "2021"
+description = "Print text with a rainbow ANSI gradient"
+license = "MIT"
+
+[lib]
+name = "ansi_gradient"
+path = "src/lib.rs"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-ansi-gradient/README.md
+++ b/rust-utils/nightly-nightly-ansi-gradient/README.md
@@ -1,0 +1,25 @@
+# nightly-ansi-gradient
+
+A tiny Rust CLI that prints given text with a rainbow ANSI color gradient. Useful for spicing up terminal output, logs, or commit messages.
+
+## Installation
+
+```sh
+cargo install --path .
+```
+
+## Usage
+
+```sh
+ansi-gradient "Hello, world!"
+```
+
+The command prints the supplied text with a smooth rainbow gradient using ANSI escape codes.
+
+## How it works
+
+The program cycles through a predefined list of ANSI color codes (red, yellow, green, blue, magenta) and wraps each character in the appropriate code. The final reset code (`\x1b[0m`) restores the terminal's default colors.
+
+## License
+
+MIT

--- a/rust-utils/nightly-nightly-ansi-gradient/src/lib.rs
+++ b/rust-utils/nightly-nightly-ansi-gradient/src/lib.rs
@@ -1,0 +1,24 @@
+pub const COLORS: [&str; 7] = [
+    "\x1b[31m", // red
+    "\x1b[33m", // orange (approximated with yellow)
+    "\x1b[33m", // yellow
+    "\x1b[32m", // green
+    "\x1b[34m", // blue
+    "\x1b[35m", // indigo (magenta)
+    "\x1b[35m", // violet (magenta)
+];
+
+/// Returns the input `text` wrapped in a repeating ANSI rainbow gradient.
+///
+/// The function does **not** print anything; it only returns the colored string.
+pub fn gradient(text: &str) -> String {
+    let mut result = String::new();
+    for (i, ch) in text.chars().enumerate() {
+        let color = COLORS[i % COLORS.len()];
+        result.push_str(color);
+        result.push(ch);
+    }
+    // Reset colors at the end so subsequent terminal output is unaffected.
+    result.push_str("\x1b[0m");
+    result
+}

--- a/rust-utils/nightly-nightly-ansi-gradient/src/main.rs
+++ b/rust-utils/nightly-nightly-ansi-gradient/src/main.rs
@@ -1,0 +1,13 @@
+use std::env;
+
+use ansi_gradient::gradient;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <text>", args[0]);
+        std::process::exit(1);
+    }
+    let input = args[1..].join(" ");
+    println!("{}", gradient(&input));
+}

--- a/rust-utils/nightly-nightly-ansi-gradient/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-ansi-gradient/tests/test_main.rs
@@ -1,0 +1,22 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ansi_gradient::gradient;
+
+    #[test]
+    fn test_gradient_simple() {
+        let input = "ABC";
+        let output = gradient(input);
+        // Expected sequence: red A, orange B, yellow C, then reset.
+        let expected = format!("{}A{}B{}C\x1b[0m", "\x1b[31m", "\x1b[33m", "\x1b[33m");
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_gradient_wraps_colors() {
+        let input = "ABCDEFGH"; // 8 chars, 7 colors -> last char repeats first color
+        let output = gradient(input);
+        // The 8th character should be colored with the first color (red).
+        assert!(output.contains("\x1b[31mH"));
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansi-gradient
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-ansi-gradient`
- **Files Created**: 5
- **Description**: A tiny Rust CLI that prints text with a rainbow ANSI color gradient for fun and emphasis in terminals.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-ansi-gradient`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-ansi-gradient/README.md`
- Run tests located in `rust-utils/nightly-nightly-ansi-gradient/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.