### PR TITLE
feat(gemini): An Ansible playbook to sweep away digital dust bunnies (old, temporary, or unused files) from remote servers, keeping them tidy.

### DIFF
--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/README.md
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/README.md
@@ -1,0 +1,62 @@
+# Nightly Digital Dust Bunny Sweeper
+
+This Ansible playbook helps maintain system hygiene by identifying and removing old, temporary, or unused files across your servers. Think of it as a digital vacuum cleaner for your infrastructure, sweeping away the 'dust bunnies' that accumulate over time.
+
+## Features
+
+*   **Configurable Paths**: Specify which directories to scan for old files.
+*   **Configurable Age**: Define how old a file must be to be considered a 'dust bunny' and eligible for removal.
+*   **Idempotent**: Ensures target directories exist before scanning.
+*   **Reporting**: Provides a summary of files found and removed.
+
+## Prerequisites
+
+*   Ansible installed on your control machine.
+*   SSH access to your target servers (if not running locally).
+*   `become` (sudo/root) privileges on target servers for file management in system directories.
+
+## Usage
+
+1.  **Configure Inventory**: Edit `src/inventory.ini` to list your target servers. For local execution, `localhost` is pre-configured.
+
+    ```ini
+    [servers]
+    localhost ansible_connection=local
+    # server1.example.com
+    # server2.example.com
+    ```
+
+2.  **Configure Cleanup Settings**: Modify `vars/cleanup_config.yml` to define the paths to scan and the age threshold for removal.
+
+    ```yaml
+    ---
+    cleanup_paths:
+      - "/tmp/digital_dust"
+      - "/var/log/archive"
+      - "/var/cache/old_packages"
+    cleanup_age_days: 30 # Files older than 30 days will be removed
+    ```
+
+3.  **Run the Playbook**: Execute the playbook from your control machine.
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/dust_bunny_sweeper.yml
+    ```
+
+    To run with a specific user (e.g., `ansible_user=youruser`) and prompt for sudo password:
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/dust_bunny_sweeper.yml -u youruser --ask-become-pass
+    ```
+
+## Testing
+
+To ensure the sweeper works as expected, a dedicated test playbook is provided. This test creates temporary files with varying ages and verifies that only the 'old' files are removed.
+
+```bash
+ansible-playbook -i tests/inventory_test.ini tests/test_dust_bunny_sweeper.yml
+```
+
+## Contributing
+
+Feel free to suggest improvements or add more sophisticated cleanup rules. Let's keep our digital spaces sparkling clean!

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/dust_bunny_sweeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/dust_bunny_sweeper.yml
@@ -1,0 +1,47 @@
+---
+- name: Sweep Digital Dust Bunnies
+  hosts: all
+  gather_facts: no
+  vars_files:
+    - ../vars/cleanup_config.yml
+
+  tasks:
+    - name: Ensure cleanup paths exist (idempotent)
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: '0755'
+      loop: "{{ cleanup_paths }}"
+      become: yes
+
+    - name: Find old files (dust bunnies)
+      ansible.builtin.find:
+        paths: "{{ item }}"
+        age: "{{ cleanup_age_days }}d"
+        recurse: yes
+        file_type: file
+      register: old_files_result
+      loop: "{{ cleanup_paths }}"
+      loop_control:
+        loop_var: item
+      become: yes
+
+    - name: Debug found files
+      ansible.builtin.debug:
+        msg: "Found {{ item.files | length }} old files in {{ item.path }}: {{ item.files | map(attribute='path') | list }}"
+      loop: "{{ old_files_result.results }}"
+      when: item.files | length > 0
+
+    - name: Remove old files
+      ansible.builtin.file:
+        path: "{{ file.path }}"
+        state: absent
+      loop: "{{ old_files_result.results | map(attribute='files') | flatten }}"
+      loop_control:
+        loop_var: file
+      when: old_files_result.results is defined and file.path is defined
+      become: yes
+
+    - name: Report cleanup summary
+      ansible.builtin.debug:
+        msg: "Digital Dust Bunny Sweeper completed. Removed {{ (old_files_result.results | map(attribute='files') | flatten) | length }} files."

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/inventory.ini
@@ -1,0 +1,5 @@
+[servers]
+localhost ansible_connection=local
+# Add your remote servers here:
+# server1.example.com
+# server2.example.com

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/inventory_test.ini
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/inventory_test.ini
@@ -1,0 +1,2 @@
+[test_servers]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/test_dust_bunny_sweeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/test_dust_bunny_sweeper.yml
@@ -1,0 +1,108 @@
+---
+- name: Test Digital Dust Bunny Sweeper
+  hosts: test_servers
+  gather_facts: no
+  vars:
+    test_base_path: "/tmp/ansible_test_dust_bunnies"
+    test_cleanup_paths:
+      - "{{ test_base_path }}/path1"
+      - "{{ test_base_path }}/path2"
+
+  tasks:
+    - name: Ensure test base path exists
+      ansible.builtin.file:
+        path: "{{ test_base_path }}"
+        state: directory
+        mode: '0777'
+      become: yes
+
+    - name: Clean up previous test runs
+      ansible.builtin.file:
+        path: "{{ test_base_path }}"
+        state: absent
+      become: yes
+      ignore_errors: yes # In case it doesn't exist
+
+    - name: Re-create test base path
+      ansible.builtin.file:
+        path: "{{ test_base_path }}"
+        state: directory
+        mode: '0777'
+      become: yes
+
+    - name: Create test cleanup paths
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: '0777'
+      loop: "{{ test_cleanup_paths }}"
+      become: yes
+
+    - name: Create an old file in path1
+      ansible.builtin.command: "touch -d '2 days ago' {{ test_cleanup_paths[0] }}/old_file.txt"
+      args:
+        creates: "{{ test_cleanup_paths[0] }}/old_file.txt"
+      become: yes
+      # Mock rationale: Simulates an old file that should be cleaned by setting its modification time to 2 days ago.
+
+    - name: Create a recent file in path1
+      ansible.builtin.command: "touch {{ test_cleanup_paths[0] }}/recent_file.txt"
+      args:
+        creates: "{{ test_cleanup_paths[0] }}/recent_file.txt"
+      become: yes
+      # Mock rationale: Simulates a recent file that should NOT be cleaned, as its modification time is current.
+
+    - name: Create an old file in path2
+      ansible.builtin.command: "touch -d '2 days ago' {{ test_cleanup_paths[1] }}/another_old_file.log"
+      args:
+        creates: "{{ test_cleanup_paths[1] }}/another_old_file.log"
+      become: yes
+      # Mock rationale: Simulates another old file.
+
+    - name: Run the main dust bunny sweeper playbook with test variables
+      ansible.builtin.include_tasks: ../src/dust_bunny_sweeper.yml
+      vars:
+        cleanup_paths: "{{ test_cleanup_paths }}"
+        cleanup_age_days: 1 # Files older than 1 day should be removed for this test
+
+    - name: Verify old_file.txt is absent
+      ansible.builtin.stat:
+        path: "{{ test_cleanup_paths[0] }}/old_file.txt"
+      register: old_file_stat
+      become: yes
+
+    - name: Assert old_file.txt is gone
+      ansible.builtin.assert:
+        that:
+          - not old_file_stat.stat.exists
+        fail_msg: "old_file.txt was not removed!"
+
+    - name: Verify recent_file.txt is present
+      ansible.builtin.stat:
+        path: "{{ test_cleanup_paths[0] }}/recent_file.txt"
+      register: recent_file_stat
+      become: yes
+
+    - name: Assert recent_file.txt is still there
+      ansible.builtin.assert:
+        that:
+          - recent_file_stat.stat.exists
+        fail_msg: "recent_file.txt was unexpectedly removed!"
+
+    - name: Verify another_old_file.log is absent
+      ansible.builtin.stat:
+        path: "{{ test_cleanup_paths[1] }}/another_old_file.log"
+      register: another_old_file_stat
+      become: yes
+
+    - name: Assert another_old_file.log is gone
+      ansible.builtin.assert:
+        that:
+          - not another_old_file_stat.stat.exists
+        fail_msg: "another_old_file.log was not removed!"
+
+    - name: Clean up test artifacts
+      ansible.builtin.file:
+        path: "{{ test_base_path }}"
+        state: absent
+      become: yes

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/vars/cleanup_config.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/vars/cleanup_config.yml
@@ -1,0 +1,6 @@
+---
+cleanup_paths:
+  - "/tmp/digital_dust"
+  - "/var/log/archive"
+  - "/var/cache/old_packages"
+cleanup_age_days: 30 # Files older than this will be removed


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-digital-dust-bunny-sweeper
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8`
- **Files Created**: 6
- **Description**: An Ansible playbook to sweep away digital dust bunnies (old, temporary, or unused files) from remote servers, keeping them tidy.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.