### PR TITLE
feat(groq): A whimsical CLI tool that estimates remaining device battery life based on capacity, draw, and efficiency.

### DIFF
--- a/rust-utils/nightly-nightly-battery-life-estimat/Cargo.toml
+++ b/rust-utils/nightly-nightly-battery-life-estimat/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "battery-life-estimator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-battery-life-estimat/README.md
+++ b/rust-utils/nightly-nightly-battery-life-estimat/README.md
@@ -1,0 +1,32 @@
+# Battery Life Estimator
+
+A whimsical CLI tool for post‑apocalyptic survivors to estimate how many hours their device will survive on the remaining battery.
+
+## Usage
+
+```sh
+battery-life-estimator <capacity_mAh> <draw_mA> [efficiency]
+```
+
+- `capacity_mAh`: current battery capacity in milliamp‑hours.
+- `draw_mA`: average current draw in milliamps.
+- `efficiency` (optional): efficiency factor (0.0‑1.0), default `0.9`.
+
+### Example
+
+```sh
+battery-life-estimator 2500 500
+# => Estimated remaining time: 4.50 hours
+```
+
+## Build
+
+```sh
+cargo build --release
+```
+
+## Test
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-battery-life-estimat/src/lib.rs
+++ b/rust-utils/nightly-nightly-battery-life-estimat/src/lib.rs
@@ -1,0 +1,13 @@
+/// Estimates remaining battery life in hours.
+///
+/// * `capacity` – current battery capacity in mAh.
+/// * `draw` – average current draw in mA.
+/// * `efficiency` – efficiency factor (0.0‑1.0). Typical default is 0.9.
+///
+/// Returns `f64::INFINITY` when `draw` is zero (no consumption).
+pub fn estimate_hours(capacity: f64, draw: f64, efficiency: f64) -> f64 {
+    if draw <= 0.0 {
+        return f64::INFINITY;
+    }
+    (capacity * efficiency) / draw
+}

--- a/rust-utils/nightly-nightly-battery-life-estimat/src/main.rs
+++ b/rust-utils/nightly-nightly-battery-life-estimat/src/main.rs
@@ -1,0 +1,40 @@
+use std::env;
+
+use battery_life_estimator::estimate_hours;
+
+fn print_usage() {
+    eprintln!("Usage: battery-life-estimator <capacity_mAh> <draw_mA> [efficiency]");
+    eprintln!("  capacity_mAh: current battery capacity in mAh");
+    eprintln!("  draw_mA: average current draw in mA");
+    eprintln!("  efficiency (optional): efficiency factor (0.0-1.0), default 0.9");
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 || args.len() > 4 {
+        print_usage();
+        std::process::exit(1);
+    }
+    let capacity: f64 = args[1].parse().unwrap_or_else(|_| {
+        eprintln!("Invalid capacity");
+        std::process::exit(1);
+    });
+    let draw: f64 = args[2].parse().unwrap_or_else(|_| {
+        eprintln!("Invalid draw");
+        std::process::exit(1);
+    });
+    let efficiency: f64 = if args.len() == 4 {
+        args[3].parse().unwrap_or_else(|_| {
+            eprintln!("Invalid efficiency");
+            std::process::exit(1);
+        })
+    } else {
+        0.9
+    };
+    let hours = estimate_hours(capacity, draw, efficiency);
+    if hours.is_infinite() {
+        println!("Estimated remaining time: ∞ hours (no draw)");
+    } else {
+        println!("Estimated remaining time: {:.2} hours", hours);
+    }
+}

--- a/rust-utils/nightly-nightly-battery-life-estimat/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-battery-life-estimat/tests/test_main.rs
@@ -1,0 +1,18 @@
+#[cfg(test)]
+mod tests {
+    use battery_life_estimator::estimate_hours;
+
+    #[test]
+    fn test_basic_estimate() {
+        // 2500 mAh capacity, 500 mA draw, 0.9 efficiency → 4.5 h
+        let hours = estimate_hours(2500.0, 500.0, 0.9);
+        assert!((hours - 4.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_zero_draw() {
+        // Zero draw should yield infinite runtime
+        let hours = estimate_hours(2500.0, 0.0, 0.9);
+        assert!(hours.is_infinite());
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-battery-life-estimator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-battery-life-estimat`
- **Files Created**: 5
- **Description**: A whimsical CLI tool that estimates remaining device battery life based on capacity, draw, and efficiency.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-battery-life-estimat`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-battery-life-estimat/README.md`
- Run tests located in `rust-utils/nightly-nightly-battery-life-estimat/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.