### PR TITLE
feat(groq): Generate QR codes as ASCII art directly from the command line.

### DIFF
--- a/rust-utils/nightly-nightly-qr-ascii-art-3/Cargo.toml
+++ b/rust-utils/nightly-nightly-qr-ascii-art-3/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "nightly-qr-ascii-art"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+qrcode = "0.7"
+clap = { version = "4.4", features = ["derive"] }

--- a/rust-utils/nightly-nightly-qr-ascii-art-3/README.md
+++ b/rust-utils/nightly-nightly-qr-ascii-art-3/README.md
@@ -1,0 +1,30 @@
+# nightly-qr-ascii-art
+
+Generate QR codes as ASCII art directly from the command line.
+
+## Build
+
+```sh
+cargo build --release
+```
+
+## Usage
+
+```sh
+# Pipe input
+echo "Hello, world!" | nightly-qr-ascii-art
+```
+
+or
+
+```sh
+nightly-qr-ascii-art "Hello, world!"
+```
+
+The program prints the QR code using `██` for black modules and two spaces for white modules.
+
+## Test
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-qr-ascii-art-3/src/lib.rs
+++ b/rust-utils/nightly-nightly-qr-ascii-art-3/src/lib.rs
@@ -1,0 +1,24 @@
+use qrcode::QrCode;
+use qrcode::EcLevel;
+use qrcode::Color;
+
+/// Generate an ASCII representation of a QR code.
+///
+/// * `input` – the string to encode.
+/// * Returns a `String` where each QR module is rendered as `██` (dark) or two spaces (light).
+pub fn generate_qr_ascii(input: &str) -> String {
+    let code = QrCode::with_error_correction_level(input.as_bytes(), EcLevel::L).unwrap();
+    let matrix = code.to_colors();
+    let mut out = String::new();
+    for row in matrix {
+        for color in row {
+            if color == Color::Dark {
+                out.push_str("██");
+            } else {
+                out.push_str("  ");
+            }
+        }
+        out.push('\n');
+    }
+    out
+}

--- a/rust-utils/nightly-nightly-qr-ascii-art-3/src/main.rs
+++ b/rust-utils/nightly-nightly-qr-ascii-art-3/src/main.rs
@@ -1,0 +1,23 @@
+use clap::Parser;
+use nightly_qr_ascii_art::generate_qr_ascii;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Input text to encode. If omitted, reads from stdin.
+    text: Option<String>,
+}
+
+fn main() {
+    let args = Args::parse();
+    let input = match args.text {
+        Some(t) => t,
+        None => {
+            let mut buf = String::new();
+            std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf).unwrap();
+            buf.trim_end().to_string()
+        }
+    };
+    let ascii = generate_qr_ascii(&input);
+    print!("{}", ascii);
+}

--- a/rust-utils/nightly-nightly-qr-ascii-art-3/tests/integration_test.rs
+++ b/rust-utils/nightly-nightly-qr-ascii-art-3/tests/integration_test.rs
@@ -1,0 +1,12 @@
+use nightly_qr_ascii_art::generate_qr_ascii;
+
+#[test]
+fn test_qr_dimensions() {
+    // "HELLO" fits in a Version‑1 QR (21×21 modules) with low error correction.
+    let out = generate_qr_ascii("HELLO");
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.len(), 21, "QR should have 21 rows");
+    for line in lines {
+        assert_eq!(line.len(), 42, "Each row should be 21 modules × 2 chars");
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-qr-ascii-art
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-qr-ascii-art-3`
- **Files Created**: 5
- **Description**: Generate QR codes as ASCII art directly from the command line.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-qr-ascii-art-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-qr-ascii-art-3/README.md`
- Run tests located in `rust-utils/nightly-nightly-qr-ascii-art-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.