### PR TITLE
feat(gemini): Deploys an ephemeral AWS cloud sandbox with expiry tags for temporal anomaly experimentation.

### DIFF
--- a/terraform-modules/nightly-nightly-temporal-sandbox/README.md
+++ b/terraform-modules/nightly-nightly-temporal-sandbox/README.md
@@ -1,0 +1,92 @@
+# Nightly Temporal Sandbox
+
+This Terraform module deploys a whimsical, yet functional, ephemeral AWS cloud sandbox. It's designed for quick, isolated experimentation with "temporal anomalies" (or any other short-lived tasks) without leaving behind persistent infrastructure. All deployed resources are tagged with an `ExpiryDate`, making them prime candidates for automated cleanup by a separate "Temporal Janitor" utility (not included here, but highly recommended!).
+
+## Features
+
+*   **Ephemeral by Design**: Resources are tagged with an `ExpiryDate` based on a configurable Time-To-Live (TTL).
+*   **Isolated Environment**: Deploys a dedicated VPC, subnet, and security group.
+*   **Basic Compute**: Includes a single EC2 instance for your experiments.
+*   **Whimsical Naming**: Resources are named with a "Temporal Sandbox" theme.
+
+## Usage
+
+1.  **Prerequisites**:
+    *   [Terraform](https://www.terraform.io/downloads) installed.
+    *   AWS CLI configured with credentials that have permissions to create VPCs, EC2 instances, and related resources.
+
+2.  **Module Integration**:
+    Create a `main.tf` file in your project:
+
+    ```terraform
+    module "temporal_sandbox" {
+      source = "./nightly-temporal-sandbox/src" # Adjust path if necessary
+
+      aws_region      = "us-east-1"
+      instance_type   = "t2.micro"
+      ttl_hours       = 24 # Sandbox will expire in 24 hours
+      sandbox_name    = "anomaly-test-001"
+    }
+
+    output "sandbox_instance_id" {
+      value       = module.temporal_sandbox.sandbox_id
+      description = "The ID of the deployed EC2 instance."
+    }
+
+    output "sandbox_expiry_timestamp" {
+      value       = module.temporal_sandbox.expiry_timestamp
+      description = "The UTC timestamp when the sandbox is intended to expire."
+    }
+    ```
+
+3.  **Initialize & Apply**:
+
+    ```bash
+    terraform init
+    terraform apply
+    ```
+
+    Confirm the plan and type `yes` to deploy.
+
+4.  **Cleanup**:
+    When your temporal experiments are complete (or after the `ttl_hours` have passed), you can destroy the sandbox:
+
+    ```bash
+    terraform destroy
+    ```
+
+    Alternatively, rely on an external "Temporal Janitor" script to find and destroy resources based on the `ExpiryDate` tag.
+
+## Inputs
+
+| Name            | Description                                   | Type     | Default                      | Required |
+| :-------------- | :-------------------------------------------- | :------- | :--------------------------- | :------- |
+| `aws_region`    | The AWS region to deploy resources into.      | `string` | `"us-east-1"`                | no       |
+| `instance_type` | The EC2 instance type for the sandbox.        | `string` | `"t2.micro"`                 | no       |
+| `ttl_hours`     | Time-To-Live for the sandbox in hours.        | `number` | `24`                         | no       |
+| `sandbox_name`  | A unique name for this temporal sandbox.      | `string` | `"default-temporal-sandbox"` | no       |
+
+## Outputs
+
+| Name                   | Description                                          |
+| :--------------------- | :--------------------------------------------------- |
+| `sandbox_id`           | The ID of the deployed EC2 instance.                 |
+| `expiry_timestamp`     | The UTC timestamp (RFC3339) when the sandbox is intended to expire. |
+| `vpc_id`               | The ID of the created VPC.                           |
+| `subnet_id`            | The ID of the created subnet.                        |
+
+## Testing
+
+The tests ensure that the Terraform module's plan output contains the expected resources and tags without actually deploying anything to AWS.
+
+To run the tests:
+
+```bash
+cd nightly-temporal-sandbox/tests
+./test_plan.sh
+```
+
+This script will:
+1.  Initialize Terraform in a temporary directory.
+2.  Run `terraform plan -json` to generate a plan.
+3.  Use `jq` to verify the presence of key resources (`aws_vpc`, `aws_instance`) and the `ExpiryDate` tag on the EC2 instance, as well as the `expiry_timestamp` output.

--- a/terraform-modules/nightly-nightly-temporal-sandbox/src/main.tf
+++ b/terraform-modules/nightly-nightly-temporal-sandbox/src/main.tf
@@ -1,0 +1,107 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_vpc" "temporal_sandbox_vpc" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name        = "${var.sandbox_name}-vpc"
+    Environment = "TemporalSandbox"
+    ExpiryDate  = time_static.expiry_timestamp.rfc3339
+  }
+}
+
+resource "aws_subnet" "temporal_sandbox_subnet" {
+  vpc_id            = aws_vpc.temporal_sandbox_vpc.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "${var.aws_region}a" # Assuming 'a' zone exists
+
+  tags = {
+    Name        = "${var.sandbox_name}-subnet"
+    Environment = "TemporalSandbox"
+    ExpiryDate  = time_static.expiry_timestamp.rfc3339
+  }
+}
+
+resource "aws_security_group" "temporal_sandbox_sg" {
+  name        = "${var.sandbox_name}-sg"
+  description = "Allow SSH and all egress for temporal sandbox"
+  vpc_id      = aws_vpc.temporal_sandbox_vpc.id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # WARNING: For sandbox only, restrict in production!
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "${var.sandbox_name}-sg"
+    Environment = "TemporalSandbox"
+    ExpiryDate  = time_static.expiry_timestamp.rfc3339
+  }
+}
+
+resource "aws_instance" "temporal_sandbox_instance" {
+  ami           = data.aws_ami.amazon_linux_2.id
+  instance_type = var.instance_type
+  subnet_id     = aws_subnet.temporal_sandbox_subnet.id
+  vpc_security_group_ids = [aws_security_group.temporal_sandbox_sg.id]
+
+  tags = {
+    Name        = "${var.sandbox_name}-instance"
+    Environment = "TemporalSandbox"
+    ExpiryDate  = time_static.expiry_timestamp.rfc3339
+  }
+}
+
+# Data source to get the latest Amazon Linux 2 AMI
+data "aws_ami" "amazon_linux_2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# Calculate expiry timestamp
+resource "time_static" "expiry_timestamp" {
+  triggers = {
+    ttl_hours = var.ttl_hours
+  }
+  # Mock rationale: time_static is a Terraform provider that calculates a timestamp.
+  # For testing, its output is deterministic based on input variables and the current time
+  # when `terraform plan` is run. The test script will verify the *format* and *presence*
+  # of this timestamp in the plan, not its exact future value.
+  # The `time_static` resource is used here to ensure the expiry date is consistently
+  # calculated and available for tagging.
+  # The `rfc3339` format is standard for timestamps.
+  after = "${var.ttl_hours}h"
+}

--- a/terraform-modules/nightly-nightly-temporal-sandbox/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-temporal-sandbox/src/outputs.tf
@@ -1,0 +1,19 @@
+output "sandbox_id" {
+  description = "The ID of the deployed EC2 instance."
+  value       = aws_instance.temporal_sandbox_instance.id
+}
+
+output "expiry_timestamp" {
+  description = "The UTC timestamp (RFC3339) when the sandbox is intended to expire."
+  value       = time_static.expiry_timestamp.rfc3339
+}
+
+output "vpc_id" {
+  description = "The ID of the created VPC."
+  value       = aws_vpc.temporal_sandbox_vpc.id
+}
+
+output "subnet_id" {
+  description = "The ID of the created subnet."
+  value       = aws_subnet.temporal_sandbox_subnet.id
+}

--- a/terraform-modules/nightly-nightly-temporal-sandbox/src/variables.tf
+++ b/terraform-modules/nightly-nightly-temporal-sandbox/src/variables.tf
@@ -1,0 +1,23 @@
+variable "aws_region" {
+  description = "The AWS region to deploy resources into."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "instance_type" {
+  description = "The EC2 instance type for the sandbox."
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "ttl_hours" {
+  description = "Time-To-Live for the sandbox in hours."
+  type        = number
+  default     = 24
+}
+
+variable "sandbox_name" {
+  description = "A unique name for this temporal sandbox."
+  type        = string
+  default     = "default-temporal-sandbox"
+}

--- a/terraform-modules/nightly-nightly-temporal-sandbox/tests/test_plan.sh
+++ b/terraform-modules/nightly-nightly-temporal-sandbox/tests/test_plan.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -euo pipefail
+
+# Mock rationale: This test script operates entirely offline by analyzing the output
+# of `terraform plan -json`. It does not interact with any actual cloud provider APIs.
+# The `terraform plan` command itself is deterministic given a set of input files
+# and variables, producing a JSON representation of the intended infrastructure changes.
+# `jq` is used to parse this local, static JSON output, ensuring the test is
+# self-contained and does not require external network access or cloud credentials
+# beyond what Terraform itself needs to *parse* the configuration (which is minimal
+# for a plan, not an apply).
+
+echo "Starting Nightly Temporal Sandbox Terraform plan tests..."
+
+# Create a temporary directory for Terraform operations
+TEST_DIR=$(mktemp -d)
+echo "Using temporary directory: $TEST_DIR"
+cp -r ../src/* "$TEST_DIR/"
+cd "$TEST_DIR"
+
+# Initialize Terraform
+echo "Initializing Terraform..."
+terraform init -backend=false > /dev/null # -backend=false for offline testing
+if [ $? -ne 0 ]; then
+    echo "Terraform init failed!"
+    exit 1
+fi
+echo "Terraform init successful."
+
+# Run terraform plan and capture JSON output
+echo "Generating Terraform plan JSON..."
+PLAN_OUTPUT=$(terraform plan -out=tfplan.binary -json -var="sandbox_name=test-sandbox" -var="ttl_hours=1" 2>&1)
+if [ $? -ne 0 ]; then
+    echo "Terraform plan failed!"
+    echo "$PLAN_OUTPUT"
+    exit 1
+fi
+echo "Terraform plan generated."
+
+# Extract the JSON part from the plan output (it might contain other logs)
+# The actual plan JSON is usually prefixed with a specific marker or is the last JSON object.
+# For simplicity, we'll assume the `terraform plan -json` output is mostly JSON.
+# A more robust approach would be to parse the entire output and find the object of type "plan".
+# For this test, we'll just try to parse the whole thing.
+PLAN_JSON=$(terraform show -json tfplan.binary)
+
+# Test 1: Verify that an aws_vpc resource is planned
+echo "Test 1: Verifying aws_vpc resource..."
+if echo "$PLAN_JSON" | jq -e '.resource_changes[] | select(.type == "aws_vpc" and .change.actions[] == "create")' > /dev/null; then
+    echo "  PASS: aws_vpc resource found in plan."
+else
+    echo "  FAIL: aws_vpc resource not found in plan."
+    exit 1
+fi
+
+# Test 2: Verify that an aws_instance resource is planned
+echo "Test 2: Verifying aws_instance resource..."
+if echo "$PLAN_JSON" | jq -e '.resource_changes[] | select(.type == "aws_instance" and .change.actions[] == "create")' > /dev/null; then
+    echo "  PASS: aws_instance resource found in plan."
+else
+    echo "  FAIL: aws_instance resource not found in plan."
+    exit 1
+fi
+
+# Test 3: Verify that the aws_instance has an ExpiryDate tag
+echo "Test 3: Verifying aws_instance has ExpiryDate tag..."
+if echo "$PLAN_JSON" | jq -e '.resource_changes[] | select(.type == "aws_instance" and .change.actions[] == "create") | .change.after.tags.ExpiryDate' > /dev/null; then
+    echo "  PASS: aws_instance has ExpiryDate tag."
+else
+    echo "  FAIL: aws_instance does not have ExpiryDate tag."
+    exit 1
+fi
+
+# Test 4: Verify that the expiry_timestamp output is present and is a valid RFC3339 format
+echo "Test 4: Verifying expiry_timestamp output..."
+EXPIRY_OUTPUT=$(echo "$PLAN_JSON" | jq -r '.planned_values.outputs.expiry_timestamp.value')
+if [[ "$EXPIRY_OUTPUT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+    echo "  PASS: expiry_timestamp output is present and in RFC3339 format: $EXPIRY_OUTPUT"
+else
+    echo "  FAIL: expiry_timestamp output is missing or not in RFC3339 format: $EXPIRY_OUTPUT"
+    exit 1
+fi
+
+echo "All tests passed for Nightly Temporal Sandbox."
+
+# Clean up temporary directory
+cd - > /dev/null
+rm -rf "$TEST_DIR"
+echo "Cleaned up temporary directory: $TEST_DIR"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-temporal-sandbox
- **Provider**: gemini
- **Location**: `terraform-modules/nightly-nightly-temporal-sandbox`
- **Files Created**: 5
- **Description**: Deploys an ephemeral AWS cloud sandbox with expiry tags for temporal anomaly experimentation.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-temporal-sandbox`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-temporal-sandbox/README.md`
- Run tests located in `terraform-modules/nightly-nightly-temporal-sandbox/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.