### PR TITLE
feat(groq): Terraform module that creates an encrypted, versioned S3 bucket with strict public‑access blocking.

### DIFF
--- a/terraform-modules/nightly-nightly-terraform-aws-s3-buc/terraform-modules/nightly-terraform-aws-s3-bucket/README.md
+++ b/terraform-modules/nightly-nightly-terraform-aws-s3-buc/terraform-modules/nightly-terraform-aws-s3-bucket/README.md
@@ -1,0 +1,56 @@
+# nightly-terraform-aws-s3-bucket
+
+## Overview
+
+A tiny, opinionated Terraform module that provisions an Amazon S3 bucket with:
+
+* Server‑side encryption (AES‑256)
+* Versioning (enabled by default)
+* Strict public‑access block settings
+* Optional force‑destroy and custom tags
+
+The module is deliberately simple so it can be dropped into any Terraform configuration.
+
+## Usage
+
+```hcl
+module "my_bucket" {
+  source = "./terraform-modules/nightly-terraform-aws-s3-bucket"
+
+  bucket_name        = "my‑awesome‑bucket"
+  force_destroy      = false
+  versioning_enabled = true
+  tags = {
+    Environment = "dev"
+    Owner       = "apocalypsai"
+  }
+}
+```
+
+## Variables
+
+| Name                | Type          | Default | Description |
+|---------------------|---------------|---------|-------------|
+| `bucket_name`       | `string`      | n/a     | Name of the S3 bucket |
+| `force_destroy`     | `bool`        | `false` | Allow bucket to be destroyed even if it contains objects |
+| `versioning_enabled`| `bool`        | `true`  | Enable versioning |
+| `tags`              | `map(string)` | `{}`    | Tags to apply |
+
+## Outputs
+
+| Name          | Description |
+|---------------|-------------|
+| `bucket_id`   | The ID of the bucket |
+| `bucket_arn`  | The ARN of the bucket |
+| `bucket_region`| The region of the bucket |
+
+## Testing
+
+A lightweight shell test lives in `tests/validate.sh`. Run it with:
+
+```bash
+cd terraform-modules/nightly-terraform-aws-s3-bucket
+bash tests/validate.sh
+```
+
+The test simply verifies that the expected resources are present in `main.tf`.

--- a/terraform-modules/nightly-nightly-terraform-aws-s3-buc/terraform-modules/nightly-terraform-aws-s3-bucket/main.tf
+++ b/terraform-modules/nightly-nightly-terraform-aws-s3-buc/terraform-modules/nightly-terraform-aws-s3-bucket/main.tf
@@ -1,0 +1,34 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+
+  force_destroy = var.force_destroy
+
+  tags = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status = var.versioning_enabled ? "Enabled" : "Suspended"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls  = true
+  restrict_public_buckets = true
+}

--- a/terraform-modules/nightly-nightly-terraform-aws-s3-buc/terraform-modules/nightly-terraform-aws-s3-bucket/outputs.tf
+++ b/terraform-modules/nightly-nightly-terraform-aws-s3-buc/terraform-modules/nightly-terraform-aws-s3-bucket/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_id" {
+  description = "The ID of the S3 bucket"
+  value       = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the S3 bucket"
+  value       = aws_s3_bucket.this.arn
+}
+
+output "bucket_region" {
+  description = "The region of the S3 bucket"
+  value       = aws_s3_bucket.this.region
+}

--- a/terraform-modules/nightly-nightly-terraform-aws-s3-buc/terraform-modules/nightly-terraform-aws-s3-bucket/tests/validate.sh
+++ b/terraform-modules/nightly-nightly-terraform-aws-s3-buc/terraform-modules/nightly-terraform-aws-s3-bucket/tests/validate.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+# Mock rationale: Ensure required resources are defined in main.tf
+required=("aws_s3_bucket.this" "aws_s3_bucket_versioning.this" "aws_s3_bucket_server_side_encryption_configuration.this" "aws_s3_bucket_public_access_block.this")
+
+for r in "${required[@]}"; do
+  if ! grep -q "$r" "$(dirname "$0")/../main.tf"; then
+    echo "Missing resource $r"
+    exit 1
+  fi
+done
+
+echo "All required resources present."

--- a/terraform-modules/nightly-nightly-terraform-aws-s3-buc/terraform-modules/nightly-terraform-aws-s3-bucket/variables.tf
+++ b/terraform-modules/nightly-nightly-terraform-aws-s3-buc/terraform-modules/nightly-terraform-aws-s3-bucket/variables.tf
@@ -1,0 +1,22 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "force_destroy" {
+  description = "Whether to allow force destroy of the bucket"
+  type        = bool
+  default     = false
+}
+
+variable "versioning_enabled" {
+  description = "Enable versioning"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to apply to the bucket"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-terraform-aws-s3-bucket
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-terraform-aws-s3-buc`
- **Files Created**: 5
- **Description**: Terraform module that creates an encrypted, versioned S3 bucket with strict public‑access blocking.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-terraform-aws-s3-buc`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-terraform-aws-s3-buc/README.md`
- Run tests located in `terraform-modules/nightly-nightly-terraform-aws-s3-buc/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.