### PR TITLE
feat(groq): An Ansible playbook that mirrors a remote APT repository to a local directory for offline package installs.

### DIFF
--- a/ansible-playbooks/nightly-nightly-ansible-apt-repo-mir/ansible-playbooks/nightly-ansible-apt-repo-mirror/README.md
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-repo-mir/ansible-playbooks/nightly-ansible-apt-repo-mirror/README.md
@@ -1,0 +1,60 @@
+# nightly-ansible-apt-repo-mirror
+
+## Overview
+
+`nightly-ansible-apt-repo-mirror` is a whimsical yet practical Ansible playbook that synchronises a remote Debian/Ubuntu APT repository to a local directory.  This enables teams to create an offline package cache – perfect for post‑apocalypse environments, CI runners without internet access, or simply speeding up repeated installations.
+
+## Features
+
+- Idempotent: creates the target directory only if it does not exist.
+- Uses `rsync` (or any command you prefer) to mirror the repository.
+- Supports custom mirror URLs and destination paths via extra variables.
+- Dry‑run (`--check`) safe – no files are created during testing.
+
+## Requirements
+
+- Ansible 2.9+ installed on the control node.
+- `rsync` available on the target host (the host where the mirror will be stored).
+
+## Usage
+
+```bash
+# Clone the repository (or copy the folder into your own playbooks directory)
+git clone https://github.com/polsala/ApocalypsAI.git
+cd ansible-playbooks/nightly-ansible-apt-repo-mirror
+
+# Run the playbook (replace variables as needed)
+ansible-playbook -i inventory.ini src/main.yml \
+  -e "mirror_url=http://archive.ubuntu.com/ubuntu" \
+  -e "local_path=/opt/apt-mirror"
+```
+
+### Dry‑run (check mode)
+
+```bash
+ansible-playbook -i inventory.ini src/main.yml \
+  -e "mirror_url=http://archive.ubuntu.com/ubuntu" \
+  -e "local_path=/opt/apt-mirror" \
+  --check
+```
+
+The dry‑run will report what would happen without actually creating directories or transferring data.
+
+## Inventory
+
+A minimal `inventory.ini` is provided that targets `localhost` for quick testing:
+
+```ini
+[local]
+localhost ansible_connection=local
+```
+
+## Testing
+
+Automated tests are located in the `tests/` directory and can be executed with:
+
+```bash
+ansible-playbook -i inventory.ini tests/test_playbook.yml --check
+```
+
+The test ensures the playbook runs in check mode without side‑effects.

--- a/ansible-playbooks/nightly-nightly-ansible-apt-repo-mir/ansible-playbooks/nightly-ansible-apt-repo-mirror/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-repo-mir/ansible-playbooks/nightly-ansible-apt-repo-mirror/inventory.ini
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-ansible-apt-repo-mir/ansible-playbooks/nightly-ansible-apt-repo-mirror/src/main.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-repo-mir/ansible-playbooks/nightly-ansible-apt-repo-mirror/src/main.yml
@@ -1,0 +1,28 @@
+- hosts: all
+  become: true
+  vars:
+    # URL of the remote APT repository (e.g., http://archive.ubuntu.com/ubuntu)
+    mirror_url: "{{ mirror_url | default('http://archive.ubuntu.com/ubuntu') }}"
+    # Local directory where the mirror will be stored
+    local_path: "{{ local_path | default('/var/local/apt-mirror') }}"
+  tasks:
+    - name: Ensure local mirror directory exists
+      file:
+        path: "{{ local_path }}"
+        state: directory
+        mode: "0755"
+
+    - name: Sync APT repository using rsync
+      # rsync works with HTTP/HTTPS sources when the remote side supports it.
+      # For pure HTTP mirrors you may need to use `apt-mirror` instead.
+      command: >
+        rsync -a --delete {{ mirror_url }}/ {{ local_path }}/
+      args:
+        # Prevent execution in check mode; Ansible will skip the command when --check is used.
+        creates: "{{ local_path }}/dists"
+      register: rsync_result
+      changed_when: rsync_result.rc == 0
+
+    - name: Report rsync outcome
+      debug:
+        msg: "Rsync completed with return code {{ rsync_result.rc }}"

--- a/ansible-playbooks/nightly-nightly-ansible-apt-repo-mir/ansible-playbooks/nightly-ansible-apt-repo-mirror/tests/test_playbook.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-repo-mir/ansible-playbooks/nightly-ansible-apt-repo-mirror/tests/test_playbook.yml
@@ -1,0 +1,20 @@
+- hosts: localhost
+  gather_facts: false
+  vars:
+    # Use a dummy URL and a temporary path to avoid any real network traffic.
+    mirror_url: "http://example.com/apt"
+    local_path: "/tmp/apt-mirror-test"
+  tasks:
+    - name: Include the mirror playbook (will run in check mode)
+      import_playbook: "../src/main.yml"
+
+    - name: Verify that the target directory was NOT created (check mode should be dry‑run)
+      stat:
+        path: "{{ local_path }}"
+      register: dir_stat
+
+    - name: Assert directory does not exist after check mode run
+      assert:
+        that:
+          - dir_stat.stat.exists == false
+        fail_msg: "Directory {{ local_path }} should not exist when the playbook is executed with --check"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansible-apt-repo-mirror
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-ansible-apt-repo-mir`
- **Files Created**: 4
- **Description**: An Ansible playbook that mirrors a remote APT repository to a local directory for offline package installs.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-ansible-apt-repo-mir`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-ansible-apt-repo-mir/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-ansible-apt-repo-mir/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.