### PR TITLE
feat(groq): Terraform module that provisions a versioned S3 bucket with encryption and lifecycle rules for post‑apocalyptic safe‑house data.

### DIFF
--- a/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
@@ -1,0 +1,30 @@
+# Nightly Safehouse S3
+
+Terraform module that creates an S3 bucket with versioning, server‑side encryption, and a lifecycle rule that transitions objects to Glacier after 30 days and deletes after 365 days. Ideal for storing backups of community resources in a post‑apocalyptic setting.
+
+## Usage
+
+```hcl
+module "safehouse_s3" {
+  source      = "./"
+  bucket_name = "my-safehouse-data"
+  tags = {
+    Environment = "post-apocalypse"
+    Owner       = "community"
+  }
+}
+```
+
+## Inputs
+
+- `bucket_name` (string, required): Name of the bucket. Must be globally unique.
+- `tags` (map(string), optional): Tags to apply.
+
+## Outputs
+
+- `bucket_id` – The ID of the created bucket.
+- `bucket_arn` – The ARN of the bucket.
+
+## Testing
+
+Run `./tests/validate.sh` from the module root.

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/main.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/main.tf
@@ -1,0 +1,30 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+  tags   = var.tags
+
+  lifecycle_rule {
+    id      = "glacier-transition"
+    enabled = true
+
+    transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/outputs.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_id" {
+  description = "The ID of the S3 bucket."
+  value       = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the S3 bucket."
+  value       = aws_s3_bucket.this.arn
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/tests/validate.sh
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/tests/validate.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Mock rationale: This script runs terraform init and validate to ensure the module syntax is correct.
+set -e
+
+# Create a temporary working directory
+TMPDIR=$(mktemp -d)
+cp -R . "$TMPDIR/module"
+cd "$TMPDIR/module"
+
+terraform init -backend=false > /dev/null 2>&1
+terraform validate
+
+echo "✅ Terraform module validation passed."

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/variables.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/variables.tf
@@ -1,0 +1,10 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket (must be globally unique)."
+  type        = string
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the bucket."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-safehouse-s3
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-safehouse-s3-8`
- **Files Created**: 5
- **Description**: Terraform module that provisions a versioned S3 bucket with encryption and lifecycle rules for post‑apocalyptic safe‑house data.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-safehouse-s3-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-safehouse-s3-8/README.md`
- Run tests located in `terraform-modules/nightly-nightly-safehouse-s3-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.