### PR TITLE
feat(groq): CLI tool that prints the full 256‑color ANSI palette as colored blocks for quick terminal color reference

### DIFF
--- a/typescript-utils/nightly-nightly-ansi-palette-swatch/README.md
+++ b/typescript-utils/nightly-nightly-ansi-palette-swatch/README.md
@@ -1,0 +1,33 @@
+# nightly-ansi-palette-swatch
+
+A whimsical yet handy CLI utility that prints the full 256‑color ANSI palette as colored blocks in your terminal.
+
+## Why?
+
+When working with terminal applications, picking the right ANSI color can be a guessing game. This tool gives you a quick visual reference, perfect for theming scripts, logs, or just adding a splash of post‑apocalyptic flair.
+
+## Installation
+
+```sh
+npm install -g ts-node typescript
+git clone <repo> && cd nightly-ansi-palette-swatch
+npm install
+```
+
+Or run directly without installing:
+
+```sh
+npx ts-node src/index.ts
+```
+
+## Usage
+
+```sh
+$ npx ts-node src/index.ts
+```
+
+The output is a 16×16 grid where each cell shows its color code padded to three digits.
+
+## License
+
+MIT

--- a/typescript-utils/nightly-nightly-ansi-palette-swatch/package.json
+++ b/typescript-utils/nightly-nightly-ansi-palette-swatch/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "nightly-ansi-palette-swatch",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": {
+    "ansi-palette": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node ./tests/test_index.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/typescript-utils/nightly-nightly-ansi-palette-swatch/src/index.ts
+++ b/typescript-utils/nightly-nightly-ansi-palette-swatch/src/index.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * nightly-ansi-palette-swatch
+ * Prints the full 256‑color ANSI palette as colored blocks.
+ *
+ * Usage:
+ *   npx ts-node src/index.ts
+ *
+ * The script outputs a grid where each cell shows its color code.
+ */
+
+export function generatePalette(): string {
+  const rows: string[] = [];
+  for (let row = 0; row < 16; row++) {
+    const cells: string[] = [];
+    for (let col = 0; col < 16; col++) {
+      const code = row * 16 + col;
+      // Background color block with padded code
+      const block = `\x1b[48;5;${code}m  ${code.toString().padStart(3, ' ')}  \x1b[0m`;
+      cells.push(block);
+    }
+    rows.push(cells.join(''));
+  }
+  return rows.join('\n');
+}
+
+// If executed directly, print to stdout
+if (require.main === module) {
+  console.log(generatePalette());
+}

--- a/typescript-utils/nightly-nightly-ansi-palette-swatch/tests/test_index.ts
+++ b/typescript-utils/nightly-nightly-ansi-palette-swatch/tests/test_index.ts
@@ -1,0 +1,8 @@
+import { generatePalette } from '../src/index';
+import assert from 'assert';
+
+const output = generatePalette();
+assert.ok(output.length > 0, 'Palette output should not be empty');
+// Verify that at least one ANSI escape sequence is present
+assert.ok(output.includes('\x1b[48;5;0m'), 'Output should contain ANSI color codes');
+console.log('All tests passed.');


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansi-palette-swatch
- **Provider**: groq
- **Location**: `typescript-utils/nightly-nightly-ansi-palette-swatch`
- **Files Created**: 4
- **Description**: CLI tool that prints the full 256‑color ANSI palette as colored blocks for quick terminal color reference

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `typescript-utils/nightly-nightly-ansi-palette-swatch`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `typescript-utils/nightly-nightly-ansi-palette-swatch/README.md`
- Run tests located in `typescript-utils/nightly-nightly-ansi-palette-swatch/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.