### PR TITLE
feat(groq): An Ansible playbook that sets a daily random post-apocalyptic quote as the system MOTD.

### DIFF
--- a/ansible-playbooks/nightly-nightly-apocalypse-motd/ansible-playbooks/nightly-apocalypse-motd/README.md
+++ b/ansible-playbooks/nightly-nightly-apocalypse-motd/ansible-playbooks/nightly-apocalypse-motd/README.md
@@ -1,0 +1,25 @@
+# Nightly Apocalypse MOTD
+
+This Ansible playbook installs a random post-apocalyptic quote into a MOTD file each time it runs. It is whimsical, yet useful for adding a bit of flavor to server logins.
+
+## Features
+- Picks a random quote from a built-in list.
+- Writes the quote to a configurable file (default `/etc/motd`).
+- Fully idempotent – running it again will replace the file with a new quote.
+
+## Requirements
+- Ansible 2.9+ installed on the control machine.
+- Target hosts reachable via SSH (the playbook defaults to `localhost`).
+
+## Usage
+```bash
+ansible-playbook -i inventory.ini src/setup_motd.yml -e "motd_path=/etc/motd"
+```
+
+You can change `motd_path` to any writable location for testing, e.g.:
+```bash
+ansible-playbook -i inventory.ini src/setup_motd.yml -e "motd_path=/tmp/motd_test"
+```
+
+## License
+MIT

--- a/ansible-playbooks/nightly-nightly-apocalypse-motd/ansible-playbooks/nightly-apocalypse-motd/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-apocalypse-motd/ansible-playbooks/nightly-apocalypse-motd/src/inventory.ini
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-apocalypse-motd/ansible-playbooks/nightly-apocalypse-motd/src/setup_motd.yml
+++ b/ansible-playbooks/nightly-nightly-apocalypse-motd/ansible-playbooks/nightly-apocalypse-motd/src/setup_motd.yml
@@ -1,0 +1,21 @@
+---
+- name: Set random apocalypse MOTD
+  hosts: all
+  become: true
+  vars:
+    # List of whimsical apocalypse quotes
+    apocalypse_quotes:
+      - "The end is nigh, but coffee is still brewing."
+      - "Welcome to the wasteland – may your logs be clean."
+      - "Apocalypse now? Just another day in the terminal."
+      - "Survive the night, enjoy the MOTD."
+      - "When the world ends, at least the prompt is friendly."
+  tasks:
+    - name: Choose a random quote
+      set_fact:
+        chosen_quote: "{{ apocalypse_quotes | random }}"
+    - name: Write MOTD file
+      copy:
+        dest: "{{ motd_path | default('/etc/motd') }}"
+        content: "{{ chosen_quote }}\\n"
+        mode: '0644'

--- a/ansible-playbooks/nightly-nightly-apocalypse-motd/ansible-playbooks/nightly-apocalypse-motd/tests/test_setup_motd.yml
+++ b/ansible-playbooks/nightly-nightly-apocalypse-motd/ansible-playbooks/nightly-apocalypse-motd/tests/test_setup_motd.yml
@@ -1,0 +1,17 @@
+---
+- hosts: localhost
+  become: false
+  vars:
+    # Use a temporary file to avoid requiring root privileges
+    motd_path: "/tmp/motd_test_{{ inventory_hostname }}"
+  tasks:
+    - name: Include the MOTD setup playbook
+      import_playbook: "../../src/setup_motd.yml"
+    - name: Verify the MOTD contains an apocalypse keyword
+      command: cat "{{ motd_path }}"
+      register: motd_content
+    - name: Assert quote contains expected word
+      assert:
+        that:
+          - "'Apocalypse' in motd_content.stdout or 'apocalypse' in motd_content.stdout"
+        # Mock rationale: we assume at least one quote includes the word "Apocalypse"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-apocalypse-motd
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-apocalypse-motd`
- **Files Created**: 4
- **Description**: An Ansible playbook that sets a daily random post-apocalyptic quote as the system MOTD.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-apocalypse-motd`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-apocalypse-motd/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-apocalypse-motd/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.