### PR TITLE
feat(groq): A tiny Terraform module that creates whimsical apocalypse‑themed random names for your resources.

### DIFF
--- a/terraform-modules/nightly-nightly-apocalypse-name-gene/README.md
+++ b/terraform-modules/nightly-nightly-apocalypse-name-gene/README.md
@@ -1,0 +1,36 @@
+# Nightly Apocalypse Name Generator
+
+A tiny Terraform module that generates a list of whimsical, apocalypse‑themed names using the `random_pet` resource. Perfect for giving your cloud resources memorable identifiers.
+
+## Usage
+
+```hcl
+module "apoc_names" {
+  source = "./"
+  count  = 5
+}
+
+output "names" {
+  value = module.apoc_names.names
+}
+```
+
+## Inputs
+
+- `count` (number, default 3): How many names to generate.
+
+## Outputs
+
+- `names` (list(string)): Generated names, each prefixed with `apoc-`.
+
+## Example
+
+Running `terraform apply` will output something like:
+
+```
+names = [
+  "apoc-ancient-wolf",
+  "apoc-bleak-owl",
+  "apoc-cryptic-raven",
+]
+```

--- a/terraform-modules/nightly-nightly-apocalypse-name-gene/main.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-name-gene/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+resource "random_pet" "apoc_name" {
+  count     = var.count
+  length    = 2
+  separator = "-"
+  prefix    = "apoc"
+}

--- a/terraform-modules/nightly-nightly-apocalypse-name-gene/outputs.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-name-gene/outputs.tf
@@ -1,0 +1,4 @@
+output "names" {
+  description = "List of generated apocalypse names"
+  value       = random_pet.apoc_name[*].id
+}

--- a/terraform-modules/nightly-nightly-apocalypse-name-gene/tests/test_module.sh
+++ b/terraform-modules/nightly-nightly-apocalypse-name-gene/tests/test_module.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Initialize a temporary directory for the test
+TEST_DIR=$(mktemp -d)
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+# Copy module files into the temp dir
+cp -r . "$TEST_DIR/module"
+
+cd "$TEST_DIR/module"
+
+# Initialize Terraform (no backend) – only the random provider is needed
+terraform init -backend=false > /dev/null
+
+# Validate the configuration syntax
+terraform validate
+
+# Run a plan (no actual resources are created, random_pet is local)
+terraform plan -input=false -no-color -out=plan.out > /dev/null
+
+# Apply only the first random_pet to force generation without persisting state
+terraform apply -auto-approve -input=false -refresh=false -target=random_pet.apoc_name[0] > /dev/null
+
+# Capture the output as JSON
+terraform output -json names > names.json
+
+# Verify that the number of generated names matches the default count (3)
+EXPECTED_COUNT=3
+ACTUAL_COUNT=$(jq '. | length' names.json)
+if [ "$ACTUAL_COUNT" -eq "$EXPECTED_COUNT" ]; then
+  echo "Test passed: generated $ACTUAL_COUNT names."
+  exit 0
+else
+  echo "Test failed: expected $EXPECTED_COUNT names, got $ACTUAL_COUNT."
+  exit 1
+fi

--- a/terraform-modules/nightly-nightly-apocalypse-name-gene/variables.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-name-gene/variables.tf
@@ -1,0 +1,5 @@
+variable "count" {
+  description = "Number of names to generate"
+  type        = number
+  default     = 3
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-apocalypse-name-generator
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-apocalypse-name-gene`
- **Files Created**: 5
- **Description**: A tiny Terraform module that creates whimsical apocalypse‑themed random names for your resources.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-apocalypse-name-gene`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-apocalypse-name-gene/README.md`
- Run tests located in `terraform-modules/nightly-nightly-apocalypse-name-gene/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.