### PR TITLE
feat(groq): A whimsical Rust CLI that solves the post‑apocalypse scavenger knapsack problem, picking the most valuable items within a weight limit.

### DIFF
--- a/rust-utils/nightly-nightly-scavenger-knapsack-5/Cargo.toml
+++ b/rust-utils/nightly-nightly-scavenger-knapsack-5/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "scavenger_knapsack"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+assert_json_diff = "2.0"

--- a/rust-utils/nightly-nightly-scavenger-knapsack-5/README.md
+++ b/rust-utils/nightly-nightly-scavenger-knapsack-5/README.md
@@ -1,0 +1,74 @@
+# nightly‑scavenger‑knapsack
+
+**What it does**
+
+In a world of limited resources, you have a backpack that can only carry a certain weight. You also have a list of scavenged items, each with a *weight* and a *value* (how useful it is for survival). This utility computes the optimal subset of items that maximizes total value without exceeding the backpack’s capacity – the classic 0/1 knapsack problem, but with a post‑apocalyptic flavor.
+
+**Features**
+
+- Reads a JSON file describing the capacity and the available items.
+- Outputs a JSON array with the names of the selected items.
+- Pure Rust, no external binaries required.
+- Deterministic, offline unit tests.
+
+**Installation**
+
+```bash
+# Clone the repository (or copy the generated folder into your project)
+git clone https://github.com/polsala/ApocalypsAI.git
+cd utils/nightly-scavenger-knapsack
+# Build the binary
+cargo build --release
+```
+
+**Usage**
+
+```bash
+# Prepare an input file (example: input.json)
+cat > input.json <<EOF
+{
+  "capacity": 10,
+  "items": [
+    {"name": "canned beans", "weight": 3, "value": 5},
+    {"name": "bottled water", "weight": 2, "value": 4},
+    {"name": "first‑aid kit", "weight": 5, "value": 7},
+    {"name": "flashlight", "weight": 1, "value": 2}
+  ]
+}
+EOF
+
+# Run the optimizer
+./target/release/scavenger_knapsack input.json
+
+# Expected output (JSON array of selected item names)
+["canned beans","bottled water","flashlight"]
+```
+
+**Input format**
+
+```json
+{
+  "capacity": <integer>,
+  "items": [
+    {"name": "string", "weight": <integer>, "value": <integer>},
+    ...
+  ]
+}
+```
+
+- `capacity` – maximum total weight the backpack can hold.
+- `items` – list of available scavenged items.
+
+**Output format**
+
+A JSON array containing the `name` of each selected item, in the order they appear in the optimal solution.
+
+**Testing**
+
+Run the built‑in test suite with:
+
+```bash
+cargo test
+```
+
+The tests are deterministic and do not require network access.

--- a/rust-utils/nightly-nightly-scavenger-knapsack-5/src/lib.rs
+++ b/rust-utils/nightly-nightly-scavenger-knapsack-5/src/lib.rs
@@ -1,0 +1,89 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub struct Item {
+    pub name: String,
+    pub weight: usize,
+    pub value: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Input {
+    pub capacity: usize,
+    pub items: Vec<Item>,
+}
+
+/// Returns a vector of item names that constitute the optimal (maximum value) selection
+/// without exceeding the given capacity.
+pub fn solve_knapsack(input: &Input) -> Vec<String> {
+    let n = input.items.len();
+    let cap = input.capacity;
+    // DP table: dp[i][w] = max value using first i items with weight limit w
+    let mut dp = vec![vec![0usize; cap + 1]; n + 1];
+    for i in 0..n {
+        let item = &input.items[i];
+        for w in 0..=cap {
+            if item.weight > w {
+                dp[i + 1][w] = dp[i][w];
+            } else {
+                let without = dp[i][w];
+                let with = dp[i][w - item.weight] + item.value;
+                dp[i + 1][w] = if with > without { with } else { without };
+            }
+        }
+    }
+    // Reconstruct selected items
+    let mut selected = Vec::new();
+    let mut w = cap;
+    for i in (0..n).rev() {
+        if dp[i + 1][w] != dp[i][w] {
+            let item = &input.items[i];
+            selected.push(item.name.clone());
+            w -= item.weight;
+        }
+        if w == 0 { break; }
+    }
+    selected.reverse();
+    selected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_json_diff::assert_json_eq;
+    use serde_json::json;
+
+    #[test]
+    fn test_basic_scenario() {
+        let input = Input {
+            capacity: 10,
+            items: vec![
+                Item { name: "canned beans".into(), weight: 3, value: 5 },
+                Item { name: "bottled water".into(), weight: 2, value: 4 },
+                Item { name: "first‑aid kit".into(), weight: 5, value: 7 },
+                Item { name: "flashlight".into(), weight: 1, value: 2 },
+            ],
+        };
+        let result = solve_knapsack(&input);
+        // Expected optimal set: beans, water, flashlight (total weight 6, value 11)
+        let expected = vec!["canned beans", "bottled water", "flashlight"];
+        assert_eq!(result, expected);
+        // Also verify JSON serialization matches expectation
+        let json_res = serde_json::to_value(&result).unwrap();
+        let json_exp = json!(expected);
+        assert_json_eq!(json_res, json_exp);
+    }
+
+    #[test]
+    fn test_no_items_fit() {
+        let input = Input {
+            capacity: 1,
+            items: vec![
+                Item { name: "heavy armor".into(), weight: 5, value: 10 },
+            ],
+        };
+        let result = solve_knapsack(&input);
+        let expected: Vec<String> = vec![];
+        assert_eq!(result, expected);
+    }
+}

--- a/rust-utils/nightly-nightly-scavenger-knapsack-5/src/main.rs
+++ b/rust-utils/nightly-nightly-scavenger-knapsack-5/src/main.rs
@@ -1,0 +1,26 @@
+use std::env;
+use std::fs;
+use std::process;
+
+mod lib;
+use lib::{solve_knapsack, Input};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: {} <input-json-file>", args[0]);
+        process::exit(1);
+    }
+    let input_path = &args[1];
+    let data = fs::read_to_string(input_path).unwrap_or_else(|err| {
+        eprintln!("Failed to read {}: {}", input_path, err);
+        process::exit(1);
+    });
+    let input: Input = serde_json::from_str(&data).unwrap_or_else(|err| {
+        eprintln!("Invalid JSON in {}: {}", input_path, err);
+        process::exit(1);
+    });
+    let selected = solve_knapsack(&input);
+    let output = serde_json::to_string(&selected).expect("Serialization failed");
+    println!("{}", output);
+}

--- a/rust-utils/nightly-nightly-scavenger-knapsack-5/tests/knapsack_test.rs
+++ b/rust-utils/nightly-nightly-scavenger-knapsack-5/tests/knapsack_test.rs
@@ -1,0 +1,35 @@
+use std::process::Command;
+use std::fs::{self, File};
+use std::io::Write;
+
+#[test]
+fn cli_returns_optimal_selection() {
+    // Mock input JSON (offline, deterministic)
+    let input_json = r#"{
+        "capacity": 8,
+        "items": [
+            {"name": "radio", "weight": 3, "value": 6},
+            {"name": "map", "weight": 2, "value": 4},
+            {"name": "knife", "weight": 1, "value": 2},
+            {"name": "tent", "weight": 5, "value": 7}
+        ]
+    }"#;
+    // Write to a temporary file
+    let tmp_dir = tempfile::tempdir().expect("tempdir failed");
+    let input_path = tmp_dir.path().join("input.json");
+    let mut file = File::create(&input_path).expect("create file");
+    file.write_all(input_json.as_bytes()).expect("write");
+
+    // Execute the compiled binary (assumes cargo build has been run)
+    let output = Command::new("./target/debug/scavenger_knapsack")
+        .arg(&input_path)
+        .output()
+        .expect("failed to execute binary");
+    assert!(output.status.success(), "binary exited with error");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Expected optimal set: radio + knife (weight 4, value 8) or map + tent (weight 7, value 11) – the latter is better.
+    let expected = "[\"map\",\"tent\"]"; // order follows DP reconstruction (map then tent)
+    assert_eq!(stdout.trim(), expected);
+    // Clean up
+    drop(tmp_dir);
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-scavenger-knapsack
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-scavenger-knapsack-5`
- **Files Created**: 5
- **Description**: A whimsical Rust CLI that solves the post‑apocalypse scavenger knapsack problem, picking the most valuable items within a weight limit.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-scavenger-knapsack-5`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-scavenger-knapsack-5/README.md`
- Run tests located in `rust-utils/nightly-nightly-scavenger-knapsack-5/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.