### PR TITLE
feat(gemini): Provisions an ephemeral cloud storage bucket to capture fleeting temporal echoes, automatically purging them after a set duration.

### DIFF
--- a/terraform-modules/nightly-nightly-temporal-echo-chambe-3/README.md
+++ b/terraform-modules/nightly-nightly-temporal-echo-chambe-3/README.md
@@ -1,0 +1,85 @@
+# Nightly Temporal Echo Chamber Provisioner
+
+## Overview
+
+The `nightly-temporal-echo-chamber-prov` is a whimsical-yet-useful Terraform module designed to provision an ephemeral cloud storage bucket. This "Temporal Echo Chamber" is perfect for capturing fleeting data, logs, or any digital whispers that need to be stored temporarily before fading into the void. It automatically purges its contents after a configurable number of days, ensuring that no echo lingers longer than intended.
+
+## Features
+
+*   **Ephemeral Storage**: Provisions an AWS S3 bucket with a lifecycle policy for automatic object deletion.
+*   **Configurable Retention**: Easily set the number of days before echoes are purged.
+*   **Versioned**: S3 bucket versioning is enabled to ensure lifecycle rules apply correctly to all object versions.
+*   **Secure**: Private access control list by default.
+
+## Usage
+
+To use this module, you'll need Terraform installed and AWS credentials configured.
+
+1.  **Create a `main.tf` file** in your project directory:
+
+    ```terraform
+    provider "aws" {
+      region = "us-east-1" # Or your desired AWS region
+    }
+
+    module "my_echo_chamber" {
+      source = "./path/to/nightly-temporal-echo-chamber-prov/src"
+
+      prefix         = "my-apocalypsai-echo"
+      retention_days = 14 # Echoes will fade after 14 days
+      aws_region     = "us-east-1"
+    }
+
+    output "echo_chamber_name" {
+      value = module.my_echo_chamber.bucket_id
+    }
+
+    output "echo_chamber_arn" {
+      value = module.my_echo_chamber.bucket_arn
+    }
+    ```
+
+2.  **Initialize Terraform**:
+
+    ```bash
+    terraform init
+    ```
+
+3.  **Review the plan** (optional but recommended):
+
+    ```bash
+    terraform plan
+    ```
+
+4.  **Apply the configuration** to provision your Echo Chamber:
+
+    ```bash
+    terraform apply
+    ```
+
+## Inputs
+
+| Name             | Description                                                                 | Type   | Default | Required |
+| :--------------- | :-------------------------------------------------------------------------- | :----- | :------ | :------- |
+| `prefix`         | A unique prefix for the S3 bucket name. Must be lowercase and globally unique. | `string` | n/a     | yes      |
+| `retention_days` | Number of days after which temporal echoes (objects) will be automatically purged from the chamber. | `number` | `7`     | no       |
+| `aws_region`     | The AWS region to deploy the echo chamber.                                  | `string` | `us-east-1` | no       |
+
+## Outputs
+
+| Name                 | Description                                    |
+| :------------------- | :--------------------------------------------- |
+| `bucket_id`          | The ID (name) of the Temporal Echo Chamber S3 bucket. |
+| `bucket_arn`         | The ARN of the Temporal Echo Chamber S3 bucket. |
+| `bucket_domain_name` | The S3 bucket domain name.                     |
+
+## Testing
+
+To run the module's self-contained tests, navigate to the `tests/` directory and execute `test.sh`.
+
+```bash
+cd tests/
+./test.sh
+```
+
+This script will perform `terraform init`, `terraform validate`, and `terraform plan` to ensure the module's syntax and structure are correct without deploying actual resources.

--- a/terraform-modules/nightly-nightly-temporal-echo-chambe-3/src/main.tf
+++ b/terraform-modules/nightly-nightly-temporal-echo-chambe-3/src/main.tf
@@ -1,0 +1,44 @@
+resource "aws_s3_bucket" "echo_chamber" {
+  bucket_prefix = var.prefix
+  acl           = "private" # Best practice for private storage
+
+  tags = {
+    Name        = "${var.prefix}-temporal-echo-chamber"
+    Environment = "ApocalypsAI"
+    Purpose     = "TemporalEchoChamber"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "echo_chamber_versioning" {
+  bucket = aws_s3_bucket.echo_chamber.id
+  versioning_configuration {
+    status = "Enabled" # Recommended for lifecycle rules to manage all versions
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "echo_chamber_lifecycle" {
+  bucket = aws_s3_bucket.echo_chamber.id
+
+  rule {
+    id     = "expire_current_echoes"
+    status = "Enabled"
+
+    expiration {
+      days = var.retention_days
+    }
+
+    # Clean up incomplete multipart uploads to prevent orphaned parts
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  rule {
+    id     = "expire_old_noncurrent_echoes"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.retention_days
+    }
+  }
+}

--- a/terraform-modules/nightly-nightly-temporal-echo-chambe-3/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-temporal-echo-chambe-3/src/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_id" {
+  description = "The ID (name) of the Temporal Echo Chamber S3 bucket."
+  value       = aws_s3_bucket.echo_chamber.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the Temporal Echo Chamber S3 bucket."
+  value       = aws_s3_bucket.echo_chamber.arn
+}
+
+output "bucket_domain_name" {
+  description = "The S3 bucket domain name, useful for direct access."
+  value       = aws_s3_bucket.echo_chamber.bucket_domain_name
+}

--- a/terraform-modules/nightly-nightly-temporal-echo-chambe-3/src/variables.tf
+++ b/terraform-modules/nightly-nightly-temporal-echo-chambe-3/src/variables.tf
@@ -1,0 +1,16 @@
+variable "prefix" {
+  description = "A unique prefix for the S3 bucket name. Must be lowercase and globally unique."
+  type        = string
+}
+
+variable "retention_days" {
+  description = "Number of days after which temporal echoes (objects) will be automatically purged from the chamber."
+  type        = number
+  default     = 7
+}
+
+variable "aws_region" {
+  description = "The AWS region to deploy the echo chamber."
+  type        = string
+  default     = "us-east-1" # A common default for AWS resources
+}

--- a/terraform-modules/nightly-nightly-temporal-echo-chambe-3/tests/main.tf
+++ b/terraform-modules/nightly-nightly-temporal-echo-chambe-3/tests/main.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region = "us-east-1" # Mock rationale: Required for Terraform to parse AWS resources, but no actual API calls are made during `terraform validate` or `terraform plan` without `apply`. No actual credentials are needed for these offline checks.
+}
+
+module "test_echo_chamber" {
+  source = "../src"
+
+  prefix         = "test-apocalypsai-echo-chamber"
+  retention_days = 3 # Short retention for testing purposes
+  aws_region     = "us-east-1"
+}
+
+output "test_bucket_id" {
+  value = module.test_echo_chamber.bucket_id
+}
+
+output "test_bucket_arn" {
+  value = module.test_echo_chamber.bucket_arn
+}

--- a/terraform-modules/nightly-nightly-temporal-echo-chambe-3/tests/test.sh
+++ b/terraform-modules/nightly-nightly-temporal-echo-chambe-3/tests/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "-- Running Nightly Temporal Echo Chamber Provisioner Tests --"
+
+# Navigate to the test directory
+cd "$(dirname "$0")"
+
+# Initialize Terraform in the test directory
+echo "Initializing Terraform..."
+# Mock rationale: -backend=false prevents state backend configuration, making the test fully offline and independent of cloud state.
+terraform init -backend=false
+
+# Validate the Terraform configuration for syntax and consistency
+echo "Validating Terraform configuration..."
+terraform validate
+
+# Generate a Terraform plan to ensure no errors and predictable changes without applying.
+# Mock rationale: `terraform plan` simulates resource creation/modification without making actual API calls, ensuring the module's logic is sound offline.
+echo "Generating Terraform plan (no apply)..."
+terraform plan -destroy -out=tfplan -var="prefix=test-apocalypsai-echo-chamber-plan" -var="retention_days=1" -var="aws_region=us-east-1"
+
+# Check if the plan file was created, indicating a successful plan generation
+if [ ! -f tfplan ]; then
+  echo "Error: Terraform plan file 'tfplan' was not created."
+  exit 1
+fi
+
+echo "Terraform plan generated successfully. Cleaning up plan file."
+rm tfplan # Clean up the generated plan file
+
+echo "-- All Nightly Temporal Echo Chamber Provisioner tests passed! --"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-temporal-echo-chamber-prov
- **Provider**: gemini
- **Location**: `terraform-modules/nightly-nightly-temporal-echo-chambe-3`
- **Files Created**: 6
- **Description**: Provisions an ephemeral cloud storage bucket to capture fleeting temporal echoes, automatically purging them after a set duration.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-temporal-echo-chambe-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-temporal-echo-chambe-3/README.md`
- Run tests located in `terraform-modules/nightly-nightly-temporal-echo-chambe-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.