### PR TITLE
feat(groq): Estimates remaining battery life with a post-apocalyptic twist.

### DIFF
--- a/rust-utils/nightly-nightly-battery-estimator/Cargo.toml
+++ b/rust-utils/nightly-nightly-battery-estimator/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nightly-battery-estimator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-battery-estimator/README.md
+++ b/rust-utils/nightly-nightly-battery-estimator/README.md
@@ -1,0 +1,33 @@
+# nightly-battery-estimator
+
+Estimates remaining battery life based on current charge and average consumption rate. Includes a whimsical "survival mode" that simulates radiation‑induced power drain.
+
+## Usage
+
+```sh
+cargo run -- <charge_percent> <consumption_rate_per_hour> [--survival]
+```
+
+- `<charge_percent>`: current battery charge (0‑100)
+- `<consumption_rate_per_hour>`: percent drained per hour (e.g., 5)
+- `--survival`: increase drain by 25% to account for post‑apocalyptic conditions.
+
+The program prints estimated remaining hours.
+
+## Example
+
+```sh
+$ cargo run -- 80 4
+Estimated remaining time: 20.00 hours
+```
+
+With survival mode:
+
+```sh
+$ cargo run -- 80 4 --survival
+Estimated remaining time (survival mode): 16.00 hours
+```
+
+## Tests
+
+Run `cargo test` to execute deterministic unit tests.

--- a/rust-utils/nightly-nightly-battery-estimator/src/lib.rs
+++ b/rust-utils/nightly-nightly-battery-estimator/src/lib.rs
@@ -1,0 +1,12 @@
+pub fn estimate_hours(charge: f64, rate: f64) -> Option<f64> {
+    if rate <= 0.0 {
+        None
+    } else {
+        Some(charge / rate)
+    }
+}
+
+pub fn apply_survival(rate: f64) -> f64 {
+    // Survival mode simulates a 25% increase in power drain due to harsh conditions.
+    rate * 1.25
+}

--- a/rust-utils/nightly-nightly-battery-estimator/src/main.rs
+++ b/rust-utils/nightly-nightly-battery-estimator/src/main.rs
@@ -1,0 +1,50 @@
+use std::env;
+use std::process;
+
+fn print_usage() {
+    eprintln!("Usage: <charge_percent> <consumption_rate_per_hour> [--survival]");
+}
+
+fn parse_arg(arg: &str) -> Result<f64, &'static str> {
+    arg.parse::<f64>().map_err(|_| "Invalid number")
+}
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+    if args.len() < 2 || args.len() > 3 {
+        print_usage();
+        process::exit(1);
+    }
+
+    let charge = match parse_arg(&args[0]) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{}", e);
+            process::exit(1);
+        }
+    };
+    let mut rate = match parse_arg(&args[1]) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{}", e);
+            process::exit(1);
+        }
+    };
+    let survival = args.get(2).map(|s| s == "--survival").unwrap_or(false);
+    if survival {
+        rate = nightly_battery_estimator::apply_survival(rate);
+    }
+
+    match nightly_battery_estimator::estimate_hours(charge, rate) {
+        Some(hours) => {
+            if survival {
+                println!("Estimated remaining time (survival mode): {:.2} hours", hours);
+            } else {
+                println!("Estimated remaining time: {:.2} hours", hours);
+            }
+        }
+        None => {
+            println!("Cannot estimate time with non‑positive consumption rate.");
+        }
+    }
+}

--- a/rust-utils/nightly-nightly-battery-estimator/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-battery-estimator/tests/test_main.rs
@@ -1,0 +1,24 @@
+#[cfg(test)]
+mod tests {
+    use nightly_battery_estimator::{estimate_hours, apply_survival};
+
+    #[test]
+    fn test_estimate_normal() {
+        let hours = estimate_hours(80.0, 4.0).unwrap();
+        assert!((hours - 20.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_estimate_zero_rate() {
+        assert!(estimate_hours(50.0, 0.0).is_none());
+    }
+
+    #[test]
+    fn test_survival_mode() {
+        let rate = 4.0;
+        let surv_rate = apply_survival(rate);
+        let hours = estimate_hours(80.0, surv_rate).unwrap();
+        // 4 * 1.25 = 5, 80 / 5 = 16
+        assert!((hours - 16.0).abs() < 1e-6);
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-battery-estimator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-battery-estimator`
- **Files Created**: 5
- **Description**: Estimates remaining battery life with a post-apocalyptic twist.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-battery-estimator`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-battery-estimator/README.md`
- Run tests located in `rust-utils/nightly-nightly-battery-estimator/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.