### PR TITLE
feat(gemini): Provisions an ephemeral AWS S3 bucket for secure, temporary message drops, with automatic deletion after a configurable duration.

### DIFF
--- a/terraform-modules/nightly-nightly-cloud-message-bottle/README.md
+++ b/terraform-modules/nightly-nightly-cloud-message-bottle/README.md
@@ -1,0 +1,78 @@
+# Nightly Cloud Message Bottle
+
+This Terraform module provisions an ephemeral AWS S3 bucket designed for secure, temporary message drops or small file transfers. Think of it as a digital message in a bottle, floating in the cloud, that automatically vanishes after a set period.
+
+It's ideal for:
+- Sharing sensitive, short-lived information between trusted parties.
+- Temporary data exchange in automated workflows.
+- A whimsical, self-cleaning cache for post-apocalyptic communiques.
+
+## Features
+
+- **Ephemeral Storage**: Objects are automatically deleted after a configurable number of days (default: 1 day).
+- **Secure by Default**: Uses AWS S3 managed encryption (SSE-S3) and is private by default.
+- **Simple Interface**: Easy to integrate into your existing Terraform configurations.
+
+## Usage
+
+To use this module, include it in your Terraform configuration:
+
+```terraform
+module "message_bottle" {
+  source = "./nightly-cloud-message-bottle" # Adjust path if using from a different location
+
+  bucket_name_prefix = "apocalypsai-message-drop"
+  expiration_days    = 3 # Messages last for 3 days
+  tags = {
+    Project     = "ApocalypsAI"
+    Environment = "Ephemeral"
+    Purpose     = "MessageBottle"
+  }
+}
+
+output "message_bottle_bucket_name" {
+  description = "The name of the ephemeral S3 bucket."
+  value       = module.message_bottle.bucket_id
+}
+
+output "message_bottle_bucket_arn" {
+  description = "The ARN of the ephemeral S3 bucket."
+  value       = module.message_bottle.bucket_arn
+}
+```
+
+## Inputs
+
+| Name                 | Description                                                                 | Type          | Default     | Required |
+|----------------------|-----------------------------------------------------------------------------|---------------|-------------|----------|
+| `bucket_name_prefix` | A unique prefix for the S3 bucket name. The module will append a random suffix. | `string`      | `""`        | yes      |
+| `expiration_days`    | Number of days after which objects in the bucket will be automatically deleted. | `number`      | `1`         | no       |
+| `tags`               | A map of tags to assign to the S3 bucket.                                   | `map(string)` | `{}`        | no       |
+
+## Outputs
+
+| Name                     | Description                               |
+|--------------------------|-------------------------------------------|
+| `bucket_id`              | The ID (name) of the created S3 bucket.   |
+| `bucket_arn`             | The ARN of the created S3 bucket.         |
+| `bucket_domain_name`     | The domain name of the created S3 bucket. |
+
+## Requirements
+
+- Terraform `~> 1.0`
+- AWS Provider `~> 4.0`
+- Configured AWS credentials (e.g., via environment variables, `~/.aws/credentials`, or IAM role).
+
+## Development & Testing
+
+To test this module locally:
+
+1. Navigate to the `tests/` directory.
+2. Run `terraform init`.
+3. Run `terraform plan`. This will show you the resources that would be created without actually provisioning them.
+   ```bash
+   cd tests
+   terraform init
+   terraform plan
+   ```
+   Verify that the plan shows the creation of an `aws_s3_bucket` resource with the expected lifecycle rules and tags.

--- a/terraform-modules/nightly-nightly-cloud-message-bottle/src/main.tf
+++ b/terraform-modules/nightly-nightly-cloud-message-bottle/src/main.tf
@@ -1,0 +1,62 @@
+resource "random_string" "bucket_suffix" {
+  length  = 8
+  special = false
+  upper   = false
+  numeric = true
+}
+
+resource "aws_s3_bucket" "message_bottle" {
+  bucket = "${var.bucket_name_prefix}-${random_string.bucket_suffix.result}"
+
+  tags = merge(
+    var.tags,
+    {
+      "ManagedBy" = "ApocalypsAI-NightlyIntegrator"
+      "Purpose"   = "EphemeralMessageBottle"
+    }
+  )
+}
+
+resource "aws_s3_bucket_acl" "message_bottle_acl" {
+  bucket = aws_s3_bucket.message_bottle.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "message_bottle_versioning" {
+  bucket = aws_s3_bucket.message_bottle.id
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "message_bottle_encryption" {
+  bucket = aws_s3_bucket.message_bottle.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "message_bottle_lifecycle" {
+  bucket = aws_s3_bucket.message_bottle.id
+
+  rule {
+    id     = "expire_objects"
+    status = "Enabled"
+
+    expiration {
+      days = var.expiration_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "message_bottle_public_access_block" {
+  bucket = aws_s3_bucket.message_bottle.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/terraform-modules/nightly-nightly-cloud-message-bottle/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-cloud-message-bottle/src/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_id" {
+  description = "The ID (name) of the created S3 bucket."
+  value       = aws_s3_bucket.message_bottle.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the created S3 bucket."
+  value       = aws_s3_bucket.message_bottle.arn
+}
+
+output "bucket_domain_name" {
+  description = "The domain name of the created S3 bucket."
+  value       = aws_s3_bucket.message_bottle.bucket_domain_name
+}

--- a/terraform-modules/nightly-nightly-cloud-message-bottle/src/variables.tf
+++ b/terraform-modules/nightly-nightly-cloud-message-bottle/src/variables.tf
@@ -1,0 +1,20 @@
+variable "bucket_name_prefix" {
+  description = "A unique prefix for the S3 bucket name. A random suffix will be appended."
+  type        = string
+}
+
+variable "expiration_days" {
+  description = "Number of days after which objects in the bucket will be automatically deleted."
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.expiration_days >= 1
+    error_message = "Expiration days must be at least 1."
+  }
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the S3 bucket."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform-modules/nightly-nightly-cloud-message-bottle/src/versions.tf
+++ b/terraform-modules/nightly-nightly-cloud-message-bottle/src/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/terraform-modules/nightly-nightly-cloud-message-bottle/tests/test.tf
+++ b/terraform-modules/nightly-nightly-cloud-message-bottle/tests/test.tf
@@ -1,0 +1,32 @@
+# Mock rationale: This test configuration uses the module and runs 'terraform plan'
+# to verify the module's syntax and expected resource creation without
+# actually provisioning AWS resources. The AWS provider is configured minimally
+# to allow 'terraform init' and 'terraform plan' to succeed without
+# requiring actual credentials for the plan phase.
+
+provider "aws" {
+  region = "us-east-1" # A default region is needed for the provider, but no actual API calls are made during 'plan'.
+}
+
+module "test_message_bottle" {
+  source = "../src" # Path to the module under test
+
+  bucket_name_prefix = "test-apocalypsai-bottle"
+  expiration_days    = 2 # Test with 2 days expiration
+  tags = {
+    TestEnv = "True"
+    Module  = "CloudMessageBottle"
+  }
+}
+
+output "test_bucket_id" {
+  value = module.test_message_bottle.bucket_id
+}
+
+output "test_bucket_arn" {
+  value = module.test_message_bottle.bucket_arn
+}
+
+output "test_bucket_domain_name" {
+  value = module.test_message_bottle.bucket_domain_name
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-cloud-message-bottle
- **Provider**: gemini
- **Location**: `terraform-modules/nightly-nightly-cloud-message-bottle`
- **Files Created**: 6
- **Description**: Provisions an ephemeral AWS S3 bucket for secure, temporary message drops, with automatic deletion after a configurable duration.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-cloud-message-bottle`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-cloud-message-bottle/README.md`
- Run tests located in `terraform-modules/nightly-nightly-cloud-message-bottle/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.