### PR TITLE
feat(gemini): An Ansible playbook to monitor and automatically restart critical systemd services, logging their "resurrection" attempts.

### DIFF
--- a/ansible-playbooks/nightly-nightly-service-sentinel/README.md
+++ b/ansible-playbooks/nightly-nightly-service-sentinel/README.md
@@ -1,0 +1,70 @@
+# Nightly Service Sentinel
+
+The Nightly Service Sentinel is an Ansible playbook designed to vigilantly monitor critical systemd services across your infrastructure. In the face of digital entropy, this sentinel ensures your essential services remain operational. Should a service be found in a "deceased" state, the sentinel will attempt a swift "resurrection" and log the event with appropriate gravitas.
+
+## Features
+
+*   **Vigilant Monitoring**: Checks the status of specified systemd services.
+*   **Automatic Resurrection**: Attempts to start services found to be inactive or failed.
+*   **Whimsical Logging**: Provides dramatic output for service status changes.
+*   **Configurable**: Easily define which services to monitor via variables.
+
+## Usage
+
+1.  **Define your inventory**: Create an `inventory.ini` file listing the hosts where you want to run the sentinel.
+
+    ```ini
+    [servers]
+    server1.example.com
+    server2.example.com
+
+    [all:vars]
+    ansible_user=your_ssh_user
+    ansible_become=true
+    ```
+
+2.  **Configure services**: Edit `vars/main.yml` to specify the services you wish to monitor.
+
+    ```yaml
+    # vars/main.yml
+    ---
+    critical_services:
+      - nginx
+      - postgresql
+      - my_custom_app
+    ```
+
+    Alternatively, pass them as extra-vars when running the playbook:
+    `ansible-playbook -i inventory.ini src/service_sentinel.yml -e "critical_services=['nginx', 'redis']"`
+
+3.  **Run the playbook**: 
+
+    ```bash
+    ansible-playbook -i inventory.ini src/service_sentinel.yml
+    ```
+
+    The playbook will connect to your hosts, check the status of each `critical_service`, and attempt to start any that are not running.
+
+## Testing
+
+This utility includes a self-contained test playbook that simulates service states on `localhost` to ensure the sentinel's logic functions correctly.
+
+To run the tests:
+
+```bash
+ansible-playbook -i tests/inventory_test.ini tests/test_service_sentinel.yml
+```
+
+The test playbook will:
+1.  Create a dummy systemd service.
+2.  Stop the dummy service.
+3.  Run the main `service_sentinel.yml` playbook, expecting it to start the dummy service.
+4.  Verify the dummy service is running.
+5.  Run the main `service_sentinel.yml` playbook again, expecting it to find the service already running.
+6.  Clean up the dummy service.
+
+## Requirements
+
+*   Ansible (version 2.9 or higher recommended)
+*   Target hosts must be running `systemd`.
+*   SSH access to target hosts with `sudo` privileges for the `ansible_user`.

--- a/ansible-playbooks/nightly-nightly-service-sentinel/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-service-sentinel/src/inventory.ini
@@ -1,0 +1,2 @@
+[servers]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-service-sentinel/src/service_sentinel.yml
+++ b/ansible-playbooks/nightly-nightly-service-sentinel/src/service_sentinel.yml
@@ -1,0 +1,62 @@
+---
+- name: Nightly Service Sentinel - Monitor and Resurrect Critical Services
+  hosts: all
+  become: true
+  vars:
+    critical_services: [] # Default empty, can be overridden by vars/main.yml or extra-vars
+
+  tasks:
+    - name: Load critical services from vars/main.yml if not already defined
+      ansible.builtin.include_vars:
+        file: vars/main.yml
+        name: service_vars
+      when: critical_services is not defined or critical_services | length == 0
+      ignore_errors: true # Allow playbook to run even if vars/main.yml is missing
+
+    - name: Set critical_services from loaded vars if still empty
+      ansible.builtin.set_fact:
+        critical_services: "{{ service_vars.critical_services | default([]) }}"
+      when: critical_services is not defined or critical_services | length == 0
+
+    - name: Ensure critical_services list is defined and not empty
+      ansible.builtin.fail:
+        msg: "No critical_services defined. Please define them in vars/main.yml or via --extra-vars."
+      when: critical_services is not defined or critical_services | length == 0
+
+    - name: Check status of critical services
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+      register: service_status
+      loop: "{{ critical_services }}"
+      ignore_errors: true # Continue even if a service doesn't exist
+
+    - name: Attempt resurrection for deceased services
+      ansible.builtin.systemd:
+        name: "{{ item.item }}"
+        state: started
+        enabled: true # Ensure it starts on boot
+      when:
+        - item.status is defined
+        - item.status.ActiveState != 'active' or item.status.SubState != 'running'
+      loop: "{{ service_status.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+      register: resurrection_attempt
+      changed_when: resurrection_attempt.changed
+
+    - name: Report sentinel findings
+      ansible.builtin.debug:
+        msg: |
+          {% if item.status is defined and (item.status.ActiveState == 'active' and item.status.SubState == 'running') %}
+          [SENTINEL REPORT] Service '{{ item.item }}' is standing strong, vigilant against the void.
+          {% elif item.status is defined and item.status.ActiveState != 'active' and item.status.SubState != 'running' and item.changed %}
+          [SENTINEL ALERT] Service '{{ item.item }}' was found deceased! Attempting resurrection... Status: {{ item.status.ActiveState }}/{{ item.status.SubState }} -> RESURRECTED!
+          {% elif item.status is defined and item.status.ActiveState != 'active' and item.status.SubState != 'running' and not item.changed %}
+          [SENTINEL WARNING] Service '{{ item.item }}' was found deceased and resurrection failed or was not attempted. Status: {{ item.status.ActiveState }}/{{ item.status.SubState }}
+          {% else %}
+          [SENTINEL NOTE] Service '{{ item.item }}' status unknown or not applicable.
+          {% endif %}
+      loop: "{{ resurrection_attempt.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+      when: resurrection_attempt.results is defined and resurrection_attempt.results | length > 0

--- a/ansible-playbooks/nightly-nightly-service-sentinel/tests/inventory_test.ini
+++ b/ansible-playbooks/nightly-nightly-service-sentinel/tests/inventory_test.ini
@@ -1,0 +1,2 @@
+[test_host]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-service-sentinel/tests/test_service_sentinel.yml
+++ b/ansible-playbooks/nightly-nightly-service-sentinel/tests/test_service_sentinel.yml
@@ -1,0 +1,100 @@
+---
+- name: Test Nightly Service Sentinel Playbook
+  hosts: test_host
+  become: true
+  vars:
+    test_service_name: dummy-sentinel-service
+    critical_services:
+      - "{{ test_service_name }}"
+
+  tasks:
+    - name: Ensure systemd is available for testing
+      ansible.builtin.command: systemctl --version
+      register: systemctl_check
+      failed_when: systemctl_check.rc != 0
+      changed_when: false
+      # Mock rationale: This check ensures systemd is present, which is a prerequisite for the playbook. It's a basic system check, not mocking a service itself.
+
+    - name: Create a dummy systemd service file
+      ansible.builtin.copy:
+        dest: "/etc/systemd/system/{{ test_service_name }}.service"
+        content: |
+          [Unit]
+          Description=Dummy Sentinel Test Service
+          After=network.target
+
+          [Service]
+          ExecStart=/bin/bash -c "while true; do sleep 1; done"
+          Restart=always
+          Type=simple
+
+          [Install]
+          WantedBy=multi-user.target
+      notify: Reload systemd daemon
+      # Mock rationale: This creates a controllable, isolated service for testing without affecting real system services.
+
+    - name: Reload systemd daemon
+      ansible.builtin.systemd:
+        daemon_reload: true
+      # Mock rationale: Essential for systemd to recognize the newly created dummy service.
+
+    - name: Stop the dummy service (if running)
+      ansible.builtin.systemd:
+        name: "{{ test_service_name }}"
+        state: stopped
+        enabled: false # Ensure it doesn't auto-start unexpectedly
+      ignore_errors: true # Service might not be running initially
+      # Mock rationale: Sets a known 'deceased' state for the dummy service to test resurrection logic.
+
+    - name: Verify dummy service is stopped before running sentinel
+      ansible.builtin.systemd:
+        name: "{{ test_service_name }}"
+      register: initial_status
+      failed_when: initial_status.status.ActiveState == 'active'
+      # Mock rationale: Confirms the mock setup is correct before the main playbook runs.
+
+    - name: Run the Nightly Service Sentinel playbook (expecting resurrection)
+      ansible.builtin.include_tasks: ../src/service_sentinel.yml
+      vars:
+        critical_services: "{{ critical_services }}"
+      # Mock rationale: Executes the target playbook with the mocked service.
+
+    - name: Verify dummy service is now running after sentinel
+      ansible.builtin.systemd:
+        name: "{{ test_service_name }}"
+      register: after_resurrection_status
+      failed_when: after_resurrection_status.status.ActiveState != 'active'
+      # Mock rationale: Asserts that the sentinel successfully 'resurrected' the service.
+
+    - name: Run the Nightly Service Sentinel playbook again (expecting no change)
+      ansible.builtin.include_tasks: ../src/service_sentinel.yml
+      vars:
+        critical_services: "{{ critical_services }}"
+      # Mock rationale: Executes the target playbook again to test idempotency and 'already running' logic.
+
+    - name: Verify dummy service is still running and no unnecessary restart occurred
+      ansible.builtin.systemd:
+        name: "{{ test_service_name }}"
+      register: final_status
+      failed_when: final_status.status.ActiveState != 'active'
+      # Mock rationale: Confirms the service remains active and the sentinel didn't unnecessarily restart it.
+
+    - name: Clean up dummy systemd service file
+      ansible.builtin.file:
+        path: "/etc/systemd/system/{{ test_service_name }}.service"
+        state: absent
+      notify: Reload systemd daemon
+      # Mock rationale: Removes the test artifact to leave the system clean.
+
+    - name: Disable and stop dummy service (if it was enabled/started by test)
+      ansible.builtin.systemd:
+        name: "{{ test_service_name }}"
+        state: stopped
+        enabled: false
+      ignore_errors: true # Service might already be stopped or removed
+      # Mock rationale: Ensures the dummy service is fully deactivated and removed from systemd's awareness.
+
+  handlers:
+    - name: Reload systemd daemon
+      ansible.builtin.systemd:
+        daemon_reload: true

--- a/ansible-playbooks/nightly-nightly-service-sentinel/vars/main.yml
+++ b/ansible-playbooks/nightly-nightly-service-sentinel/vars/main.yml
@@ -1,0 +1,6 @@
+---
+critical_services:
+  - dummy-sentinel-service
+  # Add other critical services here, e.g.:
+  # - nginx
+  # - postgresql


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-service-sentinel
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-service-sentinel`
- **Files Created**: 6
- **Description**: An Ansible playbook to monitor and automatically restart critical systemd services, logging their "resurrection" attempts.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-service-sentinel`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-service-sentinel/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-service-sentinel/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.