### PR TITLE
feat(gemini): An Ansible playbook to sweep away digital dust bunnies (temporary files, old logs, forgotten caches) from remote servers.

### DIFF
--- a/ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/README.md
+++ b/ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/README.md
@@ -1,0 +1,70 @@
+# Nightly Digital Dust Bunny Sweeper
+
+An Ansible playbook to sweep away digital dust bunnies (temporary files, old logs, forgotten caches) from remote servers.
+
+## Overview
+
+This playbook helps maintain server hygiene by identifying and removing old, unnecessary files from specified directories. It targets common locations for temporary files, logs, and caches, ensuring your systems stay lean and mean.
+
+## Features
+
+-   **Configurable Paths**: Easily define which directories to clean and what age threshold to apply.
+-   **Pattern Matching**: Use glob patterns to target specific file types (e.g., `*.log`, `*.tmp`).
+-   **Detailed Reporting**: Get a summary of what was swept away.
+
+## Usage
+
+1.  **Define your inventory**:
+    Create an `inventory.ini` file (or use an existing one) listing your target servers.
+
+    ```ini
+    [webservers]
+    web1.example.com
+    web2.example.com
+
+    [databases]
+    db1.example.com
+    ```
+
+2.  **Configure cleanup paths**:
+    Edit `src/vars/cleanup_paths.yml` to specify the directories, age thresholds (in days), and file patterns for cleanup.
+
+    ```yaml
+    # src/vars/cleanup_paths.yml
+    cleanup_targets:
+      - path: /tmp
+        age_days: 7
+        patterns: ["*"]
+      - path: /var/log
+        age_days: 30
+        patterns: ["*.log", "*.gz"]
+      - path: /var/cache/apt/archives # Example for Debian/Ubuntu
+        age_days: 30
+        patterns: ["*.deb"]
+      - path: /home/*/Downloads # Wildcard for user home directories
+        age_days: 60
+        patterns: ["*"]
+    ```
+
+3.  **Run the playbook**:
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/dust_sweeper.yml
+    ```
+
+    Add `--check` for a dry run, or `--diff` to see what changes would be made.
+
+## Requirements
+
+-   Ansible (version 2.9 or higher recommended)
+-   SSH access to target servers with appropriate permissions for file deletion.
+
+## Testing
+
+To run the automated tests:
+
+```bash
+ansible-playbook -i tests/inventory_test.ini tests/test_dust_sweeper.yml
+```
+
+The tests will create temporary files, run the cleanup playbook against them, and verify that only the "old" files are removed.

--- a/ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/src/dust_sweeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/src/dust_sweeper.yml
@@ -1,0 +1,62 @@
+---
+- name: Sweep away digital dust bunnies
+  hosts: all
+  become: yes # Requires elevated privileges for system directories
+  gather_facts: yes
+
+  vars_files:
+    - vars/cleanup_paths.yml
+
+  tasks:
+    - name: Ensure cleanup_targets is defined
+      ansible.builtin.fail:
+        msg: "Variable 'cleanup_targets' is not defined. Please check vars/cleanup_paths.yml."
+      when: cleanup_targets is not defined or cleanup_targets | length == 0
+
+    - name: Initialize swept_files list for {{ inventory_hostname }}
+      ansible.builtin.set_fact:
+        swept_files: []
+
+    - name: Process each cleanup target
+      loop: "{{ cleanup_targets }}"
+      loop_control:
+        loop_var: cleanup_item
+      block:
+        - name: Find old files in {{ cleanup_item.path }}
+          ansible.builtin.find:
+            paths: "{{ cleanup_item.path }}"
+            age: "{{ cleanup_item.age_days }}d"
+            patterns: "{{ cleanup_item.patterns | default(['*']) }}"
+            recurse: yes
+            file_type: file
+          register: old_files_found
+
+        - name: Delete old files
+          ansible.builtin.file:
+            path: "{{ item.path }}"
+            state: absent
+          loop: "{{ old_files_found.files }}"
+          when: old_files_found.files | length > 0
+          register: deleted_files_result
+
+        - name: Add deleted files to swept_files list
+          ansible.builtin.set_fact:
+            swept_files: "{{ swept_files + [item.path] }}"
+          loop: "{{ deleted_files_result.results | selectattr('changed', 'equalto', true) | map(attribute='path') | list }}"
+          when: deleted_files_result.results is defined and deleted_files_result.results | length > 0
+
+  post_tasks:
+    - name: Report on swept digital dust bunnies
+      ansible.builtin.debug:
+        msg: |
+          Digital Dust Bunny Sweeper Report for {{ inventory_hostname }}:
+          Total files swept: {{ swept_files | length }}
+          Swept files:
+          {% if swept_files | length > 0 %}
+          {% for file in swept_files %}
+          - {{ file }}
+          {% endfor %}
+          {% else %}
+          No digital dust bunnies found to sweep!
+          {% endif %}
+      when: swept_files is defined

--- a/ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/src/inventory.ini
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/src/vars/cleanup_paths.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/src/vars/cleanup_paths.yml
@@ -1,0 +1,13 @@
+cleanup_targets:
+  - path: /tmp
+    age_days: 7
+    patterns: ["*"]
+  - path: /var/log
+    age_days: 30
+    patterns: ["*.log", "*.gz"]
+  - path: /var/cache/apt/archives
+    age_days: 30
+    patterns: ["*.deb"]
+  - path: /home/*/Downloads
+    age_days: 60
+    patterns: ["*"]

--- a/ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/tests/inventory_test.ini
+++ b/ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/tests/inventory_test.ini
@@ -1,0 +1,2 @@
+[test_host]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/tests/test_dust_sweeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/tests/test_dust_sweeper.yml
@@ -1,0 +1,80 @@
+---
+- name: Test Digital Dust Bunny Sweeper
+  hosts: test_host
+  become: yes
+  gather_facts: no
+
+  vars:
+    test_dir: "/tmp/ansible_test_dust_sweeper_{{ lookup('pipe', 'date +%s%N') }}" # Unique temp dir
+    old_file_name: "old_dust_bunny.log"
+    new_file_name: "new_sparkle.txt"
+    old_file_path: "{{ test_dir }}/{{ old_file_name }}"
+    new_file_path: "{{ test_dir }}/{{ new_file_name }}"
+    mock_cleanup_targets:
+      - path: "{{ test_dir }}"
+        age_days: 1
+        patterns: ["*"]
+
+  tasks:
+    - name: Create test directory
+      ansible.builtin.file:
+        path: "{{ test_dir }}"
+        state: directory
+        mode: '0755'
+
+    - name: Create an old file
+      ansible.builtin.copy:
+        content: "This is an old file."
+        dest: "{{ old_file_path }}"
+      register: old_file_creation
+
+    - name: Set modification time for old file (to be older than 1 day)
+      # Mock rationale: Creating a file with a specific modification time to simulate an "old" file.
+      # This is deterministic and offline as it manipulates local filesystem state for testing.
+      # We use 'touch' to set the mtime, which is a standard local command.
+      ansible.builtin.command: "touch -d '2 days ago' {{ old_file_path }}"
+      args:
+        creates: "{{ old_file_path }}" # Ensure it only runs if the file exists
+      when: old_file_creation.changed
+
+    - name: Create a new file
+      ansible.builtin.copy:
+        content: "This is a new file."
+        dest: "{{ new_file_path }}"
+
+    - name: Run the dust sweeper playbook with mock targets
+      ansible.builtin.include_tasks:
+        file: ../src/dust_sweeper.yml
+      vars:
+        cleanup_targets: "{{ mock_cleanup_targets }}"
+
+    - name: Verify old file is deleted
+      ansible.builtin.stat:
+        path: "{{ old_file_path }}"
+      register: old_file_stat
+
+    - name: Assert old file is absent
+      ansible.builtin.assert:
+        that:
+          - not old_file_stat.stat.exists
+        fail_msg: "Old file '{{ old_file_path }}' was not deleted!"
+        success_msg: "Old file '{{ old_file_path }}' was successfully deleted."
+
+    - name: Verify new file still exists
+      ansible.builtin.stat:
+        path: "{{ new_file_path }}"
+      register: new_file_stat
+
+    - name: Assert new file is present
+      ansible.builtin.assert:
+        that:
+          - new_file_stat.stat.exists
+        fail_msg: "New file '{{ new_file_path }}' was unexpectedly deleted!"
+        success_msg: "New file '{{ new_file_path }}' correctly remains."
+
+  always:
+    - name: Clean up test directory
+      ansible.builtin.file:
+        path: "{{ test_dir }}"
+        state: absent
+      when: test_dir is defined and test_dir != "/" # Safety check


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-digital-dust-sweeper
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-digital-dust-sweeper-3`
- **Files Created**: 6
- **Description**: An Ansible playbook to sweep away digital dust bunnies (temporary files, old logs, forgotten caches) from remote servers.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-digital-dust-sweeper-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-digital-dust-sweeper-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.