### PR TITLE
feat(groq): Creates a whimsical “Void Portal” Terraform module that provisions a null_resource with a random portal ID and optional greeting output.

### DIFF
--- a/terraform-modules/nightly-nightly-terraform-void-porta-2/README.md
+++ b/terraform-modules/nightly-nightly-terraform-void-porta-2/README.md
@@ -1,0 +1,40 @@
+# Void Portal Terraform Module
+
+This module creates a playful “Void Portal” using Terraform's `null_resource` and the `random` provider. It generates a unique portal ID and can output a custom greeting.
+
+## Features
+- Generates a random 8‑byte hexadecimal portal ID.
+- Optionally prints a custom greeting during apply.
+- No real cloud resources are created – safe to run locally.
+
+## Usage
+```hcl
+module "void_portal" {
+  source       = "./"
+  portal_name  = "My Secret Portal"
+  greeting     = "Welcome, traveler!"
+}
+```
+
+## Variables
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `portal_name` | Human‑readable name for the portal | `string` | `"Void Portal"` |
+| `greeting`    | Optional greeting printed on apply | `string` | `null` |
+
+## Outputs
+| Name | Description |
+|------|-------------|
+| `portal_id`        | Randomly generated portal identifier |
+| `greeting_message`| The greeting that was printed (if any) |
+
+## Testing
+A simple validation script is provided under `tests/validate.sh`. Run it with:
+```bash
+cd <module‑directory>
+./tests/validate.sh
+```
+The script runs `terraform init`, `terraform validate`, and a dry‑run `terraform plan` to ensure the module is syntactically correct.
+
+## License
+MIT – feel free to adapt the portal to your own apocalyptic needs!

--- a/terraform-modules/nightly-nightly-terraform-void-porta-2/main.tf
+++ b/terraform-modules/nightly-nightly-terraform-void-porta-2/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+resource "random_id" "portal_id" {
+  byte_length = 8
+}
+
+resource "null_resource" "portal" {
+  triggers = {
+    portal_id   = random_id.portal_id.hex
+    portal_name = var.portal_name
+  }
+
+  provisioner "local-exec" {
+    command = var.greeting != null ? "echo \"${var.greeting} (Portal ID: ${random_id.portal_id.hex})\"" : "echo \"Portal \"${var.portal_name}\" initialized with ID ${random_id.portal_id.hex}\""
+  }
+}

--- a/terraform-modules/nightly-nightly-terraform-void-porta-2/outputs.tf
+++ b/terraform-modules/nightly-nightly-terraform-void-porta-2/outputs.tf
@@ -1,0 +1,9 @@
+output "portal_id" {
+  description = "Randomly generated portal identifier"
+  value       = random_id.portal_id.hex
+}
+
+output "greeting_message" {
+  description = "The greeting that was printed (if any)"
+  value       = var.greeting != null ? var.greeting : "Portal ${var.portal_name} initialized"
+}

--- a/terraform-modules/nightly-nightly-terraform-void-porta-2/tests/validate.sh
+++ b/terraform-modules/nightly-nightly-terraform-void-porta-2/tests/validate.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+# Initialize the module without a backend (local only)
+terraform init -backend=false > /dev/null
+
+# Validate syntax and configuration
+terraform validate
+
+# Perform a dry‑run plan with deterministic variable values
+terraform plan -var 'portal_name=Test Portal' -var 'greeting=Hello, traveler!' -out=plan.out > /dev/null
+
+echo "Terraform module validation passed"
+exit 0

--- a/terraform-modules/nightly-nightly-terraform-void-porta-2/variables.tf
+++ b/terraform-modules/nightly-nightly-terraform-void-porta-2/variables.tf
@@ -1,0 +1,11 @@
+variable "portal_name" {
+  description = "Human‑readable name for the portal"
+  type        = string
+  default     = "Void Portal"
+}
+
+variable "greeting" {
+  description = "Optional greeting printed on apply"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-terraform-void-portal
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-terraform-void-porta-2`
- **Files Created**: 5
- **Description**: Creates a whimsical “Void Portal” Terraform module that provisions a null_resource with a random portal ID and optional greeting output.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-terraform-void-porta-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-terraform-void-porta-2/README.md`
- Run tests located in `terraform-modules/nightly-nightly-terraform-void-porta-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.