### PR TITLE
feat(groq): Concurrent TCP‑based ping utility that measures latency of multiple hosts in parallel and outputs a JSON summary.

### DIFF
--- a/go-utils/nightly-nightly-ping-party/README.md
+++ b/go-utils/nightly-nightly-ping-party/README.md
@@ -1,0 +1,35 @@
+# nightly-ping-party
+
+A whimsical concurrent ping utility that checks the latency of multiple hosts (or IPs) by attempting TCP connections. It runs each check in parallel and prints a JSON summary of reachable hosts with their round‑trip times.
+
+## Usage
+
+```sh
+go run ./src/main.go host1.com 8.8.8.8 example.org
+```
+
+Or pipe a list of hosts (one per line) via stdin:
+
+```sh
+cat hosts.txt | go run ./src/main.go
+```
+
+## Output
+
+```json
+{
+  "results": [
+    {"host":"host1.com","latency_ms":23.5,"error":null},
+    {"host":"8.8.8.8","latency_ms":12.1,"error":null},
+    {"host":"example.org","latency_ms":null,"error":"connect timeout"}
+  ]
+}
+```
+
+## Options
+
+- `-timeout` (default 2s) – maximum time to wait for each connection.
+
+## License
+
+MIT

--- a/go-utils/nightly-nightly-ping-party/src/main.go
+++ b/go-utils/nightly-nightly-ping-party/src/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+    "bufio"
+    "encoding/json"
+    "flag"
+    "fmt"
+    "net"
+    "os"
+    "strings"
+    "sync"
+    "time"
+)
+
+type Result struct {
+    Host      string   `json:"host"`
+    LatencyMs *float64 `json:"latency_ms,omitempty"`
+    Error     *string  `json:"error,omitempty"`
+}
+
+// PingHost attempts a TCP connection to the given host on port 80 and measures the round‑trip time.
+// It returns the latency in milliseconds or an error if the connection could not be established.
+func PingHost(host string, timeout time.Duration) (float64, error) {
+    start := time.Now()
+    conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, "80"), timeout)
+    if err != nil {
+        return 0, err
+    }
+    conn.Close()
+    elapsed := time.Since(start).Seconds() * 1000 // convert to ms
+    return elapsed, nil
+}
+
+func main() {
+    timeoutFlag := flag.Duration("timeout", 2*time.Second, "connection timeout")
+    flag.Parse()
+    hosts := []string{}
+    // If positional arguments are provided, use them; otherwise read from stdin.
+    if flag.NArg() > 0 {
+        hosts = flag.Args()
+    } else {
+        scanner := bufio.NewScanner(os.Stdin)
+        for scanner.Scan() {
+            line := strings.TrimSpace(scanner.Text())
+            if line != "" {
+                hosts = append(hosts, line)
+            }
+        }
+    }
+
+    var wg sync.WaitGroup
+    results := make([]Result, len(hosts))
+    for i, h := range hosts {
+        wg.Add(1)
+        go func(idx int, host string) {
+            defer wg.Done()
+            latency, err := PingHost(host, *timeoutFlag)
+            if err != nil {
+                errStr := err.Error()
+                results[idx] = Result{Host: host, Error: &errStr}
+            } else {
+                lat := latency
+                results[idx] = Result{Host: host, LatencyMs: &lat}
+            }
+        }(i, h)
+    }
+    wg.Wait()
+    output := map[string][]Result{"results": results}
+    enc := json.NewEncoder(os.Stdout)
+    enc.SetIndent("", "  ")
+    if err := enc.Encode(output); err != nil {
+        fmt.Fprintln(os.Stderr, "failed to encode output:", err)
+        os.Exit(1)
+    }
+}

--- a/go-utils/nightly-nightly-ping-party/tests/main_test.go
+++ b/go-utils/nightly-nightly-ping-party/tests/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+    "net"
+    "testing"
+    "time"
+)
+
+func TestPingHostSuccess(t *testing.T) {
+    // Mock rationale: start a local TCP server to guarantee a reachable host.
+    ln, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        t.Fatalf("failed to start mock server: %v", err)
+    }
+    defer ln.Close()
+    addr := ln.Addr().String()
+    host, _, _ := net.SplitHostPort(addr)
+
+    // Run PingHost against the mock server
+    latency, err := PingHost(host, 1*time.Second)
+    if err != nil {
+        t.Fatalf("expected no error, got %v", err)
+    }
+    if latency <= 0 {
+        t.Fatalf("expected positive latency, got %v", latency)
+    }
+}
+
+func TestPingHostTimeout(t *testing.T) {
+    // Mock rationale: use an unroutable IP to force a timeout.
+    host := "10.255.255.1" // non‑routable address
+    _, err := PingHost(host, 200*time.Millisecond)
+    if err == nil {
+        t.Fatalf("expected timeout error, got nil")
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ping-party
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-ping-party`
- **Files Created**: 3
- **Description**: Concurrent TCP‑based ping utility that measures latency of multiple hosts in parallel and outputs a JSON summary.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-ping-party`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-ping-party/README.md`
- Run tests located in `go-utils/nightly-nightly-ping-party/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.