### PR TITLE
feat(groq): Generates a blue‑colored ASCII QR code for any text, perfect for wasteland terminals.

### DIFF
--- a/rust-utils/nightly-nightly-postapoc-qr-generato/rust-utils/nightly-postapoc-qr-generator/Cargo.toml
+++ b/rust-utils/nightly-nightly-postapoc-qr-generato/rust-utils/nightly-postapoc-qr-generator/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "postapoc-qr-generator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.2", features = ["derive"] }
+qrcode = "0.12"
+colored = "2.0"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "2.1"

--- a/rust-utils/nightly-nightly-postapoc-qr-generato/rust-utils/nightly-postapoc-qr-generator/README.md
+++ b/rust-utils/nightly-nightly-postapoc-qr-generato/rust-utils/nightly-postapoc-qr-generator/README.md
@@ -1,0 +1,23 @@
+# Post-Apocalyptic QR Generator
+
+Generate an ASCII QR code that looks like it was printed on a battered terminal in the wasteland.
+
+## Usage
+
+```sh
+cargo run -- "Your secret message"
+```
+
+The program will output a blue‑colored QR code made of block characters.
+
+## Build
+
+```sh
+cargo build --release
+```
+
+## Test
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-postapoc-qr-generato/rust-utils/nightly-postapoc-qr-generator/src/main.rs
+++ b/rust-utils/nightly-nightly-postapoc-qr-generato/rust-utils/nightly-postapoc-qr-generator/src/main.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+use qrcode::QrCode;
+use qrcode::render::unicode;
+use colored::*;
+
+/// Post-apocalyptic ASCII QR code generator
+#[derive(Parser)]
+#[command(author, version, about = "Generate an ASCII QR code for the wasteland")]
+struct Args {
+    /// Text to encode into the QR code
+    #[arg()]
+    text: String,
+}
+
+fn main() {
+    let args = Args::parse();
+    let code = QrCode::new(args.text).expect("Failed to generate QR code");
+    let qr_string = code
+        .render::<unicode::Dense1x2>()
+        .dark_color("\u{2588}\u{2588}")
+        .light_color("  ")
+        .build();
+    println!("{}", qr_string.blue());
+}

--- a/rust-utils/nightly-nightly-postapoc-qr-generato/rust-utils/nightly-postapoc-qr-generator/tests/test_cli.rs
+++ b/rust-utils/nightly-nightly-postapoc-qr-generato/rust-utils/nightly-postapoc-qr-generator/tests/test_cli.rs
@@ -1,0 +1,11 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+
+#[test]
+fn test_help_output() {
+    let mut cmd = Command::cargo_bin("postapoc-qr-generator").unwrap();
+    cmd.arg("--help");
+    cmd.assert()
+        .success()
+        .stdout(contains("Generate an ASCII QR code for the wasteland"));
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-postapoc-qr-generator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-postapoc-qr-generato`
- **Files Created**: 4
- **Description**: Generates a blue‑colored ASCII QR code for any text, perfect for wasteland terminals.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-postapoc-qr-generato`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-postapoc-qr-generato/README.md`
- Run tests located in `rust-utils/nightly-nightly-postapoc-qr-generato/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.