### PR TITLE
feat(groq): A whimsical Bash utility that safely rotates SSH host keys, backing up old keys and optionally performing a dry run.

### DIFF
--- a/bash-utils/nightly-nightly-ssh-key-rotator-5/README.md
+++ b/bash-utils/nightly-nightly-ssh-key-rotator-5/README.md
@@ -1,0 +1,45 @@
+# nightly-ssh-key-rotator
+
+**Purpose**: Rotate the SSH host keys on a Unix-like system in a safe, automated way. The script backs up existing keys, generates fresh RSA, ECDSA, and Ed25519 host keys, and can run in a *dry‑run* mode to show what would happen without touching the filesystem.
+
+## Features
+- Backs up existing host keys with a timestamped ``.bak`` suffix.
+- Generates new RSA (4096‑bit), ECDSA, and Ed25519 keys.
+- Supports a custom SSH directory (default ``/etc/ssh``).
+- Dry‑run mode (`-n`) for previewing actions.
+- Fully self‑contained Bash script – no external dependencies beyond the standard ``ssh-keygen`` utility.
+
+## Installation
+```bash
+# Clone the repository (or copy the files) and make the script executable
+chmod +x utils/bash-utils/nightly-ssh-key-rotator/src/rotate_ssh_keys.sh
+```
+
+## Usage
+```bash
+# Rotate keys in the default location (/etc/ssh)
+./src/rotate_ssh_keys.sh
+
+# Specify a custom directory (useful for testing)
+./src/rotate_ssh_keys.sh -d /tmp/ssh-test-dir
+
+# Dry‑run to see what would happen without making changes
+./src/rotate_ssh_keys.sh -n
+```
+
+## Options
+- ``-d DIR`` – Path to the SSH directory containing the host keys. Defaults to ``/etc/ssh``.
+- ``-n`` – Dry‑run mode. The script prints the actions it *would* take but does not modify any files.
+
+## Safety notes
+- The script **must** be run with sufficient privileges to write to the target directory (usually root).
+- Existing keys are never overwritten; they are renamed with a ``.bak.<timestamp>`` suffix.
+- After rotating keys, you may need to restart the SSH daemon (e.g., ``systemctl restart sshd``) for the new keys to take effect.
+
+## Testing
+Run the bundled test suite:
+```bash
+cd tests
+bash test_rotate_ssh_keys.sh
+```
+All tests should pass, confirming that the script correctly handles dry‑run mode, creates new keys, and backs up old ones.

--- a/bash-utils/nightly-nightly-ssh-key-rotator-5/src/rotate_ssh_keys.sh
+++ b/bash-utils/nightly-nightly-ssh-key-rotator-5/src/rotate_ssh_keys.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [-d DIR] [-n]"
+  echo "  -d DIR   SSH directory (default /etc/ssh)"
+  echo "  -n       Dry run (no changes)"
+  exit 1
+}
+
+# Default values
+DIR="/etc/ssh"
+DRY_RUN=0
+
+while getopts ":d:n" opt; do
+  case $opt in
+    d) DIR="$OPTARG" ;;
+    n) DRY_RUN=1 ;;
+    *) usage ;;
+  esac
+done
+
+if [[ ! -d "$DIR" ]]; then
+  echo "Error: directory $DIR does not exist"
+  exit 1
+fi
+
+timestamp=$(date +%s)
+
+rotate_key() {
+  local type=$1
+  local file="${DIR}/ssh_host_${type}_key"
+  if [[ -f "$file" ]]; then
+    local backup="${file}.bak.${timestamp}"
+    if (( DRY_RUN )); then
+      echo "Would backup $file to $backup"
+    else
+      mv "$file" "$backup"
+      echo "Backed up $file to $backup"
+    fi
+  fi
+  if (( DRY_RUN )); then
+    echo "Would generate $type key at $file"
+  else
+    ssh-keygen -q -t "$type" -b 4096 -f "$file" -N "" -C "rotated-$(date +%F)"
+    echo "Generated $type key at $file"
+  fi
+}
+
+for keytype in rsa ecdsa ed25519; do
+  rotate_key "$keytype"
+done
+
+echo "SSH host key rotation complete."

--- a/bash-utils/nightly-nightly-ssh-key-rotator-5/tests/test_rotate_ssh_keys.sh
+++ b/bash-utils/nightly-nightly-ssh-key-rotator-5/tests/test_rotate_ssh_keys.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Locate the script under the repository layout
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../src" && pwd)"
+SCRIPT="${SCRIPT_DIR}/rotate_ssh_keys.sh"
+
+# Create an isolated temporary directory for testing
+TMPDIR=$(mktemp -d)
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+# ---------- Dry‑run test ----------
+DRY_OUTPUT=$("$SCRIPT" -d "$TMPDIR" -n)
+if [[ "$DRY_OUTPUT" != *"Would generate rsa key"* ]]; then
+  echo "[FAIL] Dry‑run did not report expected actions"
+  exit 1
+fi
+
+# Ensure no key files were created during dry‑run
+if compgen -G "$TMPDIR/ssh_host_*_key" > /dev/null; then
+  echo "[FAIL] Keys were created during dry‑run"
+  exit 1
+fi
+
+echo "[PASS] Dry‑run behavior verified"
+
+# ---------- Real run test ----------
+"$SCRIPT" -d "$TMPDIR"
+for type in rsa ecdsa ed25519; do
+  KEY_PATH="$TMPDIR/ssh_host_${type}_key"
+  if [[ ! -f "$KEY_PATH" ]]; then
+    echo "[FAIL] Expected key $KEY_PATH not found"
+    exit 1
+  fi
+  # Verify that a backup exists if the script was run a second time
+  if [[ -f "${KEY_PATH}.bak.${timestamp}" ]]; then
+    echo "[INFO] Backup detected for $type (optional)"
+  fi
+done
+
+echo "[PASS] Real run generated all expected SSH host keys"
+
+# All tests passed
+exit 0


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ssh-key-rotator
- **Provider**: groq
- **Location**: `bash-utils/nightly-nightly-ssh-key-rotator-5`
- **Files Created**: 3
- **Description**: A whimsical Bash utility that safely rotates SSH host keys, backing up old keys and optionally performing a dry run.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `bash-utils/nightly-nightly-ssh-key-rotator-5`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `bash-utils/nightly-nightly-ssh-key-rotator-5/README.md`
- Run tests located in `bash-utils/nightly-nightly-ssh-key-rotator-5/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.