### PR TITLE
feat(groq): Encode text into a QR code displayed as ASCII art via a fast Rust CLI.

### DIFF
--- a/rust-utils/nightly-nightly-cryptic-qr-encoder-3/Cargo.toml
+++ b/rust-utils/nightly-nightly-cryptic-qr-encoder-3/Cargo.toml
@@ -1,0 +1,1 @@
+[package]\nname = "nightly-cryptic-qr-encoder"\nversion = "0.1.0"\nedition = "2021"\n\n[dependencies]\nqrcode = "0.13"

--- a/rust-utils/nightly-nightly-cryptic-qr-encoder-3/README.md
+++ b/rust-utils/nightly-nightly-cryptic-qr-encoder-3/README.md
@@ -1,0 +1,1 @@
+# nightly-cryptic-qr-encoder\n\nEncode a short string into a QR code rendered as ASCII art.\n\n## Usage\n\n```sh\ncargo run --quiet -- "HELLO"\n```\n\nOutputs QR code.\n\n## Build\n\n```sh\ncargo build --release\n```\n\n## Test\n\n```sh\ncargo test\n```

--- a/rust-utils/nightly-nightly-cryptic-qr-encoder-3/src/lib.rs
+++ b/rust-utils/nightly-nightly-cryptic-qr-encoder-3/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn encode_to_ascii(text: &str) -> String {\n    let code = qrcode::QrCode::new(text.as_bytes()).unwrap();\n    code.render::<qrcode::render::unicode::Dense1x2>()\n        .quiet_zone(false)\n        .build()\n}

--- a/rust-utils/nightly-nightly-cryptic-qr-encoder-3/src/main.rs
+++ b/rust-utils/nightly-nightly-cryptic-qr-encoder-3/src/main.rs
@@ -1,0 +1,1 @@
+use std::env;\nuse nightly_cryptic_qr_encoder::encode_to_ascii;\n\nfn main() {\n    let args: Vec<String> = env::args().collect();\n    if args.len() != 2 {\n        eprintln!("Usage: {} <text>", args[0]);\n        std::process::exit(1);\n    }\n    let output = encode_to_ascii(&args[1]);\n    println!("{}", output);\n}

--- a/rust-utils/nightly-nightly-cryptic-qr-encoder-3/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-cryptic-qr-encoder-3/tests/test_main.rs
@@ -1,0 +1,1 @@
+use nightly_cryptic_qr_encoder::encode_to_ascii;\n\n#[test]\nfn test_encode_hello() {\n    let ascii = encode_to_ascii("HELLO");\n    assert!(ascii.contains("██"));\n    assert!(!ascii.is_empty());\n}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-cryptic-qr-encoder
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-cryptic-qr-encoder-3`
- **Files Created**: 5
- **Description**: Encode text into a QR code displayed as ASCII art via a fast Rust CLI.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-cryptic-qr-encoder-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-cryptic-qr-encoder-3/README.md`
- Run tests located in `rust-utils/nightly-nightly-cryptic-qr-encoder-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.