### PR TITLE
feat(groq): CLI tool that computes how many units of one post‑apocalyptic item are needed to equal another based on their barter values.

### DIFF
--- a/rust-utils/nightly-nightly-barter-calculator-2/Cargo.toml
+++ b/rust-utils/nightly-nightly-barter-calculator-2/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nightly-barter-calculator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-barter-calculator-2/README.md
+++ b/rust-utils/nightly-nightly-barter-calculator-2/README.md
@@ -1,0 +1,34 @@
+# nightly-barter-calculator
+
+Utility to calculate barter exchange rates between items in a post‑apocalyptic setting.
+
+## Usage
+
+```sh
+cargo run -- <ITEM_A> <ITEM_B> <VALUE_A> <VALUE_B>
+```
+
+- **ITEM_A** – Name of the first item (e.g., `water`).
+- **ITEM_B** – Name of the second item (e.g., `canned-food`).
+- **VALUE_A** – Barter value of one unit of ITEM_A (numeric).
+- **VALUE_B** – Barter value of one unit of ITEM_B (numeric).
+
+### Example
+
+```sh
+cargo run -- water canned-food 3 5
+```
+
+Output:
+```
+You need 1.67 water to equal 1 canned‑food
+```
+
+## Build & Test
+
+```sh
+cargo build --release
+cargo test
+```
+
+The tool is deliberately lightweight and has no external dependencies beyond the Rust standard library.

--- a/rust-utils/nightly-nightly-barter-calculator-2/src/lib.rs
+++ b/rust-utils/nightly-nightly-barter-calculator-2/src/lib.rs
@@ -1,0 +1,9 @@
+/// Calculates how many units of `item_a` are needed to equal one unit of `item_b`.
+///
+/// * `value_a` – barter value of a single unit of the first item.
+/// * `value_b` – barter value of a single unit of the second item.
+///
+/// Returns the ratio `value_b / value_a`.
+pub fn calculate_exchange(value_a: f64, value_b: f64) -> f64 {
+    value_b / value_a
+}

--- a/rust-utils/nightly-nightly-barter-calculator-2/src/main.rs
+++ b/rust-utils/nightly-nightly-barter-calculator-2/src/main.rs
@@ -1,0 +1,24 @@
+use std::env;
+
+// Import the library function
+use nightly_barter_calculator::calculate_exchange;
+
+fn parse_arg<T: std::str::FromStr>(arg: Option<&String>, name: &str) -> T {
+    arg.expect(&format!("Missing argument: {}", name))
+        .parse()
+        .ok()
+        .expect(&format!("Invalid value for {}", name))
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    // args[0] is the program name
+    let item_a = args.get(1).expect("Missing ITEM_A");
+    let item_b = args.get(2).expect("Missing ITEM_B");
+    let value_a: f64 = parse_arg(args.get(3), "VALUE_A");
+    let value_b: f64 = parse_arg(args.get(4), "VALUE_B");
+
+    let rate = calculate_exchange(value_a, value_b);
+    // Show two decimal places for readability
+    println!("You need {:.2} {} to equal 1 {}", rate, item_a, item_b);
+}

--- a/rust-utils/nightly-nightly-barter-calculator-2/tests/barter_test.rs
+++ b/rust-utils/nightly-nightly-barter-calculator-2/tests/barter_test.rs
@@ -1,0 +1,23 @@
+#[cfg(test)]
+mod tests {
+    use nightly_barter_calculator::calculate_exchange;
+
+    #[test]
+    fn test_basic_ratio() {
+        let rate = calculate_exchange(3.0, 5.0);
+        // Expected 5 / 3 ≈ 1.6666667
+        assert!((rate - 1.6666667).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_equal_values() {
+        let rate = calculate_exchange(10.0, 10.0);
+        assert!((rate - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_fractional_values() {
+        let rate = calculate_exchange(2.5, 7.5);
+        assert!((rate - 3.0).abs() < 1e-9);
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-barter-calculator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-barter-calculator-2`
- **Files Created**: 5
- **Description**: CLI tool that computes how many units of one post‑apocalyptic item are needed to equal another based on their barter values.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-barter-calculator-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-barter-calculator-2/README.md`
- Run tests located in `rust-utils/nightly-nightly-barter-calculator-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.