### PR TITLE
feat(gemini): A Go-based network service that broadcasts synchronized 'temporal pulses' (timestamps) to connected clients, helping them align their internal clocks in the chaotic post-apocalyptic timeline.

### DIFF
--- a/go-utils/nightly-nightly-chronosync-beacon/README.md
+++ b/go-utils/nightly-nightly-chronosync-beacon/README.md
@@ -1,0 +1,78 @@
+# Nightly Chronosync Beacon
+
+A Go-based network service designed to broadcast synchronized 'temporal pulses' (timestamps) to connected clients. In the chaotic post-apocalyptic timeline, maintaining accurate time synchronization is crucial for coordinating efforts and understanding temporal anomalies. This beacon provides a reliable source of UTC timestamps via HTTP and WebSocket.
+
+## Features
+
+*   **HTTP Pulse Endpoint (`/pulse`)**: Provides the current UTC timestamp in RFC3339Nano format upon request.
+*   **WebSocket Stream Endpoint (`/stream`)**: Continuously broadcasts UTC timestamps at a 1-second interval to all connected WebSocket clients.
+*   **Concurrent Design**: Leverages Go's goroutines and channels to efficiently handle multiple client connections.
+*   **Graceful Shutdown**: Handles `SIGINT` and `SIGTERM` signals for a clean shutdown.
+
+## Getting Started
+
+### Prerequisites
+
+*   Go (version 1.16 or higher)
+
+### Installation
+
+1.  Clone the repository (or navigate to this utility's directory):
+
+    ```bash
+    git clone https://github.com/polsala/ApocalypsAI.git
+    cd ApocalypsAI/go-utils/nightly-chronosync-beacon
+    ```
+
+2.  The utility is self-contained. No external Go modules are strictly required beyond standard library and `golang.org/x/net/websocket` (which will be fetched automatically by `go mod tidy`).
+
+### Running the Beacon
+
+To start the Chronosync Beacon server:
+
+```bash
+cd src
+go run main.go
+```
+
+The beacon will start on `http://localhost:8080` by default. You can specify a different port using the `PORT` environment variable:
+
+```bash
+PORT=8081 go run src/main.go
+```
+
+### Usage
+
+#### 1. HTTP Pulse Endpoint
+
+Access the `/pulse` endpoint using `curl` or your web browser:
+
+```bash
+curl http://localhost:8080/pulse
+# Expected output:
+# Temporal Pulse: 2023-10-27T10:30:00.123456789Z
+```
+
+#### 2. WebSocket Stream Endpoint
+
+Connect to the `/stream` endpoint using a WebSocket client. Here's an example using `wscat` (install with `npm install -g wscat`):
+
+```bash
+wscat -c ws://localhost:8080/stream
+# Expected output (timestamps will stream every second):
+# < 2023-10-27T10:30:01.123456789Z
+# < 2023-10-27T10:30:02.123456789Z
+# < 2023-10-27T10:30:03.123456789Z
+# ...
+```
+
+## Testing
+
+To run the automated tests for the Chronosync Beacon:
+
+```bash
+cd tests
+go test -v .
+```
+
+The tests will verify both the HTTP `/pulse` endpoint and the WebSocket `/stream` functionality, ensuring the beacon operates as expected.

--- a/go-utils/nightly-nightly-chronosync-beacon/src/main.go
+++ b/go-utils/nightly-nightly-chronosync-beacon/src/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+const (
+	defaultPort       = "8080"
+	pulseInterval     = 1 * time.Second // Interval for WebSocket broadcasts
+	shutdownTimeout   = 5 * time.Second
+)
+
+// pulseHandler serves the current UTC timestamp via HTTP.
+func pulseHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	fmt.Fprintf(w, "Temporal Pulse: %s\n", time.Now().UTC().Format(time.RFC3339Nano))
+}
+
+// streamHandler upgrades the connection to a WebSocket and continuously broadcasts timestamps.
+func streamHandler(ws *websocket.Conn) {
+	defer ws.Close()
+	log.Printf("New Chronosync Beacon stream connection from %s", ws.RemoteAddr())
+
+	ticker := time.NewTicker(pulseInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			timestamp := time.Now().UTC().Format(time.RFC3339Nano)
+			if err := websocket.Message.Send(ws, timestamp); err != nil {
+				log.Printf("Failed to send pulse to %s: %v", ws.RemoteAddr(), err)
+				return // Client disconnected or error
+			}
+		case <-ws.Request().Context().Done(): // Check if client disconnected
+			log.Printf("Client %s disconnected from stream.", ws.RemoteAddr())
+			return
+		}
+	}
+}
+
+// startServer initializes and starts the HTTP server.
+func startServer(port string) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/pulse", pulseHandler)
+	mux.Handle("/stream", websocket.Handler(streamHandler))
+
+	server := &http.Server{
+		Addr:    ":" + port,
+		Handler: mux,
+		// Add timeouts for production robustness
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	go func() {
+		log.Printf("Chronosync Beacon online at http://localhost%s", server.Addr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Chronosync Beacon failed to start: %v", err)
+		}
+	}()
+	return server
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = defaultPort
+	}
+
+	server := startServer(port)
+
+	// Set up graceful shutdown
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+
+	<-stop // Wait for interrupt signal
+
+	log.Println("Shutting down Chronosync Beacon...")
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := server.Shutdown(ctx); err != nil {
+		log.Fatalf("Chronosync Beacon shutdown failed: %v", err)
+	}
+	log.Println("Chronosync Beacon gracefully stopped.")
+}

--- a/go-utils/nightly-nightly-chronosync-beacon/tests/main_test.go
+++ b/go-utils/nightly-nightly-chronosync-beacon/tests/main_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+// TestPulseHandler verifies the /pulse HTTP endpoint.
+func TestPulseHandler(t *testing.T) {
+	// # Mock rationale: httptest.NewServer creates a local, in-memory HTTP server
+	// # that mimics the behavior of our actual server, allowing us to test HTTP
+	// # handlers without binding to a real network port or requiring an external service.
+	ts := httptest.NewServer(http.HandlerFunc(pulseHandler))
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/pulse")
+	if err != nil {
+		t.Fatalf("Failed to send GET request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status OK, got %d", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
+
+	responseStr := strings.TrimSpace(string(body))
+	if !strings.HasPrefix(responseStr, "Temporal Pulse: ") {
+		t.Errorf("Response body has unexpected prefix: %s", responseStr)
+	}
+
+	timestampStr := strings.TrimPrefix(responseStr, "Temporal Pulse: ")
+	parsedTime, err := time.Parse(time.RFC3339Nano, timestampStr)
+	if err != nil {
+		t.Fatalf("Failed to parse timestamp '%s': %v", timestampStr, err)
+	}
+
+	// Check if the timestamp is recent (within a small window of test execution).
+	// This makes the test deterministic enough for time-based services without complex time mocking.
+	now := time.Now().UTC()
+	if now.Sub(parsedTime) > 5*time.Second || parsedTime.Sub(now) > 5*time.Second {
+		t.Errorf("Timestamp is not recent. Expected ~%s, got %s", now.Format(time.RFC3339Nano), parsedTime.Format(time.RFC3339Nano))
+	}
+}
+
+// TestStreamHandler verifies the /stream WebSocket endpoint.
+func TestStreamHandler(t *testing.T) {
+	// # Mock rationale: httptest.NewServer is used to create a test HTTP server.
+	// # For WebSockets, we use websocket.Handler to wrap our streamHandler,
+	// # and then connect to this test server's URL using websocket.Dial.
+	// # This allows testing WebSocket communication locally without a real network setup.
+	mux := http.NewServeMux()
+	mux.Handle("/stream", websocket.Handler(streamHandler))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/stream"
+	
+	// Use a context with timeout for the WebSocket connection and message reception
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := websocket.Dial(wsURL, "", "http://localhost") // Origin doesn't matter for local test
+	if err != nil {
+		t.Fatalf("Failed to dial WebSocket: %v", err)
+	}
+	defer conn.Close()
+
+	var msg string
+	var receivedTimes []time.Time
+
+	// Receive a few messages to ensure continuous streaming
+	for i := 0; i < 3; i++ {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("Test timed out waiting for WebSocket messages: %v", ctx.Err())
+		default:
+			if err := websocket.Message.Receive(conn, &msg); err != nil {
+				t.Fatalf("Failed to receive WebSocket message: %v", err)
+			}
+			parsedTime, err := time.Parse(time.RFC3339Nano, msg)
+			if err != nil {
+				t.Fatalf("Failed to parse timestamp from WebSocket message '%s': %v", msg, err)
+			}
+			receivedTimes = append(receivedTimes, parsedTime)
+		}
+	}
+
+	if len(receivedTimes) < 3 {
+		t.Fatalf("Expected to receive at least 3 messages, got %d", len(receivedTimes))
+	}
+
+	// Verify timestamps are increasing and roughly at the expected interval
+	for i := 1; i < len(receivedTimes); i++ {
+		if receivedTimes[i].Before(receivedTimes[i-1]) {
+			t.Errorf("Received timestamp %s is not after previous timestamp %s", receivedTimes[i], receivedTimes[i-1])
+		}
+		// Check interval, allowing for some jitter
+		diff := receivedTimes[i].Sub(receivedTimes[i-1])
+		if diff < pulseInterval/2 || diff > pulseInterval*2 { // Allow +/- 50% for network/scheduling jitter
+			t.Errorf("Unexpected time difference between pulses: %s (expected ~%s)", diff, pulseInterval)
+		}
+	}
+
+	// Check if the last timestamp is recent
+	now := time.Now().UTC()
+	lastParsedTime := receivedTimes[len(receivedTimes)-1]
+	if now.Sub(lastParsedTime) > 5*time.Second || lastParsedTime.Sub(now) > 5*time.Second {
+		t.Errorf("Last received timestamp is not recent. Expected ~%s, got %s", now.Format(time.RFC3339Nano), lastParsedTime.Format(time.RFC3339Nano))
+	}
+}
+
+// TestStartServer function to ensure the server can be started and stopped gracefully.
+func TestStartServer(t *testing.T) {
+	// # Mock rationale: We start a real server on a random available port (by passing "0")
+	// # and then immediately shut it down. This tests the server's lifecycle
+	// # without needing to interact with it over the network for a long duration.
+	// # It verifies that the server can bind and unbind from a port.
+	server := startServer("0") // Use port 0 to let the OS choose a free port
+	if server == nil {
+		t.Fatal("startServer returned nil")
+	}
+
+	// Give the server a moment to start up
+	time.Sleep(100 * time.Millisecond)
+
+	// Attempt to gracefully shut down the server
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	err := server.Shutdown(ctx)
+	if err != nil && err != http.ErrServerClosed {
+		t.Fatalf("Server shutdown failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-chronosync-beacon
- **Provider**: gemini
- **Location**: `go-utils/nightly-nightly-chronosync-beacon`
- **Files Created**: 3
- **Description**: A Go-based network service that broadcasts synchronized 'temporal pulses' (timestamps) to connected clients, helping them align their internal clocks in the chaotic post-apocalyptic timeline.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-chronosync-beacon`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-chronosync-beacon/README.md`
- Run tests located in `go-utils/nightly-nightly-chronosync-beacon/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.