### PR TITLE
feat(groq): Terraform module that provisions a versioned S3 bucket with lifecycle rules for a post‑apocalyptic safe‑house.

### DIFF
--- a/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
@@ -1,0 +1,36 @@
+# Nightly Safehouse S3 Terraform Module
+
+Provision a durable, version‑enabled S3 bucket with lifecycle rules, perfect for storing critical post‑apocalyptic data.
+
+## Usage
+
+```hcl
+module "safehouse" {
+  source      = "github.com/yourorg/polsala/terraform-modules/nightly-safehouse-s3"
+  bucket_name = "my-safehouse-bucket"
+}
+```
+
+## Features
+
+- Optional random bucket name generation
+- Versioning enabled
+- Lifecycle rule to expire non‑current versions after 365 days
+- Tags for identification
+
+## Inputs
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| bucket_name | Name of the S3 bucket (if omitted a random name is generated) | string | null |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| bucket_id | The ID of the created bucket |
+| bucket_arn | The ARN of the created bucket |
+
+## Testing
+
+Run `./tests/test.sh` to validate the module locally.

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/main.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/main.tf
@@ -1,0 +1,60 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  # Configuration is expected to be provided via environment variables
+  # e.g., AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION
+}
+
+resource "random_pet" "bucket_suffix" {
+  length    = 2
+  separator = "-"
+  keepers = {
+    bucket_name = var.bucket_name
+  }
+}
+
+locals {
+  final_bucket_name = var.bucket_name != null ? var.bucket_name : "safehouse-${random_pet.bucket_suffix.id}"
+}
+
+resource "aws_s3_bucket" "safehouse" {
+  bucket = local.final_bucket_name
+
+  tags = {
+    Name        = "Safehouse Bucket"
+    Environment = "post-apocalyptic"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "safehouse_versioning" {
+  bucket = aws_s3_bucket.safehouse.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "safehouse_lifecycle" {
+  bucket = aws_s3_bucket.safehouse.id
+
+  rule {
+    id     = "expire-noncurrent"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      days = 365
+    }
+  }
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/outputs.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_id" {
+  description = "The ID of the created bucket"
+  value       = aws_s3_bucket.safehouse.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the created bucket"
+  value       = aws_s3_bucket.safehouse.arn
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/tests/test.sh
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/tests/test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Initialize the module in a temporary directory
+WORKDIR=$(mktemp -d)
+cp -R "$(dirname "$0")/.." "$WORKDIR/module"
+cd "$WORKDIR/module"
+
+# Mock rationale: Use local backend to avoid remote state and external calls.
+terraform init -backend=false > /dev/null
+
+# Validate syntax
+terraform validate
+
+# Generate a plan without applying
+terraform plan -input=false -out=plan.out > /dev/null
+
+# Ensure the plan contains the S3 bucket resource
+if ! grep -q 'aws_s3_bucket.safehouse' plan.out; then
+  echo "Test failed: S3 bucket resource not found in plan"
+  exit 1
+fi
+
+echo "All tests passed."

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/variables.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/variables.tf
@@ -1,0 +1,5 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket (if omitted a random name is generated)"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-safehouse-s3
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-safehouse-s3-8`
- **Files Created**: 5
- **Description**: Terraform module that provisions a versioned S3 bucket with lifecycle rules for a post‑apocalyptic safe‑house.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-safehouse-s3-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-safehouse-s3-8/README.md`
- Run tests located in `terraform-modules/nightly-nightly-safehouse-s3-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.