### PR TITLE
feat(groq): Rotates an SSH private key, backing up the old key with a timestamp and generating a new RSA key pair.

### DIFF
--- a/bash-utils/nightly-nightly-ssh-key-rotator-5/README.md
+++ b/bash-utils/nightly-nightly-ssh-key-rotator-5/README.md
@@ -1,0 +1,23 @@
+# nightly-ssh-key-rotator
+
+Utility to rotate a user's SSH private key, backing up the old key with a timestamp and generating a new RSA key pair. Useful for regular key rotation in a post‑apocalyptic secure environment.
+
+## Usage
+
+```sh
+./src/rotate_ssh_keys.sh <key_path>
+```
+
+- `<key_path>`: Path to the existing private key (e.g., `~/.ssh/id_rsa`). The script will backup the existing key to `<key_path>.bak.<timestamp>` and generate a new key at the same location.
+
+## How it works
+
+1. Verify the key file exists.
+2. Create a timestamped backup of the private key and its public counterpart.
+3. Run `ssh-keygen` to generate a new RSA key pair (2048 bits) without a passphrase.
+4. Print the location of the new keys.
+
+## Requirements
+
+- `ssh-keygen` (usually provided by OpenSSH)
+- Bash 4+

--- a/bash-utils/nightly-nightly-ssh-key-rotator-5/src/rotate_ssh_keys.sh
+++ b/bash-utils/nightly-nightly-ssh-key-rotator-5/src/rotate_ssh_keys.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <private_key_path>"
+  exit 1
+fi
+
+KEY_PATH="$1"
+if [[ ! -f "$KEY_PATH" ]]; then
+  echo "Error: Private key '$KEY_PATH' does not exist."
+  exit 1
+fi
+
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+BACKUP_PRIV="${KEY_PATH}.bak.${TIMESTAMP}"
+BACKUP_PUB="${KEY_PATH}.pub.bak.${TIMESTAMP}"
+
+# Backup existing keys
+cp "$KEY_PATH" "$BACKUP_PRIV"
+if [[ -f "${KEY_PATH}.pub" ]]; then
+  cp "${KEY_PATH}.pub" "$BACKUP_PUB"
+fi
+
+# Generate new key pair
+ssh-keygen -t rsa -b 2048 -f "$KEY_PATH" -N "" -q
+
+echo "Old key backed up to: $BACKUP_PRIV"
+if [[ -f "${KEY_PATH}.pub" ]]; then
+  echo "Old public key backed up to: $BACKUP_PUB"
+fi
+echo "New key generated at: $KEY_PATH"

--- a/bash-utils/nightly-nightly-ssh-key-rotator-5/tests/test_rotate_ssh_keys.sh
+++ b/bash-utils/nightly-nightly-ssh-key-rotator-5/tests/test_rotate_ssh_keys.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create temporary directory for isolation
+TMPDIR=$(mktemp -d)
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+# Prepare dummy old key files
+OLD_KEY="$TMPDIR/id_rsa"
+OLD_PUB="${OLD_KEY}.pub"
+echo "dummy private key" > "$OLD_KEY"
+chmod 600 "$OLD_KEY"
+echo "dummy public key" > "$OLD_PUB"
+chmod 644 "$OLD_PUB"
+
+# Locate the rotator script relative to this test file
+SCRIPT_DIR="$(cd "$(dirname "$0")/../src" && pwd)"
+"$SCRIPT_DIR/rotate_ssh_keys.sh" "$OLD_KEY"
+
+# Verify that timestamped backups were created
+if ! ls "${OLD_KEY}.bak."* > /dev/null 2>&1; then
+  echo "Backup private key not found"
+  exit 1
+fi
+if ! ls "${OLD_KEY}.pub.bak."* > /dev/null 2>&1; then
+  echo "Backup public key not found"
+  exit 1
+fi
+
+# Verify that a new key was generated (content differs from dummy)
+if grep -q "dummy private key" "$OLD_KEY"; then
+  echo "New private key was not generated"
+  exit 1
+fi
+
+echo "All tests passed"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ssh-key-rotator
- **Provider**: groq
- **Location**: `bash-utils/nightly-nightly-ssh-key-rotator-5`
- **Files Created**: 3
- **Description**: Rotates an SSH private key, backing up the old key with a timestamp and generating a new RSA key pair.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `bash-utils/nightly-nightly-ssh-key-rotator-5`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `bash-utils/nightly-nightly-ssh-key-rotator-5/README.md`
- Run tests located in `bash-utils/nightly-nightly-ssh-key-rotator-5/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.