### PR TITLE
feat(groq): A tiny Rust CLI that prints a swatch of ANSI 256‑color codes for easy terminal color picking.

### DIFF
--- a/rust-utils/nightly-nightly-ansi-palette-swatch/Cargo.toml
+++ b/rust-utils/nightly-nightly-ansi-palette-swatch/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nightly-ansi-palette-swatch"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-ansi-palette-swatch/README.md
+++ b/rust-utils/nightly-nightly-ansi-palette-swatch/README.md
@@ -1,0 +1,24 @@
+# nightly-ansi-palette-swatch
+
+A tiny Rust CLI that prints a swatch of ANSI 256‑color codes to your terminal. Useful for picking colors for scripts, themes, or just for fun.
+
+## Usage
+
+```sh
+# Print all 256 colors
+nightly-ansi-palette-swatch
+
+# Print a subset, e.g., colors 16‑31
+nightly-ansi-palette-swatch --range 16-31
+```
+
+## Options
+
+- `--range START-END` – inclusive range of color codes (0‑255). Defaults to `0-255`.
+
+## Build & Run
+
+```sh
+cargo build --release
+./target/release/nightly-ansi-palette-swatch [--range START-END]
+```

--- a/rust-utils/nightly-nightly-ansi-palette-swatch/src/lib.rs
+++ b/rust-utils/nightly-nightly-ansi-palette-swatch/src/lib.rs
@@ -1,0 +1,12 @@
+pub fn generate_palette(start: u8, end: u8) -> String {
+    let mut out = String::new();
+    for code in start..=end {
+        // Print the code using its foreground ANSI 256‑color value
+        out.push_str(&format!("\x1b[38;5;{}m{:>3}\x1b[0m ", code, code));
+        // Insert a newline every 16 colors for readability
+        if (code - start + 1) % 16 == 0 {
+            out.push('\n');
+        }
+    }
+    out
+}

--- a/rust-utils/nightly-nightly-ansi-palette-swatch/src/main.rs
+++ b/rust-utils/nightly-nightly-ansi-palette-swatch/src/main.rs
@@ -1,0 +1,36 @@
+use std::env;
+use nightly_ansi_palette_swatch::generate_palette;
+
+fn parse_range(arg: &str) -> Option<(u8, u8)> {
+    let parts: Vec<&str> = arg.split('-').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+    let start = parts[0].parse::<u8>().ok()?;
+    let end = parts[1].parse::<u8>().ok()?;
+    if start > end || end > 255 {
+        return None;
+    }
+    Some((start, end))
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let mut start = 0u8;
+    let mut end = 255u8;
+    if args.len() == 3 && args[1] == "--range" {
+        if let Some((s, e)) = parse_range(&args[2]) {
+            start = s;
+            end = e;
+        } else {
+            eprintln!("Invalid range. Use --range START-END where 0 <= START <= END <= 255");
+            std::process::exit(1);
+        }
+    } else if args.len() != 1 {
+        eprintln!("Usage: {} [--range START-END]", args[0]);
+        std::process::exit(1);
+    }
+
+    let palette = generate_palette(start, end);
+    println!("{}", palette);
+}

--- a/rust-utils/nightly-nightly-ansi-palette-swatch/tests/test_palette.rs
+++ b/rust-utils/nightly-nightly-ansi-palette-swatch/tests/test_palette.rs
@@ -1,0 +1,19 @@
+#[cfg(test)]
+mod tests {
+    use nightly_ansi_palette_swatch::generate_palette;
+
+    #[test]
+    fn test_small_range_contains_expected_codes() {
+        let out = generate_palette(0, 1);
+        // Verify that the ANSI escape sequences for codes 0 and 1 appear
+        assert!(out.contains("\x1b[38;5;0m  0\x1b[0m"));
+        assert!(out.contains("\x1b[38;5;1m  1\x1b[0m"));
+    }
+
+    #[test]
+    fn test_start_greater_than_end_returns_empty() {
+        // When start > end the iterator yields nothing, resulting in an empty string
+        let out = generate_palette(5, 4);
+        assert_eq!(out, "");
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansi-palette-swatch
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-ansi-palette-swatch`
- **Files Created**: 5
- **Description**: A tiny Rust CLI that prints a swatch of ANSI 256‑color codes for easy terminal color picking.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-ansi-palette-swatch`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-ansi-palette-swatch/README.md`
- Run tests located in `rust-utils/nightly-nightly-ansi-palette-swatch/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.