### PR TITLE
feat(groq): A whimsical Rust CLI that suggests post‑apocalyptic garden plants based on radiation levels.

### DIFF
--- a/rust-utils/nightly-nightly-radiation-garden/Cargo.toml
+++ b/rust-utils/nightly-nightly-radiation-garden/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "nightly-radiation-garden"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.4", features = ["derive"] }

--- a/rust-utils/nightly-nightly-radiation-garden/README.md
+++ b/rust-utils/nightly-nightly-radiation-garden/README.md
@@ -1,0 +1,47 @@
+# nightly‑radiation‑garden
+
+**A whimsical Rust CLI for post‑apocalyptic gardeners**
+
+When the world has gone a little radioactive, you still want fresh veggies. This tool takes a location name and a radiation level (`low`, `medium`, or `high`) and prints a short list of plants that are likely to survive.
+
+## Installation
+
+```bash
+# Ensure you have Rust installed (https://rustup.rs)
+git clone https://github.com/polsala/ApocalypsAI.git
+cd utils/nightly-radiation-garden
+cargo build --release
+```
+
+The binary will be at `target/release/nightly-radiation-garden`.
+
+## Usage
+
+```bash
+./target/release/nightly-radiation-garden "Wasteland Outpost" high
+```
+
+Output example:
+
+```
+Location: Wasteland Outpost
+Radiation level: high
+Recommended plants:
+ - Radish (tolerates high radiation)
+ - Sunflower (absorbs contaminants)
+ - Kale (hardy leafy green)
+```
+
+## How it works
+
+The program contains a tiny hard‑coded lookup table mapping radiation levels to a few hardy plants. It is deliberately simple – the goal is to be a fun, self‑contained example of a Rust CLI utility.
+
+## Testing
+
+Run the test suite with:
+
+```bash
+cargo test
+```
+
+All tests are deterministic and run offline.

--- a/rust-utils/nightly-nightly-radiation-garden/src/main.rs
+++ b/rust-utils/nightly-nightly-radiation-garden/src/main.rs
@@ -1,0 +1,42 @@
+use clap::Parser;
+
+/// Simple mapping of radiation levels to hardy plants.
+static PLANT_MAP: phf::Map<&'static str, &'static [&'static str]> = phf::phf_map! {
+    "low" => &["Tomato", "Lettuce", "Carrot"],
+    "medium" => &["Radish", "Sunflower", "Kale"],
+    "high" => &["Radish", "Sunflower", "Kale"],
+};
+
+/// Command‑line arguments.
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Post‑apocalyptic garden planner", long_about = None)]
+struct Args {
+    /// Name of the location (e.g., "Wasteland Outpost")
+    location: String,
+    /// Radiation level: low, medium, or high
+    #[arg(value_parser = validate_radiation)]
+    radiation: String,
+}
+
+fn validate_radiation(s: &str) -> Result<String, String> {
+    let lower = s.to_lowercase();
+    match lower.as_str() {
+        "low" | "medium" | "high" => Ok(lower),
+        _ => Err(format!("Invalid radiation level '{}'. Use low, medium, or high.", s)),
+    }
+}
+
+fn recommend_plants(radiation: &str) -> &'static [&'static str] {
+    PLANT_MAP.get(radiation).copied().unwrap_or(&[])
+}
+
+fn main() {
+    let args = Args::parse();
+    let plants = recommend_plants(&args.radiation);
+    println!("Location: {}", args.location);
+    println!("Radiation level: {}", args.radiation);
+    println!("Recommended plants:");
+    for plant in plants {
+        println!(" - {}", plant);
+    }
+}

--- a/rust-utils/nightly-nightly-radiation-garden/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-radiation-garden/tests/test_main.rs
@@ -1,0 +1,28 @@
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+
+    #[test]
+    fn test_low_radiation() {
+        let plants = recommend_plants("low");
+        assert_eq!(plants, &["Tomato", "Lettuce", "Carrot"]);
+    }
+
+    #[test]
+    fn test_medium_radiation() {
+        let plants = recommend_plants("medium");
+        assert_eq!(plants, &["Radish", "Sunflower", "Kale"]);
+    }
+
+    #[test]
+    fn test_high_radiation() {
+        let plants = recommend_plants("high");
+        assert_eq!(plants, &["Radish", "Sunflower", "Kale"]);
+    }
+
+    #[test]
+    fn test_invalid_radiation_returns_empty() {
+        let plants = recommend_plants("unknown");
+        assert!(plants.is_empty());
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-radiation-garden
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-radiation-garden`
- **Files Created**: 4
- **Description**: A whimsical Rust CLI that suggests post‑apocalyptic garden plants based on radiation levels.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-radiation-garden`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-radiation-garden/README.md`
- Run tests located in `rust-utils/nightly-nightly-radiation-garden/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.