### PR TITLE
feat(groq): Estimates remaining laptop battery life and delivers apocalypse‑themed warnings.

### DIFF
--- a/rust-utils/nightly-nightly-battery-forecast/Cargo.toml
+++ b/rust-utils/nightly-nightly-battery-forecast/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "battery-forecast"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-battery-forecast/README.md
+++ b/rust-utils/nightly-nightly-battery-forecast/README.md
@@ -1,0 +1,29 @@
+# nightly-battery-forecast
+
+Estimates remaining battery life and gives apocalypse‑themed warnings.
+
+## Usage
+
+```sh
+battery-forecast <current_percent> <consumption_rate_mAh_per_hour> <battery_capacity_mAh>
+```
+
+Example:
+
+```sh
+battery-forecast 45 1500 6000
+```
+
+The tool will print the estimated hours left and a whimsical warning.
+
+## Build
+
+```sh
+cargo build --release
+```
+
+## Test
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-battery-forecast/src/lib.rs
+++ b/rust-utils/nightly-nightly-battery-forecast/src/lib.rs
@@ -1,0 +1,17 @@
+pub fn estimate_hours(capacity_mah: f64, percent: f64, consumption_rate_mah_per_h: f64) -> f64 {
+    if consumption_rate_mah_per_h == 0.0 {
+        return f64::INFINITY;
+    }
+    let remaining = capacity_mah * (percent / 100.0);
+    remaining / consumption_rate_mah_per_h
+}
+
+pub fn warning_message(hours: f64) -> &'static str {
+    if hours > 5.0 {
+        "You have enough juice to outrun the raiders."
+    } else if hours > 2.0 {
+        "Battery low, seek shelter soon."
+    } else {
+        "Critical! Power will die before sunrise."
+    }
+}

--- a/rust-utils/nightly-nightly-battery-forecast/src/main.rs
+++ b/rust-utils/nightly-nightly-battery-forecast/src/main.rs
@@ -1,0 +1,34 @@
+use std::env;
+use battery_forecast::{estimate_hours, warning_message};
+
+fn print_usage() {
+    eprintln!("Usage: battery-forecast <current_percent> <consumption_rate_mAh_per_hour> <battery_capacity_mAh>");
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 4 {
+        print_usage();
+        std::process::exit(1);
+    }
+    let percent: f64 = args[1].parse().unwrap_or_else(|_| {
+        eprintln!("Invalid percent");
+        std::process::exit(1);
+    });
+    let rate: f64 = args[2].parse().unwrap_or_else(|_| {
+        eprintln!("Invalid consumption rate");
+        std::process::exit(1);
+    });
+    let capacity: f64 = args[3].parse().unwrap_or_else(|_| {
+        eprintln!("Invalid capacity");
+        std::process::exit(1);
+    });
+
+    let hours = estimate_hours(capacity, percent, rate);
+    if hours.is_infinite() {
+        println!("Infinite runtime (no consumption).");
+    } else {
+        println!("Estimated remaining time: {:.2} hours", hours);
+        println!("{}", warning_message(hours));
+    }
+}

--- a/rust-utils/nightly-nightly-battery-forecast/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-battery-forecast/tests/test_main.rs
@@ -1,0 +1,26 @@
+use battery_forecast::estimate_hours;
+use battery_forecast::warning_message;
+
+#[test]
+fn test_estimate_hours_normal() {
+    let hours = estimate_hours(6000.0, 50.0, 1500.0);
+    assert!((hours - 2.0).abs() < 1e-6);
+}
+
+#[test]
+fn test_warning_high() {
+    let msg = warning_message(6.0);
+    assert_eq!(msg, "You have enough juice to outrun the raiders.");
+}
+
+#[test]
+fn test_warning_medium() {
+    let msg = warning_message(3.0);
+    assert_eq!(msg, "Battery low, seek shelter soon.");
+}
+
+#[test]
+fn test_warning_low() {
+    let msg = warning_message(1.5);
+    assert_eq!(msg, "Critical! Power will die before sunrise.");
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-battery-forecast
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-battery-forecast`
- **Files Created**: 5
- **Description**: Estimates remaining laptop battery life and delivers apocalypse‑themed warnings.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-battery-forecast`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-battery-forecast/README.md`
- Run tests located in `rust-utils/nightly-nightly-battery-forecast/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.