### PR TITLE
feat(groq): Convert Gregorian dates to a whimsical post‑apocalypse Wasteland Calendar via CLI or API.

### DIFF
--- a/typescript-utils/nightly-nightly-wasteland-calendar-3/README.md
+++ b/typescript-utils/nightly-nightly-wasteland-calendar-3/README.md
@@ -1,0 +1,29 @@
+# nightly-wasteland-calendar
+
+Convert Gregorian dates to the post‑apocalypse Wasteland Calendar.
+
+## Usage
+
+```sh
+npx nightly-wasteland-calendar 2025-04-01
+# => Wasteland Year 2, Month 4, Day 1
+```
+
+## API
+
+```ts
+import { toWasteland } from "./src/index";
+
+const wasteland = toWasteland("2025-04-01");
+// "Year 2, Month 4, Day 1"
+```
+
+## Installation
+
+```sh
+npm install -g nightly-wasteland-calendar
+```
+
+## License
+
+MIT

--- a/typescript-utils/nightly-nightly-wasteland-calendar-3/package.json
+++ b/typescript-utils/nightly-nightly-wasteland-calendar-3/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "nightly-wasteland-calendar",
+  "version": "0.1.0",
+  "description": "Convert Gregorian dates to a whimsical post‑apocalypse calendar",
+  "main": "dist/index.js",
+  "bin": {
+    "nightly-wasteland-calendar": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && node ./dist/tests/index.test.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/typescript-utils/nightly-nightly-wasteland-calendar-3/src/index.ts
+++ b/typescript-utils/nightly-nightly-wasteland-calendar-3/src/index.ts
@@ -1,0 +1,28 @@
+export function toWasteland(gregorianDate: string): string {
+  // Expect YYYY-MM-DD
+  const [yearStr, monthStr, dayStr] = gregorianDate.split("-");
+  const year = parseInt(yearStr, 10);
+  const month = parseInt(monthStr, 10);
+  const day = parseInt(dayStr, 10);
+  if (isNaN(year) || isNaN(month) || isNaN(day)) {
+    throw new Error("Invalid date format. Expected YYYY-MM-DD");
+  }
+  const wastelandYear = year - 2023; // apocalypse year 2023
+  return `Year ${wastelandYear}, Month ${month}, Day ${day}`;
+}
+
+// CLI entry point
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.length !== 1) {
+    console.error("Usage: nightly-wasteland-calendar <YYYY-MM-DD>");
+    process.exit(1);
+  }
+  try {
+    const result = toWasteland(args[0]);
+    console.log(`Wasteland ${result}`);
+  } catch (e: any) {
+    console.error(e.message);
+    process.exit(1);
+  }
+}

--- a/typescript-utils/nightly-nightly-wasteland-calendar-3/tests/index.test.ts
+++ b/typescript-utils/nightly-nightly-wasteland-calendar-3/tests/index.test.ts
@@ -1,0 +1,23 @@
+import { toWasteland } from "../src/index";
+import assert from "assert";
+
+function runTests() {
+  // Test known conversions
+  assert.strictEqual(toWasteland("2023-01-01"), "Year 0, Month 1, Day 1");
+  assert.strictEqual(toWasteland("2025-04-01"), "Year 2, Month 4, Day 1");
+  assert.strictEqual(toWasteland("2020-12-31"), "Year -3, Month 12, Day 31");
+
+  // Test invalid format handling
+  let threw = false;
+  try {
+    toWasteland("invalid-date");
+  } catch (e: any) {
+    threw = true;
+    assert.strictEqual(e.message, "Invalid date format. Expected YYYY-MM-DD");
+  }
+  assert.strictEqual(threw, true);
+
+  console.log("All tests passed");
+}
+
+runTests();

--- a/typescript-utils/nightly-nightly-wasteland-calendar-3/tsconfig.json
+++ b/typescript-utils/nightly-nightly-wasteland-calendar-3/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-wasteland-calendar
- **Provider**: groq
- **Location**: `typescript-utils/nightly-nightly-wasteland-calendar-3`
- **Files Created**: 5
- **Description**: Convert Gregorian dates to a whimsical post‑apocalypse Wasteland Calendar via CLI or API.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `typescript-utils/nightly-nightly-wasteland-calendar-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `typescript-utils/nightly-nightly-wasteland-calendar-3/README.md`
- Run tests located in `typescript-utils/nightly-nightly-wasteland-calendar-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.