### PR TITLE
feat(groq): Concurrent TCP echo server with an HTTP endpoint that reports total connections.

### DIFF
--- a/go-utils/nightly-nightly-echo-multitool/README.md
+++ b/go-utils/nightly-nightly-echo-multitool/README.md
@@ -1,0 +1,35 @@
+Nightly Echo Multitool
+=======================
+
+Overview
+--------
+A tiny Go utility that runs two services concurrently:
+
+1. **TCP Echo Server** – Listens for TCP connections, echoes each line back to the client, and counts connections.
+2. **HTTP Stats Server** – Exposes `/stats` which returns the total number of TCP connections handled.
+
+Both services run in the background and the program blocks forever, making it suitable for quick demos or as a building block for larger systems.
+
+Build & Run
+-----------
+```bash
+# Build the binary
+go build -o echo-multitool src/main.go
+
+# Run (default ports: TCP 9000, HTTP 9001)
+./echo-multitool
+```
+
+Custom ports can be set by editing the `tcpAddr` and `httpAddr` variables in `src/main.go` before building.
+
+Testing
+-------
+Run the automated test suite with:
+```bash
+go test ./tests
+```
+The test starts the servers on random free ports, verifies that a line sent to the TCP server is echoed back, and checks that the HTTP `/stats` endpoint reports exactly one connection.
+
+License
+-------
+MIT – see LICENSE file in the repository root.

--- a/go-utils/nightly-nightly-echo-multitool/src/main.go
+++ b/go-utils/nightly-nightly-echo-multitool/src/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "log"
+    "net"
+    "net/http"
+    "sync/atomic"
+)
+
+var totalConnections uint64
+
+func handleTCP(conn net.Conn) {
+    atomic.AddUint64(&totalConnections, 1)
+    defer conn.Close()
+    scanner := bufio.NewScanner(conn)
+    for scanner.Scan() {
+        line := scanner.Text()
+        fmt.Fprintln(conn, line) // echo back the received line
+    }
+    if err := scanner.Err(); err != nil {
+        log.Printf("TCP scanner error: %v", err)
+    }
+}
+
+func startTCP(address string) {
+    ln, err := net.Listen("tcp", address)
+    if err != nil {
+        log.Fatalf("TCP listen error: %v", err)
+    }
+    go func() {
+        for {
+            conn, err := ln.Accept()
+            if err != nil {
+                log.Printf("TCP accept error: %v", err)
+                continue
+            }
+            go handleTCP(conn)
+        }
+    }()
+}
+
+func statsHandler(w http.ResponseWriter, r *http.Request) {
+    fmt.Fprintf(w, "total_connections %d\n", atomic.LoadUint64(&totalConnections))
+}
+
+func startHTTP(address string) {
+    http.HandleFunc("/stats", statsHandler)
+    go func() {
+        if err := http.ListenAndServe(address, nil); err != nil {
+            log.Fatalf("HTTP server error: %v", err)
+        }
+    }()
+}
+
+func main() {
+    // Default ports – change here if you need different ones before building.
+    tcpAddr := ":9000"
+    httpAddr := ":9001"
+    startTCP(tcpAddr)
+    startHTTP(httpAddr)
+    // Block forever; the servers run in background goroutines.
+    select {}
+}

--- a/go-utils/nightly-nightly-echo-multitool/tests/main_test.go
+++ b/go-utils/nightly-nightly-echo-multitool/tests/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "io/ioutil"
+    "net"
+    "net/http"
+    "strings"
+    "testing"
+    "time"
+)
+
+func TestEchoAndStats(t *testing.T) {
+    // Acquire free ports for TCP and HTTP by listening on :0 and then closing.
+    tcpLn, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        t.Fatalf("failed to acquire TCP port: %v", err)
+    }
+    tcpAddr := tcpLn.Addr().String()
+    tcpLn.Close()
+
+    httpLn, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        t.Fatalf("failed to acquire HTTP port: %v", err)
+    }
+    httpAddr := httpLn.Addr().String()
+    httpLn.Close()
+
+    // Start the services on the chosen ports.
+    startTCP(tcpAddr)
+    startHTTP(httpAddr)
+
+    // Give the goroutines a moment to start listening.
+    time.Sleep(100 * time.Millisecond)
+
+    // ---- TCP echo verification ----
+    conn, err := net.Dial("tcp", tcpAddr)
+    if err != nil {
+        t.Fatalf("TCP dial failed: %v", err)
+    }
+    defer conn.Close()
+
+    testMsg := "hello world"
+    fmt.Fprintf(conn, "%s\n", testMsg)
+    resp, err := bufio.NewReader(conn).ReadString('\n')
+    if err != nil {
+        t.Fatalf("reading echo response failed: %v", err)
+    }
+    resp = strings.TrimSpace(resp)
+    if resp != testMsg {
+        t.Fatalf("expected echo %q, got %q", testMsg, resp)
+    }
+
+    // ---- HTTP stats verification ----
+    httpURL := fmt.Sprintf("http://%s/stats", httpAddr)
+    httpResp, err := http.Get(httpURL)
+    if err != nil {
+        t.Fatalf("HTTP GET to /stats failed: %v", err)
+    }
+    defer httpResp.Body.Close()
+    body, err := ioutil.ReadAll(httpResp.Body)
+    if err != nil {
+        t.Fatalf("reading HTTP body failed: %v", err)
+    }
+    if !strings.Contains(string(body), "total_connections 1") {
+        t.Fatalf("expected stats to contain count 1, got %s", string(body))
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-echo-multitool
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-echo-multitool`
- **Files Created**: 3
- **Description**: Concurrent TCP echo server with an HTTP endpoint that reports total connections.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-echo-multitool`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-echo-multitool/README.md`
- Run tests located in `go-utils/nightly-nightly-echo-multitool/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.