### PR TITLE
feat(groq): Terraform module that provisions a versioned, encrypted S3 bucket with a 30‑day lifecycle for post‑apocalyptic safe‑house supplies

### DIFF
--- a/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
@@ -1,0 +1,32 @@
+Nightly Safehouse S3 Terraform Module
+
+This module creates an AWS S3 bucket configured for a post‑apocalyptic safe‑house:
+  * Versioning enabled so you never lose a supply list
+  * Server‑side encryption (AES‑256) for data at rest
+  * Lifecycle rule that expires objects older than 30 days (to keep the bucket tidy)
+  * Optional tags for cost allocation
+
+Usage:
+  1. Add the module to your Terraform configuration:
+     module "safehouse" {
+       source      = "./terraform-modules/nightly-safehouse-s3"
+       bucket_name = "my‑safehouse‑supplies"
+       tags = {
+         Environment = "post‑apocalypse"
+         Owner       = "survivors"
+       }
+     }
+
+  2. Run the usual Terraform workflow:
+     terraform init -backend=false
+     terraform apply -auto-approve
+
+Variables:
+  bucket_name (string, required) – Name of the S3 bucket. Must be globally unique.
+  tags        (map(string), optional) – Key/value pairs to tag the bucket.
+
+Outputs:
+  bucket_id  – The ID of the created bucket.
+  bucket_arn – The ARN of the created bucket.
+
+The module does not create any IAM policies; you must grant the necessary permissions to the executing role.

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/main.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  # Configuration is expected to be supplied via environment variables or shared credentials.
+}
+
+resource "aws_s3_bucket" "safehouse" {
+  bucket = var.bucket_name
+  tags   = var.tags
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "expire-old-supplies"
+    enabled = true
+    expiration {
+      days = 30
+    }
+    filter {}
+  }
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/outputs.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_id" {
+  description = "The ID of the created S3 bucket"
+  value       = aws_s3_bucket.safehouse.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the created S3 bucket"
+  value       = aws_s3_bucket.safehouse.arn
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/tests/test_module.sh
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/tests/test_module.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Test script for nightly-safehouse-s3 Terraform module
+# Mock rationale: The test runs entirely offline, checking that the expected
+# resources and configurations are present in the Terraform files.
+
+set -euo pipefail
+
+# Helper to assert a pattern exists in a file
+assert_in_file() {
+  local pattern=$1
+  local file=$2
+  if ! grep -qE "$pattern" "$file"; then
+    echo "FAIL: Expected pattern '$pattern' not found in $file"
+    exit 1
+  fi
+}
+
+# 1. Verify required provider block exists
+assert_in_file "required_providers\s*{[^}]*aws" "main.tf"
+
+# 2. Verify S3 bucket resource name and versioning enabled
+assert_in_file "resource \"aws_s3_bucket\" \"safehouse\"" "main.tf"
+assert_in_file "versioning \{[^}]*enabled\s*=\s*true" "main.tf"
+
+# 3. Verify server‑side encryption configuration
+assert_in_file "sse_algorithm\s*=\s*\"AES256\"" "main.tf"
+
+# 4. Verify lifecycle rule with 30‑day expiration
+assert_in_file "expiration \{[^}]*days\s*=\s*30" "main.tf"
+
+# 5. Verify variables are declared
+assert_in_file "variable \"bucket_name\"" "variables.tf"
+assert_in_file "variable \"tags\"" "variables.tf"
+
+# 6. Verify outputs are defined
+assert_in_file "output \"bucket_id\"" "outputs.tf"
+assert_in_file "output \"bucket_arn\"" "outputs.tf"
+
+echo "PASS: All checks passed for nightly-safehouse-s3 module"

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/variables.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/variables.tf
@@ -1,0 +1,10 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket (must be globally unique)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Optional tags to assign to the bucket"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-safehouse-s3
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-safehouse-s3-8`
- **Files Created**: 5
- **Description**: Terraform module that provisions a versioned, encrypted S3 bucket with a 30‑day lifecycle for post‑apocalyptic safe‑house supplies

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-safehouse-s3-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-safehouse-s3-8/README.md`
- Run tests located in `terraform-modules/nightly-nightly-safehouse-s3-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.