### PR TITLE
feat(groq): Deterministic post‑apocalyptic nickname generator CLI written in Rust

### DIFF
--- a/rust-utils/nightly-nightly-wasteland-nickname-g/Cargo.toml
+++ b/rust-utils/nightly-nightly-wasteland-nickname-g/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "wasteland-nickname"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-wasteland-nickname-g/README.md
+++ b/rust-utils/nightly-nightly-wasteland-nickname-g/README.md
@@ -1,0 +1,29 @@
+# Nightly Wasteland Nickname Generator
+
+A tiny Rust CLI that turns any name into a post‑apocalyptic nickname.
+
+## Usage
+
+```sh
+cargo run -- <name>
+# or pipe a name via stdin
+echo "Bob" | cargo run
+```
+
+Example:
+
+```
+$ cargo run -- Alice
+Ashen Alice the Keeper
+```
+
+## How it works
+
+The program computes a simple checksum of the input string, then selects an adjective and a title from predefined lists. The result is deterministic – the same input always yields the same nickname.
+
+## Build & Test
+
+```sh
+cargo build --release
+cargo test
+```

--- a/rust-utils/nightly-nightly-wasteland-nickname-g/src/lib.rs
+++ b/rust-utils/nightly-nightly-wasteland-nickname-g/src/lib.rs
@@ -1,0 +1,18 @@
+pub fn checksum(name: &str) -> u64 {
+    name.bytes().map(|b| b as u64).sum()
+}
+
+pub fn generate_nickname(name: &str) -> String {
+    const ADJECTIVES: [&str; 10] = [
+        "Dusty", "Radiant", "Grim", "Wasteland", "Rusty",
+        "Silent", "Blazing", "Cinder", "Ashen", "Gritty",
+    ];
+    const TITLES: [&str; 7] = [
+        "the Scavenger", "the Wanderer", "the Survivor", "the Nomad",
+        "the Raider", "the Keeper", "the Whisperer",
+    ];
+    let sum = checksum(name);
+    let adj = ADJECTIVES[(sum as usize) % ADJECTIVES.len()];
+    let title = TITLES[((sum / ADJECTIVES.len() as u64) as usize) % TITLES.len()];
+    format!("{} {} {}", adj, name, title)
+}

--- a/rust-utils/nightly-nightly-wasteland-nickname-g/src/main.rs
+++ b/rust-utils/nightly-nightly-wasteland-nickname-g/src/main.rs
@@ -1,0 +1,22 @@
+use std::io::{self, Read};
+use wasteland_nickname::generate_nickname;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let name = if args.len() > 1 {
+        args[1].clone()
+    } else {
+        // Read from stdin if no argument supplied
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer).expect("Failed to read stdin");
+        buffer.trim().to_string()
+    };
+
+    if name.is_empty() {
+        eprintln!("Please provide a name via argument or stdin");
+        std::process::exit(1);
+    }
+
+    let nickname = generate_nickname(&name);
+    println!("{}", nickname);
+}

--- a/rust-utils/nightly-nightly-wasteland-nickname-g/tests/test_nickname.rs
+++ b/rust-utils/nightly-nightly-wasteland-nickname-g/tests/test_nickname.rs
@@ -1,0 +1,10 @@
+use wasteland_nickname::generate_nickname;
+
+#[test]
+fn test_generate_nickname_alice() {
+    // Checksum for "Alice" = 65 + 108 + 105 + 99 + 101 = 478
+    // 478 % 10 = 8 -> "Ashen"
+    // (478 / 10) = 47; 47 % 7 = 5 -> "the Keeper"
+    let result = generate_nickname("Alice");
+    assert_eq!(result, "Ashen Alice the Keeper");
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-wasteland-nickname-generator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-wasteland-nickname-g`
- **Files Created**: 5
- **Description**: Deterministic post‑apocalyptic nickname generator CLI written in Rust

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-wasteland-nickname-g`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-wasteland-nickname-g/README.md`
- Run tests located in `rust-utils/nightly-nightly-wasteland-nickname-g/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.