### PR TITLE
feat(groq): A fast Rust CLI that converts between common radiation units (Sv, mSv, µSv, rem, rad).

### DIFF
--- a/rust-utils/nightly-nightly-radiation-unit-conve/Cargo.toml
+++ b/rust-utils/nightly-nightly-radiation-unit-conve/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "radiation-unit-converter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.4", features = ["derive"] }
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"

--- a/rust-utils/nightly-nightly-radiation-unit-conve/README.md
+++ b/rust-utils/nightly-nightly-radiation-unit-conve/README.md
@@ -1,0 +1,51 @@
+# Radiation Unit Converter
+
+`radiation-unit-converter` is a tiny, zero‑dependency (aside from `clap`) Rust CLI that converts radiation measurements between the most common units:
+
+- Sievert (Sv)
+- Millisievert (mSv)
+- Microsievert (µSv)
+- Rem
+- Rad
+
+## Installation
+
+```bash
+# Install via Cargo (requires Rust toolchain)
+cargo install radiation-unit-converter --git https://github.com/polsala/ApocalypsAI.git --locked
+```
+
+> **Note**: The utility lives under the `rust-utils/nightly-radiation-unit-converter` directory in the repository. The above command clones the repo and builds the binary.
+
+## Usage
+
+```bash
+# Convert 1 Sv to mSv
+radiation-unit-converter 1 Sv mSv
+# → 1000.000000 mSv
+
+# Convert 5 rem to rad (they are equivalent)
+radiation-unit-converter 5 rem rad
+# → 5.000000 rad
+```
+
+The tool prints the converted value with six decimal places followed by the target unit.
+
+## How it works
+
+The program parses three positional arguments:
+1. The numeric value (`f64`).
+2. The source unit (case‑insensitive, accepts `Sv`, `mSv`, `µSv`, `rem`, `rad`).
+3. The destination unit.
+
+Internally it normalises the input to Sieverts and then converts to the requested unit.
+
+## Testing
+
+Run the test suite with:
+
+```bash
+cargo test
+```
+
+All tests are deterministic and run offline.

--- a/rust-utils/nightly-nightly-radiation-unit-conve/src/main.rs
+++ b/rust-utils/nightly-nightly-radiation-unit-conve/src/main.rs
@@ -1,0 +1,63 @@
+use clap::{Parser, ValueEnum};
+
+#[derive(Parser)]
+#[command(name = "radconv")]
+#[command(about = "Convert radiation units (Sv, mSv, µSv, rem, rad)")]
+struct Cli {
+    /// Numeric value to convert
+    value: f64,
+    /// Unit of the input value
+    #[arg(value_enum)]
+    from: Unit,
+    /// Unit to convert to
+    #[arg(value_enum)]
+    to: Unit,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum Unit {
+    Sv,
+    #[clap(alias = "mSv")]
+    MsV,
+    #[clap(alias = "uSv")]
+    USv,
+    Rem,
+    Rad,
+}
+
+impl Unit {
+    fn to_sieverts(self, val: f64) -> f64 {
+        match self {
+            Unit::Sv => val,
+            Unit::MsV => val / 1000.0,
+            Unit::USv => val / 1_000_000.0,
+            Unit::Rem => val * 0.01,
+            Unit::Rad => val * 0.01,
+        }
+    }
+    fn from_sieverts(self, sv: f64) -> f64 {
+        match self {
+            Unit::Sv => sv,
+            Unit::MsV => sv * 1000.0,
+            Unit::USv => sv * 1_000_000.0,
+            Unit::Rem => sv / 0.01,
+            Unit::Rad => sv / 0.01,
+        }
+    }
+    fn unit_name(self) -> &'static str {
+        match self {
+            Unit::Sv => "Sv",
+            Unit::MsV => "mSv",
+            Unit::USv => "µSv",
+            Unit::Rem => "rem",
+            Unit::Rad => "rad",
+        }
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let sv = cli.from.to_sieverts(cli.value);
+    let result = cli.to.from_sieverts(sv);
+    println!("{:.6} {}", result, cli.to.unit_name());
+}

--- a/rust-utils/nightly-nightly-radiation-unit-conve/tests/cli.rs
+++ b/rust-utils/nightly-nightly-radiation-unit-conve/tests/cli.rs
@@ -1,0 +1,20 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+
+#[test]
+fn test_sv_to_msv() {
+    let mut cmd = Command::cargo_bin("radiation-unit-converter").unwrap();
+    cmd.arg("1").arg("Sv").arg("mSv");
+    cmd.assert()
+        .success()
+        .stdout(contains("1000.000000 mSv"));
+}
+
+#[test]
+fn test_rem_to_rad() {
+    let mut cmd = Command::cargo_bin("radiation-unit-converter").unwrap();
+    cmd.arg("5").arg("rem").arg("rad");
+    cmd.assert()
+        .success()
+        .stdout(contains("5.000000 rad"));
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-radiation-unit-converter
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-radiation-unit-conve`
- **Files Created**: 4
- **Description**: A fast Rust CLI that converts between common radiation units (Sv, mSv, µSv, rem, rad).

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-radiation-unit-conve`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-radiation-unit-conve/README.md`
- Run tests located in `rust-utils/nightly-nightly-radiation-unit-conve/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.