### PR TITLE
feat(groq): Docker container that prints a random cryptid description, with optional seed for reproducible output

### DIFF
--- a/docker-tools/nightly-nightly-docker-cryptid-gener/Dockerfile
+++ b/docker-tools/nightly-nightly-docker-cryptid-gener/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY src/ .
+ENV PYTHONUNBUFFERED=1
+ENTRYPOINT ["python", "main.py"]

--- a/docker-tools/nightly-nightly-docker-cryptid-gener/README.md
+++ b/docker-tools/nightly-nightly-docker-cryptid-gener/README.md
@@ -1,0 +1,23 @@
+# Nightly Docker Cryptid Generator
+
+Utility that runs in a Docker container and prints a random cryptid (mythical creature) description. Seedable for reproducible output.
+
+## Build
+
+```sh
+docker build -t nightly-cryptid-generator .
+```
+
+## Run
+
+```sh
+# Random cryptid (different each run)
+docker run --rm nightly-cryptid-generator
+
+# Deterministic output using a seed
+docker run --rm -e CRYPTID_SEED=0 nightly-cryptid-generator
+```
+
+## How it works
+
+The container runs a tiny Python script that selects a cryptid from a built‑in list using the `random` module. If the environment variable `CRYPTID_SEED` is set, it seeds the RNG for reproducible results.

--- a/docker-tools/nightly-nightly-docker-cryptid-gener/src/main.py
+++ b/docker-tools/nightly-nightly-docker-cryptid-gener/src/main.py
@@ -1,0 +1,22 @@
+import os
+import random
+
+cryptids = {
+    "Mothman": "A winged humanoid reported in Point Pleasant, West Virginia.",
+    "Jersey Devil": "A flying biped with hooves, haunting the Pine Barrens of New Jersey.",
+    "Chupacabra": "A blood‑sucking creature said to prey on livestock in the Americas."
+}
+
+def main():
+    seed = os.getenv("CRYPTID_SEED")
+    rnd = random.Random()
+    if seed is not None:
+        try:
+            rnd.seed(int(seed))
+        except ValueError:
+            rnd.seed(seed)
+    name = rnd.choice(list(cryptids.keys()))
+    print(f"{name}: {cryptids[name]}")
+
+if __name__ == "__main__":
+    main()

--- a/docker-tools/nightly-nightly-docker-cryptid-gener/tests/test_main.sh
+++ b/docker-tools/nightly-nightly-docker-cryptid-gener/tests/test_main.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+# Build the Docker image (quiet output)
+docker build -t test-cryptid-gen . > /dev/null
+
+# Run the container with a known seed
+output=$(docker run --rm -e CRYPTID_SEED=0 test-cryptid-gen)
+
+expected="Chupacabra: A blood‑sucking creature said to prey on livestock in the Americas."
+
+if [[ "$output" == "$expected" ]]; then
+  echo "PASS"
+  exit 0
+else
+  echo "FAIL: expected '$expected' but got '$output'"
+  exit 1
+fi


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-docker-cryptid-generator
- **Provider**: groq
- **Location**: `docker-tools/nightly-nightly-docker-cryptid-gener`
- **Files Created**: 4
- **Description**: Docker container that prints a random cryptid description, with optional seed for reproducible output

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `docker-tools/nightly-nightly-docker-cryptid-gener`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `docker-tools/nightly-nightly-docker-cryptid-gener/README.md`
- Run tests located in `docker-tools/nightly-nightly-docker-cryptid-gener/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.