### PR TITLE
feat(gemini): A Go-based distributed service that aggregates 'mood' reports from various network components and provides an overall system emotional resonance.

### DIFF
--- a/go-utils/nightly-nightly-network-mood-ring/README.md
+++ b/go-utils/nightly-nightly-network-mood-ring/README.md
@@ -1,0 +1,119 @@
+# Nightly Network Mood Ring
+
+## Overview
+
+The `nightly-network-mood-ring` is a whimsical yet useful Go-based service designed to track the 'emotional resonance' of your distributed systems. Instead of traditional health checks, components report their 'mood' (e.g., Serene, Anxious, Chaotic), and this central service aggregates them, providing a snapshot of the network's collective emotional state.
+
+It's perfect for gaining a high-level, human-readable understanding of system health, or simply adding a touch of personality to your monitoring dashboards.
+
+## Features
+
+*   **Mood Reporting**: Components send their current mood via a simple HTTP POST request.
+*   **Aggregated Status**: Query the service to get a list of all reported component moods.
+*   **Ephemeral States**: Moods are updated, reflecting the latest state of each component.
+*   **Go Concurrency**: Built with Go's powerful concurrency model for efficient handling of multiple reports.
+
+## Usage
+
+### 1. Run the Mood Ring Server
+
+Navigate to the `src` directory and run the Go application:
+
+```bash
+cd src
+go run main.go
+```
+
+By default, the server will listen on `http://localhost:8080`. You can change the port by setting the `PORT` environment variable:
+
+```bash
+PORT=9000 go run main.go
+```
+
+### 2. Report a Component's Mood
+
+Send a POST request to the `/report` endpoint with a JSON payload specifying the `source` and `mood`.
+
+**Example (using `curl`):**
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"source": "frontend-service-alpha", "mood": "Optimistic"}' \
+     http://localhost:8080/report
+
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"source": "database-replica-01", "mood": "Serene"}' \
+     http://localhost:8080/report
+
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"source": "auth-microservice", "mood": "Anxious"}' \
+     http://localhost:8080/report
+```
+
+**Available Whimsical Moods (suggestions, but any string is accepted):**
+
+*   `Serene`
+*   `Optimistic`
+*   `Anxious`
+*   `Chaotic`
+*   `Melancholy`
+*   `Vigilant`
+*   `Overwhelmed`
+*   `Curious`
+*   `Content`
+
+### 3. Check the Network's Overall Mood
+
+Send a GET request to the `/status` endpoint:
+
+**Example (using `curl`):**
+
+```bash
+curl http://localhost:8080/status
+```
+
+**Example Response:**
+
+```json
+{
+  "component_moods": [
+    {
+      "source": "auth-microservice",
+      "mood": "Anxious",
+      "timestamp": "2023-10-27T10:30:10.555444333Z"
+    },
+    {
+      "source": "database-replica-01",
+      "mood": "Serene",
+      "timestamp": "2023-10-27T10:30:05.987654321Z"
+    },
+    {
+      "source": "frontend-service-alpha",
+      "mood": "Optimistic",
+      "timestamp": "2023-10-27T10:30:00.123456789Z"
+    }
+  ]
+}
+```
+
+## Development
+
+### Project Structure
+
+```
+nightly-network-mood-ring/
+├── README.md
+├── src/
+│   └── main.go
+└── tests/
+    └── main_test.go
+```
+
+### Running Tests
+
+Navigate to the `tests` directory and run:
+
+```bash
+cd tests
+go test .
+```

--- a/go-utils/nightly-nightly-network-mood-ring/src/main.go
+++ b/go-utils/nightly-nightly-network-mood-ring/src/main.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"sync"
+	"time"
+)
+
+// MoodReport represents a single mood reported by a component.
+type MoodReport struct {
+	Source    string    `json:"source"`
+	Mood      string    `json:"mood"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// MoodRing stores and manages the moods of various components.
+type MoodRing struct {
+	mu             sync.RWMutex
+	componentMoods map[string]MoodReport
+}
+
+// NewMoodRing creates and returns a new MoodRing instance.
+func NewMoodRing() *MoodRing {
+	return &MoodRing{
+		componentMoods: make(map[string]MoodReport),
+	}
+}
+
+// reportMoodHandler handles incoming POST requests to report a component's mood.
+func (mr *MoodRing) reportMoodHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Only POST method is allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var report MoodReport
+	if err := json.NewDecoder(r.Body).Decode(&report); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if report.Source == "" || report.Mood == "" {
+		http.Error(w, "'source' and 'mood' fields are required", http.StatusBadRequest)
+		return
+	}
+
+	report.Timestamp = time.Now().UTC()
+
+	mr.mu.Lock()
+	mr.componentMoods[report.Source] = report
+	mr.mu.Unlock()
+
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "Mood for %s updated to %s\n", report.Source, report.Mood)
+	log.Printf("Received mood report: Source=%s, Mood=%s\n", report.Source, report.Mood)
+}
+
+// getStatusHandler handles incoming GET requests to retrieve the overall network mood.
+func (mr *MoodRing) getStatusHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Only GET method is allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	mr.mu.RLock()
+	defer mr.mu.RUnlock()
+
+	allMoods := make([]MoodReport, 0, len(mr.componentMoods))
+	for _, mood := range mr.componentMoods {
+		allMoods = append(allMoods, mood)
+	}
+
+	// Sort by source for deterministic output in tests and consistent API responses
+	sort.Slice(allMoods, func(i, j int) bool {
+		return allMoods[i].Source < allMoods[j].Source
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string][]MoodReport{"component_moods": allMoods}); err != nil {
+		log.Printf("Error encoding response: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
+}
+
+func main() {
+	mr := NewMoodRing()
+
+	http.HandleFunc("/report", mr.reportMoodHandler)
+	http.HandleFunc("/status", mr.getStatusHandler)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	addr := fmt.Sprintf(":%s", port)
+	log.Printf("Nightly Network Mood Ring server starting on port %s...\n", port)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}

--- a/go-utils/nightly-nightly-network-mood-ring/tests/main_test.go
+++ b/go-utils/nightly-nightly-network-mood-ring/tests/main_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+// # Mock rationale:
+// The tests use `httptest.NewRecorder` and `http.NewRequest` to simulate HTTP requests and responses
+// without actually binding to a network port or making external calls. This ensures tests are
+// deterministic, fast, and offline. Time.Now() is used for timestamps, which is acceptable as
+// the exact time value isn't asserted, only its presence and update behavior.
+
+func TestReportMoodHandler_Success(t *testing.T) {
+	mr := NewMoodRing()
+
+	// Test reporting a new mood
+	reportPayload := []byte(`{"source": "test-service-1", "mood": "Optimistic"}`)
+	req := httptest.NewRequest(http.MethodPost, "/report", bytes.NewBuffer(reportPayload))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	mr.reportMoodHandler(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	expected := "Mood for test-service-1 updated to Optimistic\n"
+	if rr.Body.String() != expected {
+		t.Errorf("handler returned unexpected body: got %v want %v", rr.Body.String(), expected)
+	}
+
+	mr.mu.RLock()
+	defer mr.mu.RUnlock()
+	if len(mr.componentMoods) != 1 {
+		t.Fatalf("Expected 1 mood report, got %d", len(mr.componentMoods))
+	}
+	if mood, ok := mr.componentMoods["test-service-1"]; !ok || mood.Mood != "Optimistic" {
+		t.Errorf("Mood not correctly stored: got %+v", mood)
+	}
+
+	// Test updating an existing mood
+	updatePayload := []byte(`{"source": "test-service-1", "mood": "Anxious"}`)
+	req = httptest.NewRequest(http.MethodPost, "/report", bytes.NewBuffer(updatePayload))
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+
+	mr.reportMoodHandler(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code for update: got %v want %v", status, http.StatusOK)
+	}
+
+	mr.mu.RLock()
+	defer mr.mu.RUnlock()
+	if len(mr.componentMoods) != 1 {
+		t.Fatalf("Expected 1 mood report after update, got %d", len(mr.componentMoods))
+	}
+	if mood, ok := mr.componentMoods["test-service-1"]; !ok || mood.Mood != "Anxious" {
+		t.Errorf("Mood not correctly updated: got %+v", mood)
+	}
+}
+
+func TestReportMoodHandler_InvalidMethod(t *testing.T) {
+	mr := NewMoodRing()
+	req := httptest.NewRequest(http.MethodGet, "/report", nil)
+	rr := httptest.NewRecorder()
+
+	mr.reportMoodHandler(rr, req)
+
+	if status := rr.Code; status != http.StatusMethodNotAllowed {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestReportMoodHandler_InvalidBody(t *testing.T) {
+	mr := NewMoodRing()
+	req := httptest.NewRequest(http.MethodPost, "/report", bytes.NewBuffer([]byte(`invalid json`)))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	mr.reportMoodHandler(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusBadRequest)
+	}
+}
+
+func TestReportMoodHandler_MissingFields(t *testing.T) {
+	mr := NewMoodRing()
+
+	// Missing source
+	payload := []byte(`{"mood": "Optimistic"}`)
+	req := httptest.NewRequest(http.MethodPost, "/report", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mr.reportMoodHandler(rr, req)
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code for missing source: got %v want %v", status, http.StatusBadRequest)
+	}
+
+	// Missing mood
+	payload = []byte(`{"source": "test-service-2"}`)
+	req = httptest.NewRequest(http.MethodPost, "/report", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	mr.reportMoodHandler(rr, req)
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code for missing mood: got %v want %v", status, http.StatusBadRequest)
+	}
+}
+
+func TestGetStatusHandler_Success(t *testing.T) {
+	mr := NewMoodRing()
+
+	// Report some moods first
+	reportPayload1 := []byte(`{"source": "service-A", "mood": "Serene"}`)
+	req1 := httptest.NewRequest(http.MethodPost, "/report", bytes.NewBuffer(reportPayload1))
+	req1.Header.Set("Content-Type", "application/json")
+	rr1 := httptest.NewRecorder()
+	mr.reportMoodHandler(rr1, req1)
+
+	reportPayload2 := []byte(`{"source": "service-B", "mood": "Chaotic"}`)
+	req2 := httptest.NewRequest(http.MethodPost, "/report", bytes.NewBuffer(reportPayload2))
+	req2.Header.Set("Content-Type", "application/json")
+	rr2 := httptest.NewRecorder()
+	mr.reportMoodHandler(rr2, req2)
+
+	// Now get status
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rr := httptest.NewRecorder()
+
+	mr.getStatusHandler(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	var response map[string][]MoodReport
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("Could not decode response: %v", err)
+	}
+
+	if len(response["component_moods"]) != 2 {
+		t.Fatalf("Expected 2 component moods, got %d", len(response["component_moods"]))
+	}
+
+	// Due to sorting in the handler, service-A should be first
+	if response["component_moods"][0].Source != "service-A" || response["component_moods"][0].Mood != "Serene" {
+		t.Errorf("Expected service-A Serene, got %+v", response["component_moods"][0])
+	}
+	if response["component_moods"][1].Source != "service-B" || response["component_moods"][1].Mood != "Chaotic" {
+		t.Errorf("Expected service-B Chaotic, got %+v", response["component_moods"][1])
+	}
+
+	// Test timestamp presence
+	if response["component_moods"][0].Timestamp.IsZero() {
+		t.Errorf("Timestamp for service-A is zero")
+	}
+}
+
+func TestGetStatusHandler_NoMoods(t *testing.T) {
+	mr := NewMoodRing()
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rr := httptest.NewRecorder()
+
+	mr.getStatusHandler(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	var response map[string][]MoodReport
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("Could not decode response: %v", err)
+	}
+
+	if len(response["component_moods"]) != 0 {
+		t.Errorf("Expected 0 component moods, got %d", len(response["component_moods"]))
+	}
+}
+
+func TestGetStatusHandler_InvalidMethod(t *testing.T) {
+	mr := NewMoodRing()
+	req := httptest.NewRequest(http.MethodPost, "/status", nil)
+	rr := httptest.NewRecorder()
+
+	mr.getStatusHandler(rr, req)
+
+	if status := rr.Code; status != http.StatusMethodNotAllowed {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestMain(m *testing.M) {
+	// Suppress log output during tests for cleaner test results
+	log.SetOutput(bytes.NewBuffer(nil))
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-network-mood-ring
- **Provider**: gemini
- **Location**: `go-utils/nightly-nightly-network-mood-ring`
- **Files Created**: 3
- **Description**: A Go-based distributed service that aggregates 'mood' reports from various network components and provides an overall system emotional resonance.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-network-mood-ring`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-network-mood-ring/README.md`
- Run tests located in `go-utils/nightly-nightly-network-mood-ring/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.