### PR TITLE
feat(groq): Lists and optionally deletes local git branches that have already been merged into a base branch (default main).

### DIFF
--- a/bash-utils/nightly-nightly-branch-pruner/README.md
+++ b/bash-utils/nightly-nightly-branch-pruner/README.md
@@ -1,0 +1,32 @@
+# nightly-branch-pruner
+
+Utility to list (and optionally delete) local git branches that have already been merged into a base branch (default `main`). Helps keep your repository tidy.
+
+## Usage
+
+```sh
+./branch_pruner.sh [-b base_branch] [-d] [-r remote]
+```
+
+- `-b base_branch` : Base branch to compare against (default: `main`).
+- `-d` : Delete the merged branches (dry‑run by default).
+- `-r remote` : Remote name to delete remote branches as well (default: none).
+
+The script prints the branches it would delete. With `-d` it actually deletes them locally and, if `-r` is provided, also on the remote.
+
+## Example
+
+```sh
+# Dry‑run (default)
+./branch_pruner.sh
+
+# Delete merged branches locally
+./branch_pruner.sh -d
+
+# Delete merged branches locally and on origin
+./branch_pruner.sh -d -r origin
+```
+
+## Safety
+
+The script never deletes the base branch itself and skips `main`/`master`. Use `-d` only when you are sure.

--- a/bash-utils/nightly-nightly-branch-pruner/src/branch_pruner.sh
+++ b/bash-utils/nightly-nightly-branch-pruner/src/branch_pruner.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# nightly-branch-pruner
+# Lists (and optionally deletes) local git branches that have been merged into a base branch.
+#
+# Options:
+#   -b <base>   Base branch to compare against (default: main)
+#   -d          Delete the merged branches (dry‑run by default)
+#   -r <remote> Remote name to delete remote branches as well (optional)
+
+set -euo pipefail
+
+BASE_BRANCH="main"
+DELETE=false
+REMOTE=""
+
+while getopts ":b:dr:" opt; do
+  case $opt in
+    b) BASE_BRANCH="$OPTARG" ;;
+    d) DELETE=true ;;
+    r) REMOTE="$OPTARG" ;;
+    \?) echo "Invalid option: -$OPTARG" >&2; exit 1 ;;
+    :)  echo "Option -$OPTARG requires an argument." >&2; exit 1 ;;
+  esac
+done
+
+# Ensure we are inside a git repository
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+  echo "Error: Not a git repository." >&2
+  exit 1
+fi
+
+# Fetch latest refs for remote branches if a remote is specified
+if [[ -n "$REMOTE" ]]; then
+  git fetch "$REMOTE" > /dev/null 2>&1 || true
+fi
+
+# Get list of merged branches, exclude base, main, master, and the current branch
+MERGED_BRANCHES=$(git branch --merged "$BASE_BRANCH" | \
+  grep -vE "^\*| $BASE_BRANCH$| master$| main$" | \
+  sed 's/^ *//')
+
+if [[ -z "$MERGED_BRANCHES" ]]; then
+  echo "No merged branches found (excluding $BASE_BRANCH, main, master)."
+  exit 0
+fi
+
+if $DELETE; then
+  echo "Deleting merged branches:"
+  while IFS= read -r branch; do
+    echo "  $branch"
+    git branch -d "$branch"
+    if [[ -n "$REMOTE" ]]; then
+      git push "$REMOTE" --delete "$branch" || true
+    fi
+  done <<< "$MERGED_BRANCHES"
+else
+  echo "Merged branches (dry‑run):"
+  while IFS= read -r branch; do
+    echo "  $branch"
+  done <<< "$MERGED_BRANCHES"
+fi

--- a/bash-utils/nightly-nightly-branch-pruner/tests/test_branch_pruner.sh
+++ b/bash-utils/nightly-nightly-branch-pruner/tests/test_branch_pruner.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Test suite for nightly-branch-pruner
+# This script creates a temporary git repository, sets up merged and unmerged branches,
+# runs the pruner in dry‑run and delete modes, and checks the expected output.
+
+set -euo pipefail
+
+# Helper to run the script and capture stdout
+run_pruner() {
+  local args="$1"
+  ./src/branch_pruner.sh $args
+}
+
+# Create a temporary directory for the repo
+TMPDIR=$(mktemp -d)
+cd "$TMPDIR"
+
+git init -q
+
+git config user.email "tester@example.com"
+git config user.name "Test User"
+
+# Create initial commit on main
+echo "initial" > README.md
+git add README.md
+git commit -q -m "initial commit"
+
+git checkout -b feature-merged -q
+echo "feature" > feature.txt
+git add feature.txt
+git commit -q -m "add feature"
+
+git checkout main -q
+git merge --no-ff feature-merged -q -m "merge feature-merged"
+
+# Create a branch that stays unmerged
+git checkout -b feature-unmerged -q
+echo "unmerged" > unmerged.txt
+git add unmerged.txt
+git commit -q -m "add unmerged"
+
+git checkout main -q
+
+# ---- Dry‑run test ----
+OUTPUT=$(run_pruner "")
+# Expect feature-merged to appear, feature-unmerged not to appear
+if ! echo "$OUTPUT" | grep -q "feature-merged"; then
+  echo "[FAIL] Dry‑run did not list merged branch 'feature-merged'" >&2
+  exit 1
+fi
+if echo "$OUTPUT" | grep -q "feature-unmerged"; then
+  echo "[FAIL] Dry‑run incorrectly listed unmerged branch 'feature-unmerged'" >&2
+  exit 1
+fi
+
+echo "[PASS] Dry‑run lists only merged branches"
+
+# ---- Delete mode test ----
+run_pruner "-d"
+# After deletion, the merged branch should no longer exist
+if git branch --list | grep -q "feature-merged"; then
+  echo "[FAIL] Branch 'feature-merged' was not deleted" >&2
+  exit 1
+fi
+# Unmerged branch should still exist
+if ! git branch --list | grep -q "feature-unmerged"; then
+  echo "[FAIL] Unmerged branch 'feature-unmerged' disappeared unexpectedly" >&2
+  exit 1
+fi
+
+echo "[PASS] Delete mode removes only merged branches"
+
+# Cleanup
+cd /
+rm -rf "$TMPDIR"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-branch-pruner
- **Provider**: groq
- **Location**: `bash-utils/nightly-nightly-branch-pruner`
- **Files Created**: 3
- **Description**: Lists and optionally deletes local git branches that have already been merged into a base branch (default main).

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `bash-utils/nightly-nightly-branch-pruner`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `bash-utils/nightly-nightly-branch-pruner/README.md`
- Run tests located in `bash-utils/nightly-nightly-branch-pruner/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.