### PR TITLE
feat(groq): Displays the full 256‑color ANSI terminal palette with visual swatches and optional color codes.

### DIFF
--- a/node-utils/nightly-nightly-ansi-palette-swatch/README.md
+++ b/node-utils/nightly-nightly-ansi-palette-swatch/README.md
@@ -1,0 +1,25 @@
+# nightly-ansi-palette-swatch
+
+Displays the 256‑color ANSI palette in your terminal.
+
+## Usage
+
+```sh
+node src/main.js          # prints palette with color blocks
+node src/main.js --format=hex   # prints hex codes alongside each swatch
+node src/main.js --format=rgb   # prints RGB values alongside each swatch
+```
+
+## How it works
+
+The script iterates over color indices 0‑255 and prints a colored block using the ANSI escape sequence `\x1b[38;5;<n>m█\x1b[0m`. When `--format` is supplied, it also prints the corresponding color value (hex or rgb) derived from the xterm 256‑color chart.
+
+## Testing
+
+Run the test suite with:
+
+```sh
+node tests/test_main.js
+```
+
+The tests verify that the utility produces the expected ANSI sequences for a few sample colors and that the `--format` flag works correctly.

--- a/node-utils/nightly-nightly-ansi-palette-swatch/src/main.js
+++ b/node-utils/nightly-nightly-ansi-palette-swatch/src/main.js
@@ -1,0 +1,88 @@
+// nightly-ansi-palette-swatch
+// Prints the 256‑color ANSI palette with optional color codes.
+
+const process = require('process');
+
+/**
+ * Convert an xterm 256‑color index to its RGB components.
+ * @param {number} n - Color index (0‑255)
+ * @returns {{r:number,g:number,b:number}}
+ */
+function indexToRGB(n) {
+  if (n < 16) {
+    // Standard and high‑intensity colors – use a static table.
+    const table = [
+      [0, 0, 0], [128, 0, 0], [0, 128, 0], [128, 128, 0],
+      [0, 0, 128], [128, 0, 128], [0, 128, 128], [192, 192, 192],
+      [128, 128, 128], [255, 0, 0], [0, 255, 0], [255, 255, 0],
+      [0, 0, 255], [255, 0, 255], [0, 255, 255], [255, 255, 255]
+    ];
+    return { r: table[n][0], g: table[n][1], b: table[n][2] };
+  } else if (n >= 16 && n <= 231) {
+    // 6×6×6 color cube.
+    const i = n - 16;
+    const r = Math.floor(i / 36);
+    const g = Math.floor((i % 36) / 6);
+    const b = i % 6;
+    const level = [0, 95, 135, 175, 215, 255];
+    return { r: level[r], g: level[g], b: level[b] };
+  } else if (n >= 232 && n <= 255) {
+    // Grayscale ramp.
+    const gray = 8 + (n - 232) * 10;
+    return { r: gray, g: gray, b: gray };
+  }
+  // Fallback (should never happen).
+  return { r: 0, g: 0, b: 0 };
+}
+
+/**
+ * Convert RGB to a hex string.
+ * @param {{r:number,g:number,b:number}} rgb
+ * @returns {string}
+ */
+function rgbToHex({ r, g, b }) {
+  const toHex = (v) => v.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+/**
+ * Parse command‑line arguments.
+ * @returns {{format:string|null}}
+ */
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const result = { format: null };
+  args.forEach(arg => {
+    if (arg.startsWith('--format=')) {
+      const fmt = arg.split('=')[1];
+      if (['hex', 'rgb'].includes(fmt)) {
+        result.format = fmt;
+      }
+    }
+  });
+  return result;
+}
+
+function printPalette(format) {
+  const cols = 16;
+  for (let row = 0; row < 16; row++) {
+    let line = '';
+    for (let col = 0; col < cols; col++) {
+      const idx = row * cols + col;
+      const block = `\x1b[38;5;${idx}m█\x1b[0m`;
+      let suffix = '';
+      if (format === 'hex') {
+        const hex = rgbToHex(indexToRGB(idx));
+        suffix = ` ${hex}`;
+      } else if (format === 'rgb') {
+        const { r, g, b } = indexToRGB(idx);
+        suffix = ` rgb(${r},${g},${b})`;
+      }
+      line += block + suffix + ' ';
+    }
+    console.log(line.trimEnd());
+  }
+}
+
+const { format } = parseArgs();
+printPalette(format);

--- a/node-utils/nightly-nightly-ansi-palette-swatch/tests/test_main.js
+++ b/node-utils/nightly-nightly-ansi-palette-swatch/tests/test_main.js
@@ -1,0 +1,43 @@
+// Tests for nightly-ansi-palette-swatch
+// These tests run offline and use child_process to capture output.
+
+const { execSync } = require('child_process');
+const assert = require('assert');
+const path = require('path');
+
+function run(args = '') {
+  // Execute the utility and return stdout as a string.
+  const cmd = `node ${path.join(__dirname, '..', 'src', 'main.js')} ${args}`;
+  // Mock rationale: we run the script synchronously; no external resources are needed.
+  return execSync(cmd, { encoding: 'utf8' });
+}
+
+// Helper to check for an ANSI escape sequence for a given index.
+function containsColor(output, idx) {
+  const esc = `\x1b[38;5;${idx}m█\x1b[0m`;
+  return output.includes(esc);
+}
+
+// Test that the basic palette includes the first and last colors.
+(function testBasicPalette() {
+  const out = run();
+  assert(containsColor(out, 0), 'output should contain color index 0');
+  assert(containsColor(out, 255), 'output should contain color index 255');
+  console.log('✅ testBasicPalette passed');
+})();
+
+// Test that the --format=hex flag adds hex codes.
+(function testHexFormat() {
+  const out = run('--format=hex');
+  assert(out.includes('#000000'), 'hex output should contain #000000 for index 0');
+  assert(out.includes('#ffffff'), 'hex output should contain #ffffff for index 15');
+  console.log('✅ testHexFormat passed');
+})();
+
+// Test that the --format=rgb flag adds rgb strings.
+(function testRgbFormat() {
+  const out = run('--format=rgb');
+  assert(out.includes('rgb(0,0,0)'), 'rgb output should contain rgb(0,0,0) for index 0');
+  assert(out.includes('rgb(255,255,255)'), 'rgb output should contain rgb(255,255,255) for index 15');
+  console.log('✅ testRgbFormat passed');
+})();


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansi-palette-swatch
- **Provider**: groq
- **Location**: `node-utils/nightly-nightly-ansi-palette-swatch`
- **Files Created**: 3
- **Description**: Displays the full 256‑color ANSI terminal palette with visual swatches and optional color codes.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `node-utils/nightly-nightly-ansi-palette-swatch`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `node-utils/nightly-nightly-ansi-palette-swatch/README.md`
- Run tests located in `node-utils/nightly-nightly-ansi-palette-swatch/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.