### PR TITLE
feat(groq): Installs a daily random apocalypse-themed MOTD using Ansible and a cron job.

### DIFF
--- a/ansible-playbooks/nightly-nightly-apocalypse-quote-rot/README.md
+++ b/ansible-playbooks/nightly-nightly-apocalypse-quote-rot/README.md
@@ -1,0 +1,24 @@
+Nightly Apocalypse Quote Rotator
+
+This Ansible playbook installs a collection of apocalypse-themed quotes on the target host and configures a daily cron job that updates the system MOTD with a random quote each morning at 9:00 AM. It also updates the MOTD immediately when the playbook is run.
+
+Prerequisites
+- Ansible 2.9 or newer installed on the control machine.
+- The target host must have the `shuf` utility (part of coreutils) available.
+
+Installation
+1. Clone the repository or copy the files into a directory.
+2. Run the playbook:
+   ansible-playbook -i src/inventory.ini src/setup_quotes.yml
+
+What the playbook does
+- Copies a list of quotes to /usr/local/share/apocalypse_quotes.txt on the target.
+- Installs a cron job that runs daily at 09:00 and writes a random quote to /etc/motd.
+- Immediately selects a random quote and writes it to /etc/motd so you see a new message right away.
+
+Idempotence
+The playbook is safe to run multiple times; Ansible will only make changes when necessary.
+
+Testing
+A simple syntax‑check test is provided under the tests/ directory. Run it with:
+   ansible-playbook -i src/inventory.ini tests/test_setup_quotes.yml --check

--- a/ansible-playbooks/nightly-nightly-apocalypse-quote-rot/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-apocalypse-quote-rot/src/inventory.ini
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-apocalypse-quote-rot/src/quotes.txt
+++ b/ansible-playbooks/nightly-nightly-apocalypse-quote-rot/src/quotes.txt
@@ -1,0 +1,5 @@
+The ashes of the old world are the fertile soil of the new.
+When the sky falls, we learn to walk in the dark.
+From ruin springs resilience.
+Even the dead cities whisper of hope.
+Survival is not a chance, it's a choice.

--- a/ansible-playbooks/nightly-nightly-apocalypse-quote-rot/src/setup_quotes.yml
+++ b/ansible-playbooks/nightly-nightly-apocalypse-quote-rot/src/setup_quotes.yml
@@ -1,0 +1,30 @@
+- name: Apocalypse Quote Rotator
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Deploy quotes file
+      copy:
+        src: quotes.txt
+        dest: /usr/local/share/apocalypse_quotes.txt
+        mode: "0644"
+
+    - name: Install daily cron job to update MOTD
+      cron:
+        name: "Update MOTD with random apocalypse quote"
+        minute: "0"
+        hour: "9"
+        job: "shuf -n 1 /usr/local/share/apocalypse_quotes.txt > /etc/motd"
+        state: present
+
+    - name: Select a random quote now
+      command: shuf -n 1 /usr/local/share/apocalypse_quotes.txt
+      register: quote_output
+      changed_when: false
+
+    - name: Write the selected quote to MOTD
+      copy:
+        dest: /etc/motd
+        content: "{{ quote_output.stdout }}\n"
+        mode: "0644"

--- a/ansible-playbooks/nightly-nightly-apocalypse-quote-rot/tests/test_setup_quotes.yml
+++ b/ansible-playbooks/nightly-nightly-apocalypse-quote-rot/tests/test_setup_quotes.yml
@@ -1,0 +1,1 @@
+- import_playbook: ../src/setup_quotes.yml


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-apocalypse-quote-rotator
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-apocalypse-quote-rot`
- **Files Created**: 5
- **Description**: Installs a daily random apocalypse-themed MOTD using Ansible and a cron job.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-apocalypse-quote-rot`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-apocalypse-quote-rot/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-apocalypse-quote-rot/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.