### PR TITLE
feat(groq): An Ansible playbook that installs a daily cron job to display a random emoji mood each morning.

### DIFF
--- a/ansible-playbooks/nightly-nightly-emoji-mood-notifier/README.md
+++ b/ansible-playbooks/nightly-nightly-emoji-mood-notifier/README.md
@@ -1,0 +1,24 @@
+# Emoji Mood Notifier
+
+A whimsical Ansible playbook that installs a tiny script which prints a random emoji mood to the console each morning via a cron job. Useful for adding a splash of joy to your server's daily routine.
+
+## Requirements
+
+- Ansible 2.9+
+- Target host with cron support
+
+## Usage
+
+```bash
+ansible-playbook -i inventory.ini src/main.yml
+```
+
+The playbook will:
+
+1. Copy `notify.sh` to `/usr/local/bin/emoji_mood_notifier.sh`.
+2. Make it executable.
+3. Create a daily cron job at 09:00 that runs the script.
+
+## Customization
+
+Edit `src/notify.sh` to change the list of emojis or the output format.

--- a/ansible-playbooks/nightly-nightly-emoji-mood-notifier/src/main.yml
+++ b/ansible-playbooks/nightly-nightly-emoji-mood-notifier/src/main.yml
@@ -1,0 +1,19 @@
+- name: Install Emoji Mood Notifier
+  hosts: all
+  become: true
+  vars:
+    script_path: /usr/local/bin/emoji_mood_notifier.sh
+  tasks:
+    - name: Copy notifier script
+      copy:
+        src: notify.sh
+        dest: "{{ script_path }}"
+        mode: '0755'
+
+    - name: Ensure daily cron job
+      cron:
+        name: "Emoji Mood Notifier"
+        minute: "0"
+        hour: "9"
+        job: "{{ script_path }}"
+        state: present

--- a/ansible-playbooks/nightly-nightly-emoji-mood-notifier/src/notify.sh
+++ b/ansible-playbooks/nightly-nightly-emoji-mood-notifier/src/notify.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+EMOJIS=("😀" "😎" "🤖" "🌟" "🚀" "🦄")
+RANDOM_INDEX=$((RANDOM % ${#EMOJIS[@]}))
+echo "Good morning! Your mood emoji: ${EMOJIS[$RANDOM_INDEX]}"

--- a/ansible-playbooks/nightly-nightly-emoji-mood-notifier/tests/test_emoji_mood.yml
+++ b/ansible-playbooks/nightly-nightly-emoji-mood-notifier/tests/test_emoji_mood.yml
@@ -1,0 +1,13 @@
+- name: Test Emoji Mood Notifier Playbook Syntax
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Run playbook in check mode
+      ansible.builtin.command: ansible-playbook -i localhost, -c local src/main.yml --check
+      register: result
+      changed_when: false
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - result.rc == 0
+      # Mock rationale: assume playbook runs successfully in check mode.


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-emoji-mood-notifier
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-emoji-mood-notifier`
- **Files Created**: 4
- **Description**: An Ansible playbook that installs a daily cron job to display a random emoji mood each morning.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-emoji-mood-notifier`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-emoji-mood-notifier/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-emoji-mood-notifier/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.