### PR TITLE
feat(groq): Generates a random post‑apocalyptic motivational quote and stores it with a timestamp.

### DIFF
--- a/ansible-playbooks/nightly-nightly-quote-of-the-wastela/README.md
+++ b/ansible-playbooks/nightly-nightly-quote-of-the-wastela/README.md
@@ -1,0 +1,24 @@
+# Nightly Quote of the Wasteland
+
+Utility that, when run, picks a random post‑apocalyptic motivational quote and writes it to `/var/wasteland/quotes/<timestamp>.txt`. Useful for adding a touch of bleak optimism to your servers.
+
+## Usage
+
+```bash
+ansible-playbook -i utils/nightly-quote-of-the-wasteland/src/inventory.ini utils/nightly-quote-of-the-wasteland/src/playbook.yml
+```
+
+## How it works
+
+- Defines a list of quotes.
+- Uses Ansible's `random` filter to pick one.
+- Creates the target directory.
+- Writes the quote to a timestamped file.
+
+## Testing
+
+Run the test playbook:
+
+```bash
+ansible-playbook -i utils/nightly-quote-of-the-wasteland/src/inventory.ini utils/nightly-quote-of-the-wasteland/tests/test_playbook.yml
+```

--- a/ansible-playbooks/nightly-nightly-quote-of-the-wastela/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-quote-of-the-wastela/src/inventory.ini
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-quote-of-the-wastela/src/playbook.yml
+++ b/ansible-playbooks/nightly-nightly-quote-of-the-wastela/src/playbook.yml
@@ -1,0 +1,31 @@
+- name: Generate a random wasteland quote
+  hosts: localhost
+  gather_facts: false
+  vars:
+    quote_list:
+      - "Even the darkest night ends with sunrise."
+      - "Hope is the last fuel in the bunker."
+      - "When the world crumbles, build your own throne."
+      - "Radiation may scar, but it also reveals."
+      - "Survive the storm, then dance in the ash."
+    quote_dir: "/var/wasteland/quotes"
+  tasks:
+    - name: Choose a random quote
+      set_fact:
+        chosen_quote: "{{ quote_list | random }}"
+
+    - name: Get timestamp for filename
+      set_fact:
+        ts: "{{ lookup('pipe','date +%Y%m%d%H%M%S') }}"
+
+    - name: Ensure quote directory exists
+      file:
+        path: "{{ quote_dir }}"
+        state: directory
+        mode: '0755'
+
+    - name: Write quote to timestamped file
+      copy:
+        dest: "{{ quote_dir }}/{{ ts }}.txt"
+        content: "{{ chosen_quote }}\n"
+        mode: '0644'

--- a/ansible-playbooks/nightly-nightly-quote-of-the-wastela/tests/test_playbook.yml
+++ b/ansible-playbooks/nightly-nightly-quote-of-the-wastela/tests/test_playbook.yml
@@ -1,0 +1,47 @@
+- name: Test Quote of the Wasteland playbook
+  hosts: localhost
+  gather_facts: false
+  vars:
+    quote_list:
+      - "Even the darkest night ends with sunrise."
+      - "Hope is the last fuel in the bunker."
+      - "When the world crumbles, build your own throne."
+      - "Radiation may scar, but it also reveals."
+      - "Survive the storm, then dance in the ash."
+    quote_dir: "/tmp/wasteland_test_quotes"
+  tasks:
+    - name: Ensure clean test directory
+      file:
+        path: "{{ quote_dir }}"
+        state: absent
+
+    - name: Run the main playbook with test vars
+      import_playbook: "../src/playbook.yml"
+      vars:
+        quote_dir: "{{ quote_dir }}"
+
+    - name: Find generated quote file
+      find:
+        paths: "{{ quote_dir }}"
+        patterns: "*.txt"
+        file_type: file
+      register: found_files
+
+    - name: Ensure exactly one file was created
+      assert:
+        that:
+          - "found_files.files | length == 1"
+
+    - name: Read the quote content
+      slurp:
+        src: "{{ found_files.files[0].path }}"
+      register: quote_content
+
+    - name: Decode content
+      set_fact:
+        quote_text: "{{ quote_content.content | b64decode | trim }}"
+
+    - name: Verify quote is from the list
+      assert:
+        that:
+          - "quote_text in quote_list"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-quote-of-the-wasteland
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-quote-of-the-wastela`
- **Files Created**: 4
- **Description**: Generates a random post‑apocalyptic motivational quote and stores it with a timestamp.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-quote-of-the-wastela`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-quote-of-the-wastela/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-quote-of-the-wastela/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.