### PR TITLE
feat(groq): Shows system uptime with a whimsical emoji reflecting how long the machine has survived.

### DIFF
--- a/bash-utils/nightly-nightly-uptime-emoji-report-2/README.md
+++ b/bash-utils/nightly-nightly-uptime-emoji-report-2/README.md
@@ -1,0 +1,34 @@
+# nightly-uptime-emoji-report
+
+A whimsical Bash utility that reads the system uptime and prints an emoji representing how long the machine has been alive. Perfect for adding a touch of post‑apocalyptic flair to your terminal.
+
+## Usage
+
+```sh
+./src/main.sh
+```
+
+Output example:
+
+```
+System uptime: 3 days 4 hours 12 minutes 🌳
+```
+
+## Emoji Legend
+
+- 🌱 – less than 1 day
+- 🌿 – 1‑3 days
+- 🌳 – 3‑7 days
+- 🌲 – more than 7 days
+
+## How it works
+
+The script reads `/proc/uptime`, converts the seconds to days, hours, and minutes, then selects an emoji based on the total days.
+
+## Testing
+
+Run the test suite with:
+
+```sh
+bash tests/test_main.sh
+```

--- a/bash-utils/nightly-nightly-uptime-emoji-report-2/src/main.sh
+++ b/bash-utils/nightly-nightly-uptime-emoji-report-2/src/main.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# nightly-uptime-emoji-report
+# Reads system uptime and prints an emoji based on duration.
+
+# Function to convert seconds to human‑readable format
+format_uptime() {
+  local total_seconds=$1
+  local days=$(( total_seconds / 86400 ))
+  local hours=$(( (total_seconds % 86400) / 3600 ))
+  local minutes=$(( (total_seconds % 3600) / 60 ))
+  echo "${days} days ${hours} hours ${minutes} minutes"
+}
+
+# Function to select emoji based on days
+select_emoji() {
+  local days=$1
+  if (( days < 1 )); then
+    echo "🌱"
+  elif (( days < 3 )); then
+    echo "🌿"
+  elif (( days < 7 )); then
+    echo "🌳"
+  else
+    echo "🌲"
+  fi
+}
+
+# Main execution
+main() {
+  if [[ ! -r /proc/uptime ]]; then
+    echo "Cannot read /proc/uptime"
+    exit 1
+  fi
+  # First field is total seconds
+  local uptime_seconds=$(awk '{print int($1)}' /proc/uptime)
+  local human=$(format_uptime "$uptime_seconds")
+  local days=$(( uptime_seconds / 86400 ))
+  local emoji=$(select_emoji "$days")
+  echo "System uptime: $human $emoji"
+}
+
+# If script is executed (not sourced), run main
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/bash-utils/nightly-nightly-uptime-emoji-report-2/tests/test_main.sh
+++ b/bash-utils/nightly-nightly-uptime-emoji-report-2/tests/test_main.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Tests for nightly-uptime-emoji-report
+
+# Load functions from script
+source "$(dirname "$0")/../src/main.sh"
+
+# Test format_uptime
+test_format_uptime() {
+  local result
+  result=$(format_uptime 90061) # 1 day 1 hour 1 minute
+  if [[ "$result" != "1 days 1 hours 1 minutes" ]]; then
+    echo "FAIL: format_uptime"
+    exit 1
+  fi
+}
+
+# Test select_emoji boundaries
+test_select_emoji() {
+  local e
+  e=$(select_emoji 0)
+  [[ "$e" == "🌱" ]] || { echo "FAIL: emoji <1 day"; exit 1; }
+  e=$(select_emoji 2)
+  [[ "$e" == "🌿" ]] || { echo "FAIL: emoji 1-3 days"; exit 1; }
+  e=$(select_emoji 5)
+  [[ "$e" == "🌳" ]] || { echo "FAIL: emoji 3-7 days"; exit 1; }
+  e=$(select_emoji 10)
+  [[ "$e" == "🌲" ]] || { echo "FAIL: emoji >7 days"; exit 1; }
+}
+
+# Run tests
+test_format_uptime
+test_select_emoji
+
+echo "All tests passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-uptime-emoji-report
- **Provider**: groq
- **Location**: `bash-utils/nightly-nightly-uptime-emoji-report-2`
- **Files Created**: 3
- **Description**: Shows system uptime with a whimsical emoji reflecting how long the machine has survived.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `bash-utils/nightly-nightly-uptime-emoji-report-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `bash-utils/nightly-nightly-uptime-emoji-report-2/README.md`
- Run tests located in `bash-utils/nightly-nightly-uptime-emoji-report-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.