### PR TITLE
feat(gemini): A high-performance CLI tool to generate a registry of 'relic' files in a directory, calculating their checksums and assigning a whimsical 'decay status'.

### DIFF
--- a/rust-utils/nightly-nightly-relic-registry-cli/Cargo.toml
+++ b/rust-utils/nightly-nightly-relic-registry-cli/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nightly-relic-registry-cli"
+version = "0.1.0"
+edition = "2021"
+authors = ["ApocalypsAI Nightly Integrator"]
+description = "A high-performance CLI tool to generate a registry of 'relic' files in a directory, calculating their checksums and assigning a whimsical 'decay status'."
+license = "MIT"
+repository = "https://github.com/polsala/ApocalypsAI"
+
+[dependencies]
+clap = { version = "4.0", features = ["derive"] }
+walkdir = "2.3"
+sha2 = "0.10"
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+tempfile = "3.0"
+filetime = "0.2"

--- a/rust-utils/nightly-nightly-relic-registry-cli/README.md
+++ b/rust-utils/nightly-nightly-relic-registry-cli/README.md
@@ -1,0 +1,95 @@
+# Nightly Relic Registry CLI
+
+`nightly-relic-registry-cli` is a high-performance command-line utility crafted to help you catalog and assess the 'decay status' of files (or 'relics') within a specified directory. It recursively scans, calculates SHA256 checksums, records modification times, and assigns a whimsical decay status based on age.
+
+## Features
+
+*   **Recursive Scanning**: Traverses directories to find all files.
+*   **SHA256 Checksums**: Ensures the integrity of your digital relics.
+*   **Decay Status**: Assigns a fun status (Pristine, Weathered, Decaying, Dust) based on the file's last modification time.
+*   **JSON Output**: Generates a structured JSON file for easy parsing and integration.
+
+## Installation
+
+To install `nightly-relic-registry-cli`, you need to have Rust and Cargo installed. If you don't, visit [rustup.rs](https://rustup.rs/) for instructions.
+
+```bash
+cargo install nightly-relic-registry-cli
+```
+
+Alternatively, you can clone the repository and build from source:
+
+```bash
+git clone https://github.com/polsala/ApocalypsAI.git
+cd ApocalypsAI/rust-utils/nightly-relic-registry-cli
+cargo build --release
+# The executable will be found at target/release/nightly-relic-registry-cli
+```
+
+## Usage
+
+Run the utility by specifying the input directory and an optional output file.
+
+```bash
+nightly-relic-registry-cli --input-dir /path/to/your/relics --output-file my_relic_manifest.json
+```
+
+### Arguments
+
+*   `-i`, `--input-dir <DIR>`: The directory to scan for relics. (Required)
+*   `-o`, `--output-file <FILE>`: The output file for the relic registry in JSON format. Defaults to `relic_registry.json`. (Optional)
+
+### Example
+
+```bash
+# Scan your 'documents' folder and save the registry to 'documents_registry.json'
+nightly-relic-registry-cli -i ~/documents -o documents_registry.json
+
+# Scan the current directory and save to the default output file
+nightly-relic-registry-cli -i .
+```
+
+## Output Format
+
+The output is a JSON array of relic entries, each with the following structure:
+
+```json
+[
+  {
+    "id": "RELIC-1",
+    "path": "/path/to/your/relics/document.txt",
+    "filename": "document.txt",
+    "checksum_sha256": "a1b2c3d4e5f6...",
+    "last_modified": "2023-10-27T10:00:00Z",
+    "decay_status": "Pristine",
+    "size_bytes": 12345
+  },
+  {
+    "id": "RELIC-2",
+    "path": "/path/to/your/relics/archive/old_photo.jpg",
+    "filename": "old_photo.jpg",
+    "checksum_sha256": "f6e5d4c3b2a1...",
+    "last_modified": "2018-05-15T14:30:00Z",
+    "decay_status": "Weathered",
+    "size_bytes": 987654
+  }
+]
+```
+
+### Decay Status Definitions
+
+*   `Pristine`: Last modified less than 1 year ago.
+*   `Weathered`: Last modified 1 to 5 years ago.
+*   `Decaying`: Last modified 5 to 10 years ago.
+*   `Dust`: Last modified more than 10 years ago.
+*   `Unknown`: Modification time could not be retrieved.
+
+## Development
+
+To contribute or modify the tool:
+
+1.  Clone the repository.
+2.  Navigate to `rust-utils/nightly-relic-registry-cli`.
+3.  Run tests: `cargo test`
+4.  Build: `cargo build`
+5.  Run: `cargo run -- -i <input_dir> -o <output_file>`

--- a/rust-utils/nightly-nightly-relic-registry-cli/src/main.rs
+++ b/rust-utils/nightly-nightly-relic-registry-cli/src/main.rs
@@ -1,0 +1,124 @@
+use clap::Parser;
+use walkdir::WalkDir;
+use sha2::{Sha256, Digest};
+use chrono::{Utc, Duration, DateTime};
+use serde::{Serialize, Deserialize};
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Directory to scan for relics
+    #[clap(short, long, value_parser)]
+    input_dir: String,
+
+    /// Output file for the relic registry (JSON format)
+    #[clap(short, long, value_parser, default_value = "relic_registry.json")]
+    output_file: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+enum DecayStatus {
+    Pristine,
+    Weathered,
+    Decaying,
+    Dust,
+    Unknown, // For files with no valid modification time
+}
+
+impl DecayStatus {
+    fn from_timestamp(timestamp: DateTime<Utc>) -> Self {
+        let now = Utc::now();
+        let age = now - timestamp;
+
+        if age < Duration::days(365) { // Less than 1 year
+            DecayStatus::Pristine
+        } else if age < Duration::days(365 * 5) { // 1 to 5 years
+            DecayStatus::Weathered
+        } else if age < Duration::days(365 * 10) { // 5 to 10 years
+            DecayStatus::Decaying
+        } else { // More than 10 years
+            DecayStatus::Dust
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct RelicEntry {
+    id: String,
+    path: PathBuf,
+    filename: String,
+    checksum_sha256: String,
+    last_modified: Option<DateTime<Utc>>,
+    decay_status: DecayStatus,
+    size_bytes: u64,
+}
+
+fn calculate_sha256(path: &Path) -> io::Result<String> {
+    let mut file = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0; 1024];
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn generate_relic_registry(input_dir: &Path) -> io::Result<Vec<RelicEntry>> {
+    let mut registry = Vec::new();
+    let mut relic_counter = 0;
+
+    for entry in WalkDir::new(input_dir).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.is_file() {
+            relic_counter += 1;
+            let filename = path.file_name().unwrap_or_default().to_string_lossy().into_owned();
+            let checksum = calculate_sha256(path)?;
+            let metadata = fs::metadata(path)?;
+            let last_modified: Option<DateTime<Utc>> = metadata.modified().ok().map(Into::into);
+            let decay_status = last_modified.map_or(DecayStatus::Unknown, DecayStatus::from_timestamp);
+            let size_bytes = metadata.len();
+
+            registry.push(RelicEntry {
+                id: format!("RELIC-{}", relic_counter),
+                path: path.to_path_buf(),
+                filename,
+                checksum_sha256: checksum,
+                last_modified,
+                decay_status,
+                size_bytes,
+            });
+        }
+    }
+    Ok(registry)
+}
+
+fn main() -> io::Result<()> {
+    let args = Args::parse();
+
+    let input_path = PathBuf::from(&args.input_dir);
+    if !input_path.exists() {
+        eprintln!("Error: Input directory '{}' does not exist.", args.input_dir);
+        std::process::exit(1);
+    }
+    if !input_path.is_dir() {
+        eprintln!("Error: Input path '{}' is not a directory.", args.input_dir);
+        std::process::exit(1);
+    }
+
+    println!("Scanning '{}' for relics...", args.input_dir);
+    let registry = generate_relic_registry(&input_path)?;
+
+    let output_json = serde_json::to_string_pretty(&registry)?;
+    fs::write(&args.output_file, output_json)?;
+
+    println!("Relic registry generated successfully to '{}'. Found {} relics.", args.output_file, registry.len());
+
+    Ok(())
+}

--- a/rust-utils/nightly-nightly-relic-registry-cli/tests/test_relic_registry.rs
+++ b/rust-utils/nightly-nightly-relic-registry-cli/tests/test_relic_registry.rs
@@ -1,0 +1,178 @@
+use super::*;
+use std::fs::{self, File};
+use std::io::Write;
+use tempfile::tempdir;
+use chrono::{Utc, Duration};
+
+// Mock rationale: We create temporary files and directories to simulate a file system
+// without relying on actual user files or external resources. This ensures tests are
+// deterministic and isolated. We also control file modification times for decay status testing.
+
+#[test]
+fn test_calculate_sha256() -> io::Result<()> {
+    let dir = tempdir()?;
+    let file_path = dir.path().join("test_file.txt");
+    fs::write(&file_path, "hello world")?;
+    let expected_checksum = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e7304336293879ecb";
+    assert_eq!(calculate_sha256(&file_path)?, expected_checksum);
+    Ok(())
+}
+
+#[test]
+fn test_decay_status_from_timestamp() {
+    let now = Utc::now();
+
+    // Pristine: less than 1 year old
+    let pristine_time = now - Duration::days(100);
+    assert_eq!(DecayStatus::from_timestamp(pristine_time), DecayStatus::Pristine);
+
+    // Weathered: 1 to 5 years old
+    let weathered_time = now - Duration::days(365 * 2); // 2 years old
+    assert_eq!(DecayStatus::from_timestamp(weathered_time), DecayStatus::Weathered);
+
+    // Decaying: 5 to 10 years old
+    let decaying_time = now - Duration::days(365 * 7); // 7 years old
+    assert_eq!(DecayStatus::from_timestamp(decaying_time), DecayStatus::Decaying);
+
+    // Dust: more than 10 years old
+    let dust_time = now - Duration::days(365 * 12); // 12 years old
+    assert_eq!(DecayStatus::from_timestamp(dust_time), DecayStatus::Dust);
+}
+
+#[test]
+fn test_generate_relic_registry() -> io::Result<()> {
+    let dir = tempdir()?;
+    let input_dir = dir.path().join("relics");
+    fs::create_dir(&input_dir)?;
+
+    // Create a pristine file (less than 1 year old)
+    let pristine_file_path = input_dir.join("pristine.txt");
+    fs::write(&pristine_file_path, "fresh data")?;
+    // Set modification time to recent (within 1 year)
+    let now = Utc::now();
+    let one_month_ago = now - Duration::days(30);
+    filetime::set_file_mtime(&pristine_file_path, filetime::FileTime::from_system_time(one_month_ago.into()))?;
+
+    // Create a weathered file (2 years old)
+    let weathered_file_path = input_dir.join("old_log.txt");
+    fs::write(&weathered_file_path, "old log entries")?;
+    let two_years_ago = now - Duration::days(365 * 2);
+    filetime::set_file_mtime(&weathered_file_path, filetime::FileTime::from_system_time(two_years_ago.into()))?;
+
+    // Create a decaying file (7 years old)
+    let decaying_file_path = input_dir.join("ancient_config.cfg");
+    fs::write(&decaying_file_path, "config v1")?;
+    let seven_years_ago = now - Duration::days(365 * 7);
+    filetime::set_file_mtime(&decaying_file_path, filetime::FileTime::from_system_time(seven_years_ago.into()))?;
+
+    // Create a dust file (12 years old)
+    let dust_file_path = input_dir.join("forgotten_memo.doc");
+    fs::write(&dust_file_path, "top secret memo")?;
+    let twelve_years_ago = now - Duration::days(365 * 12);
+    filetime::set_file_mtime(&dust_file_path, filetime::FileTime::from_system_time(twelve_years_ago.into()))?;
+
+    // Create a subdirectory with another file
+    let sub_dir = input_dir.join("sub_dir");
+    fs::create_dir(&sub_dir)?;
+    let sub_file_path = sub_dir.join("nested.txt");
+    fs::write(&sub_file_path, "nested data")?;
+    filetime::set_file_mtime(&sub_file_path, filetime::FileTime::from_system_time(one_month_ago.into()))?; // Pristine
+
+    let registry = generate_relic_registry(&input_dir)?;
+
+    assert_eq!(registry.len(), 5); // 4 files in root, 1 in sub_dir
+
+    // Check specific entries
+    let pristine_entry = registry.iter().find(|e| e.filename == "pristine.txt").unwrap();
+    assert_eq!(pristine_entry.decay_status, DecayStatus::Pristine);
+    assert_eq!(pristine_entry.checksum_sha256, calculate_sha256(&pristine_file_path)?);
+
+    let weathered_entry = registry.iter().find(|e| e.filename == "old_log.txt").unwrap();
+    assert_eq!(weathered_entry.decay_status, DecayStatus::Weathered);
+
+    let decaying_entry = registry.iter().find(|e| e.filename == "ancient_config.cfg").unwrap();
+    assert_eq!(decaying_entry.decay_status, DecayStatus::Decaying);
+
+    let dust_entry = registry.iter().find(|e| e.filename == "forgotten_memo.doc").unwrap();
+    assert_eq!(dust_entry.decay_status, DecayStatus::Dust);
+
+    let nested_entry = registry.iter().find(|e| e.filename == "nested.txt").unwrap();
+    assert_eq!(nested_entry.decay_status, DecayStatus::Pristine);
+    assert!(nested_entry.path.to_string_lossy().contains("sub_dir"));
+
+    Ok(())
+}
+
+#[test]
+fn test_main_cli_output() -> io::Result<()> {
+    let dir = tempdir()?;
+    let input_dir = dir.path().join("test_input");
+    fs::create_dir(&input_dir)?;
+    fs::write(input_dir.join("file1.txt"), "content1")?;
+    fs::write(input_dir.join("file2.txt"), "content2")?;
+
+    let output_file = dir.path().join("test_registry.json");
+
+    // Temporarily set command line arguments
+    let args = vec![
+        "nightly-relic-registry-cli".to_string(),
+        "--input-dir".to_string(),
+        input_dir.to_string_lossy().to_string(),
+        "--output-file".to_string(),
+        output_file.to_string_lossy().to_string(),
+    ];
+    // Mock rationale: We capture stdout/stderr to verify the CLI output without
+    // actually printing to the console during tests. This makes the test deterministic.
+    let original_args = std::env::args().collect::<Vec<String>>();
+    std::env::set_var("RUST_BACKTRACE", "0"); // Suppress backtrace for cleaner test output
+    std::env::set_args(args);
+
+    let result = std::panic::catch_unwind(|| {
+        main()
+    });
+
+    // Restore original arguments
+    std::env::set_args(original_args);
+
+    assert!(result.is_ok(), "main function panicked: {:?}", result.err());
+    assert!(result.unwrap().is_ok(), "main function returned an error");
+
+    assert!(output_file.exists());
+    let content = fs::read_to_string(&output_file)?;
+    let registry: Vec<RelicEntry> = serde_json::from_str(&content)?;
+
+    assert_eq!(registry.len(), 2);
+    assert!(content.contains("file1.txt"));
+    assert!(content.contains("file2.txt"));
+    assert!(content.contains("Pristine")); // Default decay status for newly created files
+
+    Ok(())
+}
+
+#[test]
+fn test_main_cli_invalid_input_dir() -> io::Result<()> {
+    let dir = tempdir()?;
+    let non_existent_dir = dir.path().join("non_existent");
+    let output_file = dir.path().join("test_registry.json");
+
+    let args = vec![
+        "nightly-relic-registry-cli".to_string(),
+        "--input-dir".to_string(),
+        non_existent_dir.to_string_lossy().to_string(),
+        "--output-file".to_string(),
+        output_file.to_string_lossy().to_string(),
+    ];
+    let original_args = std::env::args().collect::<Vec<String>>();
+    std::env::set_args(args);
+
+    // Mock rationale: We expect the program to exit with an error code,
+    // so we catch the panic that `std::process::exit` causes in tests.
+    let result = std::panic::catch_unwind(|| {
+        main().unwrap(); // main() returns Result, unwrap() will panic on Err
+    });
+
+    std::env::set_args(original_args);
+
+    assert!(result.is_err()); // Expect a panic due to exit(1)
+    Ok(())
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-relic-registry-cli
- **Provider**: gemini
- **Location**: `rust-utils/nightly-nightly-relic-registry-cli`
- **Files Created**: 4
- **Description**: A high-performance CLI tool to generate a registry of 'relic' files in a directory, calculating their checksums and assigning a whimsical 'decay status'.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-relic-registry-cli`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-relic-registry-cli/README.md`
- Run tests located in `rust-utils/nightly-nightly-relic-registry-cli/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.