### PR TITLE
feat(groq): Generates a whimsical ASCII map showing random placement of scavenged items for post‑apocalyptic adventures.

### DIFF
--- a/rust-utils/nightly-nightly-scavenger-map-3/rust-utils/nightly-scavenger-map/Cargo.toml
+++ b/rust-utils/nightly-nightly-scavenger-map-3/rust-utils/nightly-scavenger-map/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "scavenger_map"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = "0.8"

--- a/rust-utils/nightly-nightly-scavenger-map-3/rust-utils/nightly-scavenger-map/README.md
+++ b/rust-utils/nightly-nightly-scavenger-map-3/rust-utils/nightly-scavenger-map/README.md
@@ -1,0 +1,33 @@
+# Scavenger Map Generator
+
+A whimsical Rust CLI that creates a tiny ASCII map showing where to find your scavenged items in a post‑apocalyptic world.
+
+## Usage
+
+```sh
+cargo run -- <item1> <item2> ...
+```
+
+Example:
+
+```sh
+cargo run -- water canned-food medkit
+```
+
+Outputs something like:
+
+```
+. . . . . . . . . .
+. . . . . . . . . .
+. . . . . . . . . .
+. . . . . . . . . .
+. . . . . . . . . .
+```
+
+(Actual map will have letters representing items.)
+
+## Testing
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-scavenger-map-3/rust-utils/nightly-scavenger-map/src/main.rs
+++ b/rust-utils/nightly-nightly-scavenger-map-3/rust-utils/nightly-scavenger-map/src/main.rs
@@ -1,0 +1,44 @@
+use rand::{Rng, SeedableRng};
+use rand::rngs::StdRng;
+use std::env;
+
+const WIDTH: usize = 10;
+const HEIGHT: usize = 5;
+
+fn generate_map(items: &[String], seed: u64) -> Vec<Vec<char>> {
+    let mut map = vec![vec!['.'; WIDTH]; HEIGHT];
+    let mut rng = StdRng::seed_from_u64(seed);
+    for item in items {
+        let mut placed = false;
+        for _ in 0..100 {
+            let x = rng.gen_range(0..WIDTH);
+            let y = rng.gen_range(0..HEIGHT);
+            if map[y][x] == '.' {
+                map[y][x] = item.chars().next().unwrap_or('?').to_ascii_uppercase();
+                placed = true;
+                break;
+            }
+        }
+        if !placed {
+            // map full, stop placing further items
+            break;
+        }
+    }
+    map
+}
+
+fn print_map(map: &[Vec<char>]) {
+    for row in map {
+        let line: String = row.iter().map(|c| format!("{} ", c)).collect();
+        println!("{}", line.trim_end());
+    }
+}
+
+fn main() {
+    // Collect command‑line arguments (skip program name)
+    let args: Vec<String> = env::args().skip(1).collect();
+    // Fixed seed ensures deterministic output for testing
+    let seed = 42u64;
+    let map = generate_map(&args, seed);
+    print_map(&map);
+}

--- a/rust-utils/nightly-nightly-scavenger-map-3/rust-utils/nightly-scavenger-map/tests/integration_test.rs
+++ b/rust-utils/nightly-nightly-scavenger-map-3/rust-utils/nightly-scavenger-map/tests/integration_test.rs
@@ -1,0 +1,21 @@
+#[test]
+fn test_map_output_fixed_seed() {
+    // Mock rationale: we run the binary with known args and verify deterministic output.
+    let output = std::process::Command::new("cargo")
+        .args(&["run", "--quiet", "--", "water", "canned", "medkit"]) // three items
+        .output()
+        .expect("failed to execute cargo run");
+    let stdout = std::str::from_utf8(&output.stdout).unwrap().trim();
+
+    // Verify that each item's initial appears somewhere on the map.
+    assert!(stdout.contains('W'), "Map should contain 'W' for water");
+    assert!(stdout.contains('C'), "Map should contain 'C' for canned");
+    assert!(stdout.contains('M'), "Map should contain 'M' for medkit");
+
+    // Verify map dimensions (5 rows, 10 columns)
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 5, "Map should have 5 rows");
+    for line in lines {
+        assert_eq!(line.split_whitespace().count(), 10, "Each row should have 10 columns");
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-scavenger-map
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-scavenger-map-3`
- **Files Created**: 4
- **Description**: Generates a whimsical ASCII map showing random placement of scavenged items for post‑apocalyptic adventures.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-scavenger-map-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-scavenger-map-3/README.md`
- Run tests located in `rust-utils/nightly-nightly-scavenger-map-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.