### PR TITLE
feat(gemini): A Terraform module to define and enforce consistent naming and tagging conventions for logical groups of cloud resources, treating them as celestial constellations.

### DIFF
--- a/terraform-modules/nightly-nightly-cloud-constellation/README.md
+++ b/terraform-modules/nightly-nightly-cloud-constellation/README.md
@@ -1,0 +1,68 @@
+# Nightly Cloud Constellation Mapper
+
+Chart your cloud cosmos with the Nightly Cloud Constellation Mapper! This Terraform module helps you define logical groupings of your cloud resources, treating them as celestial constellations. It enforces consistent naming prefixes and tagging conventions, making it easier to manage, identify, and observe your infrastructure.
+
+## Features
+
+*   **Constellation Definition**: Define a unique "constellation" name and an environment.
+*   **Consistent Naming**: Generates a standardized prefix for resources belonging to the constellation.
+*   **Automated Tagging**: Provides a set of essential tags to apply to all resources within the constellation, including the constellation name, environment, and a `ManagedBy` tag.
+*   **Whimsical yet Practical**: Brings a touch of cosmic order to your cloud chaos.
+
+## Usage
+
+To use this module, include it in your Terraform configuration and pass the required variables.
+
+```terraform
+module "my_constellation" {
+  source = "./path/to/nightly-cloud-constellation-mapper/src" # Or a Git/registry source
+  
+  constellation_name = "Andromeda"
+  environment        = "dev"
+  additional_tags    = {
+    "Owner" = "ApocalypsAI"
+  }
+}
+
+resource "aws_s3_bucket" "constellation_bucket" {
+  bucket = "${module.my_constellation.prefix}-data-store"
+  tags   = module.my_constellation.tags
+  # ... other bucket configurations
+}
+
+output "constellation_prefix" {
+  value = module.my_constellation.prefix
+}
+
+output "constellation_tags" {
+  value = module.my_constellation.tags
+}
+```
+
+## Inputs
+
+| Name                 | Description                                                               | Type        | Default     | Required |
+| :------------------- | :------------------------------------------------------------------------ | :---------- | :---------- | :------- |
+| `constellation_name` | The whimsical name for your cloud constellation (e.g., "Orion", "Pegasus"). | `string`    | `""`        | yes      |
+| `environment`        | The environment this constellation belongs to (e.g., "dev", "prod", "staging"). | `string`    | `""`        | yes      |
+| `additional_tags`    | A map of additional tags to merge with the default constellation tags.    | `map(string)` | `{}`        | no       |
+
+## Outputs
+
+| Name                 | Description                                                               |
+| :------------------- | :------------------------------------------------------------------------ |
+| `prefix`             | A standardized naming prefix for resources in this constellation (e.g., `andromeda-dev`). |
+| `tags`               | A map of tags to apply to all resources within this constellation. Includes `Constellation`, `Environment`, `ManagedBy`, and any `additional_tags`. |
+
+## Development & Testing
+
+The module includes a `tests/` directory with an example configuration and a `test.sh` script to validate its outputs deterministically and offline.
+
+To run tests:
+
+```bash
+cd tests
+./test.sh
+```
+
+**Prerequisites for testing**: `terraform` and `jq` must be installed and available in your PATH.

--- a/terraform-modules/nightly-nightly-cloud-constellation/src/main.tf
+++ b/terraform-modules/nightly-nightly-cloud-constellation/src/main.tf
@@ -1,0 +1,18 @@
+locals {
+  # Sanitize names for use in prefixes (lowercase, replace spaces/special chars with hyphens)
+  sanitized_constellation_name = lower(replace(var.constellation_name, "/[^a-zA-Z0-9]+/", "-"))
+  sanitized_environment        = lower(replace(var.environment, "/[^a-zA-Z0-9]+/", "-"))
+  
+  # Generate a consistent prefix
+  generated_prefix = "${local.sanitized_constellation_name}-${local.sanitized_environment}"
+
+  # Define base tags
+  base_tags = {
+    "Constellation" = var.constellation_name
+    "Environment"   = var.environment
+    "ManagedBy"     = "ApocalypsAI-ConstellationMapper"
+  }
+
+  # Merge base tags with additional tags
+  merged_tags = merge(local.base_tags, var.additional_tags)
+}

--- a/terraform-modules/nightly-nightly-cloud-constellation/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-cloud-constellation/src/outputs.tf
@@ -1,0 +1,9 @@
+output "prefix" {
+  description = "A standardized naming prefix for resources in this constellation."
+  value       = local.generated_prefix
+}
+
+output "tags" {
+  description = "A map of tags to apply to all resources within this constellation."
+  value       = local.merged_tags
+}

--- a/terraform-modules/nightly-nightly-cloud-constellation/src/variables.tf
+++ b/terraform-modules/nightly-nightly-cloud-constellation/src/variables.tf
@@ -1,0 +1,15 @@
+variable "constellation_name" {
+  description = "The whimsical name for your cloud constellation (e.g., \"Orion\", \"Pegasus\")."
+  type        = string
+}
+
+variable "environment" {
+  description = "The environment this constellation belongs to (e.g., \"dev\", \"prod\", \"staging\")."
+  type        = string
+}
+
+variable "additional_tags" {
+  description = "A map of additional tags to merge with the default constellation tags."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform-modules/nightly-nightly-cloud-constellation/tests/main.tf
+++ b/terraform-modules/nightly-nightly-cloud-constellation/tests/main.tf
@@ -1,0 +1,14 @@
+# Mock rationale: This test configuration uses the module locally and relies on
+# Terraform's plan output to verify logic, without provisioning actual cloud resources.
+# The 'null_resource' is a common pattern to ensure a provider is initialized if
+# the module itself doesn't directly use one, but for this module, it's not strictly
+# necessary as it only processes inputs and generates outputs.
+# We'll rely on the 'test.sh' script to assert outputs from 'terraform plan -json'.
+
+module "test_constellation" {
+  source = "../src" # Path to the module under test
+  
+  constellation_name = var.test_constellation_name
+  environment        = var.test_environment
+  additional_tags    = var.test_additional_tags
+}

--- a/terraform-modules/nightly-nightly-cloud-constellation/tests/outputs.tf
+++ b/terraform-modules/nightly-nightly-cloud-constellation/tests/outputs.tf
@@ -1,0 +1,7 @@
+output "test_prefix" {
+  value = module.test_constellation.prefix
+}
+
+output "test_tags" {
+  value = module.test_constellation.tags
+}

--- a/terraform-modules/nightly-nightly-cloud-constellation/tests/test.sh
+++ b/terraform-modules/nightly-nightly-cloud-constellation/tests/test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "--- Running Terraform module tests ---"
+
+# Define test variables
+TEST_CONSTELLATION_NAME="Ursa Major"
+TEST_ENVIRONMENT="staging"
+TEST_ADDITIONAL_TAGS='{"Project":"Stargazer","CostCenter":"Alpha"}'
+
+# Initialize Terraform in the test directory
+echo "Initializing Terraform..."
+terraform -chdir=./ init -backend=false > /dev/null
+
+# Plan and capture output as JSON
+echo "Planning Terraform configuration..."
+PLAN_OUTPUT=$(terraform -chdir=./ plan -var="test_constellation_name=${TEST_CONSTELLATION_NAME}" \
+                                      -var="test_environment=${TEST_ENVIRONMENT}" \
+                                      -var="test_additional_tags=${TEST_ADDITIONAL_TAGS}" \
+                                      -json -out=tfplan.json)
+
+# Show the plan in JSON format to extract outputs
+echo "Showing Terraform plan JSON..."
+SHOW_OUTPUT=$(terraform -chdir=./ show -json tfplan.json)
+
+# Extract planned outputs using jq
+PLANNED_PREFIX=$(echo "${SHOW_OUTPUT}" | jq -r '.planned_values.outputs.test_prefix.value')
+PLANNED_TAGS=$(echo "${SHOW_OUTPUT}" | jq -r '.planned_values.outputs.test_tags.value')
+
+echo "Planned Prefix: ${PLANNED_PREFIX}"
+echo "Planned Tags: ${PLANNED_TAGS}"
+
+# Assertions
+echo "--- Running Assertions ---"
+
+# Assert prefix
+EXPECTED_PREFIX="ursa-major-staging"
+if [[ "${PLANNED_PREFIX}" == "${EXPECTED_PREFIX}" ]]; then
+  echo "✅ Prefix assertion passed: '${PLANNED_PREFIX}' matches '${EXPECTED_PREFIX}'"
+else
+  echo "❌ Prefix assertion failed: Expected '${EXPECTED_PREFIX}', got '${PLANNED_PREFIX}'"
+  exit 1
+fi
+
+# Assert tags (this is more complex due to JSON string comparison, let's check key-values)
+# Expected tags: Constellation, Environment, ManagedBy, Project, CostCenter
+if echo "${PLANNED_TAGS}" | jq -e '.Constellation == "Ursa Major"' > /dev/null; then
+  echo "✅ Tag 'Constellation' assertion passed."
+else
+  echo "❌ Tag 'Constellation' assertion failed."
+  exit 1
+fi
+
+if echo "${PLANNED_TAGS}" | jq -e '.Environment == "staging"' > /dev/null; then
+  echo "✅ Tag 'Environment' assertion passed."
+else
+  echo "❌ Tag 'Environment' assertion failed."
+  exit 1
+fi
+
+if echo "${PLANNED_TAGS}" | jq -e '.ManagedBy == "ApocalypsAI-ConstellationMapper"' > /dev/null; then
+  echo "✅ Tag 'ManagedBy' assertion passed."
+else
+  echo "❌ Tag 'ManagedBy' assertion failed."
+  exit 1
+fi
+
+if echo "${PLANNED_TAGS}" | jq -e '.Project == "Stargazer"' > /dev/null; then
+  echo "✅ Tag 'Project' assertion passed."
+else
+  echo "❌ Tag 'Project' assertion failed."
+  exit 1
+fi
+
+if echo "${PLANNED_TAGS}" | jq -e '.CostCenter == "Alpha"' > /dev/null; then
+  echo "✅ Tag 'CostCenter' assertion passed."
+else
+  echo "❌ Tag 'CostCenter' assertion failed."
+  exit 1
+fi
+
+echo "--- All tests passed! ---"
+rm -f tfplan.json .terraform.lock.hcl
+rm -rf .terraform

--- a/terraform-modules/nightly-nightly-cloud-constellation/tests/variables.tf
+++ b/terraform-modules/nightly-nightly-cloud-constellation/tests/variables.tf
@@ -1,0 +1,15 @@
+variable "test_constellation_name" {
+  description = "Constellation name for testing."
+  type        = string
+}
+
+variable "test_environment" {
+  description = "Environment for testing."
+  type        = string
+}
+
+variable "test_additional_tags" {
+  description = "Additional tags for testing."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-cloud-constellation-mapper
- **Provider**: gemini
- **Location**: `terraform-modules/nightly-nightly-cloud-constellation`
- **Files Created**: 8
- **Description**: A Terraform module to define and enforce consistent naming and tagging conventions for logical groups of cloud resources, treating them as celestial constellations.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-cloud-constellation`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-cloud-constellation/README.md`
- Run tests located in `terraform-modules/nightly-nightly-cloud-constellation/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.