### PR TITLE
feat(groq): A concurrent Go server that broadcasts a random whimsical quote to each TCP client, with a matching client CLI.

### DIFF
--- a/go-utils/nightly-nightly-quote-broadcast-2/README.md
+++ b/go-utils/nightly-nightly-quote-broadcast-2/README.md
@@ -1,0 +1,39 @@
+# nightly-quote-broadcast
+
+A whimsical Go utility that can act as a TCP server broadcasting a random quote to each connecting client, or as a client that fetches and displays the quote. Perfect for adding a touch of post‑apocalyptic inspiration to your terminal.
+
+## Installation
+
+```sh
+go build -o quote-broadcast ./src/main.go
+```
+
+## Usage
+
+### Server
+
+```sh
+./quote-broadcast server -port 9090
+```
+
+Starts a TCP server on port 9090. Each client that connects receives a random quote and the connection is closed.
+
+### Client
+
+```sh
+./quote-broadcast client -addr localhost:9090
+```
+
+Connects to the server, prints the received quote, and exits.
+
+## How it works
+
+The server spawns a new goroutine for each incoming connection, selects a quote from an embedded list using a deterministic round‑robin counter, writes it to the socket, and closes the connection. The client simply reads until EOF and prints the data.
+
+## Testing
+
+Run the test suite with:
+
+```sh
+go test ./...
+```

--- a/go-utils/nightly-nightly-quote-broadcast-2/src/main.go
+++ b/go-utils/nightly-nightly-quote-broadcast-2/src/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+    "bufio"
+    "flag"
+    "fmt"
+    "io"
+    "log"
+    "net"
+    "os"
+    "sync/atomic"
+)
+
+var quotes = []string{
+    "The wasteland whispers.",
+    "Hope is a fragile ember.",
+    "Even ruins have stories.",
+    "Silence sings louder than bombs.",
+}
+
+// counter provides a deterministic round‑robin selection of quotes.
+var counter uint64
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "expected 'server' or 'client' subcommand")
+        os.Exit(1)
+    }
+
+    switch os.Args[1] {
+    case "server":
+        serverCmd := flag.NewFlagSet("server", flag.ExitOnError)
+        port := serverCmd.Int("port", 8080, "port to listen on")
+        serverCmd.Parse(os.Args[2:])
+        runServer(*port)
+    case "client":
+        clientCmd := flag.NewFlagSet("client", flag.ExitOnError)
+        addr := clientCmd.String("addr", "localhost:8080", "address of the quote server")
+        clientCmd.Parse(os.Args[2:])
+        runClient(*addr)
+    default:
+        fmt.Fprintln(os.Stderr, "unknown subcommand")
+        os.Exit(1)
+    }
+}
+
+func runServer(port int) {
+    ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+    if err != nil {
+        log.Fatalf("failed to listen on port %d: %v", port, err)
+    }
+    defer ln.Close()
+    log.Printf("quote server listening on %s", ln.Addr())
+    for {
+        conn, err := ln.Accept()
+        if err != nil {
+            log.Printf("accept error: %v", err)
+            continue
+        }
+        go handleConn(conn)
+    }
+}
+
+func handleConn(conn net.Conn) {
+    defer conn.Close()
+    idx := atomic.AddUint64(&counter, 1) - 1
+    quote := quotes[idx%uint64(len(quotes))]
+    fmt.Fprintln(conn, quote)
+}
+
+func runClient(address string) {
+    conn, err := net.Dial("tcp", address)
+    if err != nil {
+        log.Fatalf("failed to connect to %s: %v", address, err)
+    }
+    defer conn.Close()
+    reader := bufio.NewReader(conn)
+    for {
+        line, err := reader.ReadString('\n')
+        if err != nil {
+            if err == io.EOF {
+                break
+            }
+            log.Fatalf("read error: %v", err)
+        }
+        fmt.Print(line)
+    }
+}

--- a/go-utils/nightly-nightly-quote-broadcast-2/tests/main_test.go
+++ b/go-utils/nightly-nightly-quote-broadcast-2/tests/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+    "io"
+    "net"
+    "strings"
+    "testing"
+    "time"
+)
+
+// TestQuoteBroadcast verifies that a client receives the expected first quote
+// from a freshly started server. The server uses a deterministic round‑robin
+// counter, so the first connection should always get the first element of the
+// quotes slice.
+func TestQuoteBroadcast(t *testing.T) {
+    // Start a listener on an OS‑assigned port.
+    ln, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        t.Fatalf("failed to listen: %v", err)
+    }
+    defer ln.Close()
+
+    // Run the server loop in a goroutine.
+    go func() {
+        for {
+            conn, err := ln.Accept()
+            if err != nil {
+                // Listener closed, exit goroutine.
+                return
+            }
+            go handleConn(conn)
+        }
+    }()
+
+    // Give the server a moment to start.
+    time.Sleep(10 * time.Millisecond)
+
+    // Connect as a client.
+    conn, err := net.Dial("tcp", ln.Addr().String())
+    if err != nil {
+        t.Fatalf("client failed to connect: %v", err)
+    }
+    defer conn.Close()
+
+    // Read the quote.
+    data, err := io.ReadAll(conn)
+    if err != nil {
+        t.Fatalf("failed to read from server: %v", err)
+    }
+    received := strings.TrimSpace(string(data))
+    expected := quotes[0]
+    if received != expected {
+        t.Fatalf("expected %q, got %q", expected, received)
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-quote-broadcast
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-quote-broadcast-2`
- **Files Created**: 3
- **Description**: A concurrent Go server that broadcasts a random whimsical quote to each TCP client, with a matching client CLI.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-quote-broadcast-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-quote-broadcast-2/README.md`
- Run tests located in `go-utils/nightly-nightly-quote-broadcast-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.