### PR TITLE
feat(groq): A tiny Go utility that concurrently measures TCP connection latency to a list of hosts and outputs a JSON summary.

### DIFF
--- a/go-utils/nightly-nightly-concurrent-ping-swee-5/README.md
+++ b/go-utils/nightly-nightly-concurrent-ping-swee-5/README.md
@@ -1,0 +1,30 @@
+Nightly Concurrent Ping Sweeper
+
+Overview:
+A lightweight Go tool that concurrently pings (via TCP connect) a list of host:port pairs and reports the latency in milliseconds. Useful for quick health‑checks of services in a micro‑service environment.
+
+Build & Run:
+
+    go build -o ping-sweeper ./src/main.go
+    ./ping-sweeper host1:80 host2:443 ...
+
+Or run directly with go run:
+
+    go run ./src/main.go host1:80 host2:443
+
+The program prints a pretty‑printed JSON array where each element contains the host, measured latency (ms), and an error field if the connection failed.
+
+Example output:
+
+    [
+      {
+        "host": "example.com:80",
+        "latency_ms": 23.4
+      },
+      {
+        "host": "unreachable.local:1234",
+        "error": "dial tcp 192.0.2.1:1234: connect: connection refused"
+      }
+    ]
+
+The concurrency level is capped at 10 simultaneous connections and each attempt times out after 2 seconds.

--- a/go-utils/nightly-nightly-concurrent-ping-swee-5/src/main.go
+++ b/go-utils/nightly-nightly-concurrent-ping-swee-5/src/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "net"
+    "os"
+    "sync"
+    "time"
+)
+
+type Result struct {
+    Host      string  `json:"host"`
+    LatencyMs float64 `json:"latency_ms,omitempty"`
+    Error     string  `json:"error,omitempty"`
+}
+
+// PingHost attempts a TCP connection to the given host within the timeout.
+// On success it returns the elapsed time in milliseconds; on failure it returns the error string.
+func PingHost(host string, timeout time.Duration) Result {
+    start := time.Now()
+    conn, err := net.DialTimeout("tcp", host, timeout)
+    if err != nil {
+        return Result{Host: host, Error: err.Error()}
+    }
+    conn.Close()
+    elapsed := time.Since(start).Seconds() * 1000
+    return Result{Host: host, LatencyMs: elapsed}
+}
+
+// PingHosts concurrently pings a slice of hosts respecting the concurrency limit.
+func PingHosts(hosts []string, timeout time.Duration, concurrency int) []Result {
+    var wg sync.WaitGroup
+    sem := make(chan struct{}, concurrency)
+    results := make([]Result, len(hosts))
+    for i, h := range hosts {
+        wg.Add(1)
+        go func(idx int, host string) {
+            defer wg.Done()
+            sem <- struct{}{}
+            results[idx] = PingHost(host, timeout)
+            <-sem
+        }(i, h)
+    }
+    wg.Wait()
+    return results
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("Usage: go run ./src/main.go host1:port [host2:port ...]")
+        os.Exit(1)
+    }
+    hosts := os.Args[1:]
+    timeout := 2 * time.Second
+    concurrency := 10
+    res := PingHosts(hosts, timeout, concurrency)
+    out, _ := json.MarshalIndent(res, "", "  ")
+    fmt.Println(string(out))
+}

--- a/go-utils/nightly-nightly-concurrent-ping-swee-5/tests/main_test.go
+++ b/go-utils/nightly-nightly-concurrent-ping-swee-5/tests/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+    "net"
+    "testing"
+    "time"
+)
+
+// startMockServer launches a TCP listener that accepts a connection,
+// sleeps for the specified delay, then closes the connection.
+// It returns the address (host:port) and a cleanup function.
+func startMockServer(t *testing.T, delay time.Duration) (string, func()) {
+    ln, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        t.Fatalf("failed to start mock server: %v", err)
+    }
+    go func() {
+        for {
+            conn, err := ln.Accept()
+            if err != nil {
+                return // listener closed
+            }
+            // Simulate processing delay then close.
+            time.Sleep(delay)
+            conn.Close()
+        }
+    }()
+    return ln.Addr().String(), func() { ln.Close() }
+}
+
+func TestPingHosts(t *testing.T) {
+    // Fast mock server (~50ms latency)
+    fastAddr, closeFast := startMockServer(t, 50*time.Millisecond)
+    defer closeFast()
+    // Slow mock server (~200ms latency)
+    slowAddr, closeSlow := startMockServer(t, 200*time.Millisecond)
+    defer closeSlow()
+    // Unreachable address (no server listening)
+    badAddr := "127.0.0.1:9" // commonly closed port
+
+    hosts := []string{fastAddr, slowAddr, badAddr}
+    results := PingHosts(hosts, 1*time.Second, 2)
+
+    // Fast host should have latency < 100ms and no error.
+    if results[0].Error != "" && results[0].LatencyMs > 100 {
+        t.Errorf("expected fast host latency <100ms, got %.2f ms, err: %s", results[0].LatencyMs, results[0].Error)
+    }
+    // Slow host should have latency roughly between 150ms and 300ms.
+    if results[1].Error != "" && (results[1].LatencyMs < 150 || results[1].LatencyMs > 300) {
+        t.Errorf("expected slow host latency ~200ms, got %.2f ms, err: %s", results[1].LatencyMs, results[1].Error)
+    }
+    // Bad host must report an error.
+    if results[2].Error == "" {
+        t.Errorf("expected error for unreachable host, got none")
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-concurrent-ping-sweeper
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-concurrent-ping-swee-5`
- **Files Created**: 3
- **Description**: A tiny Go utility that concurrently measures TCP connection latency to a list of hosts and outputs a JSON summary.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-concurrent-ping-swee-5`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-concurrent-ping-swee-5/README.md`
- Run tests located in `go-utils/nightly-nightly-concurrent-ping-swee-5/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.