### PR TITLE
feat(groq): Terraform module to provision a secure, versioned S3 bucket with optional public access block.

### DIFF
--- a/terraform-modules/nightly-nightly-terraform-s3-bucket-2/README.md
+++ b/terraform-modules/nightly-nightly-terraform-s3-bucket-2/README.md
@@ -1,0 +1,29 @@
+# nightly-terraform-s3-bucket
+
+## Summary
+Terraform module that creates an S3 bucket with server‑side encryption, versioning, and optional public access block.
+
+## Usage
+```hcl
+module "secure_bucket" {
+  source = "./utils/nightly-terraform-s3-bucket"
+
+  bucket_name          = "my-app-data"
+  versioning           = true
+  block_public_access  = true
+  tags = {
+    Environment = "dev"
+    Owner       = "team-a"
+  }
+}
+```
+
+## Variables
+- **bucket_name** (string, required): Name of the bucket.
+- **versioning** (bool, default `true`): Enable versioning.
+- **block_public_access** (bool, default `true`): Enable public access block.
+- **tags** (map(string), optional): Tags to apply to the bucket.
+
+## Outputs
+- **bucket_id** – ID of the S3 bucket.
+- **bucket_arn** – ARN of the S3 bucket.

--- a/terraform-modules/nightly-nightly-terraform-s3-bucket-2/src/main.tf
+++ b/terraform-modules/nightly-nightly-terraform-s3-bucket-2/src/main.tf
@@ -1,0 +1,33 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+
+  tags = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = var.versioning ? "Enabled" : "Suspended"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  count = var.block_public_access ? 1 : 0
+
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls  = true
+  restrict_public_buckets = true
+}

--- a/terraform-modules/nightly-nightly-terraform-s3-bucket-2/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-terraform-s3-bucket-2/src/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_id" {
+  description = "ID of the S3 bucket"
+  value       = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = aws_s3_bucket.this.arn
+}

--- a/terraform-modules/nightly-nightly-terraform-s3-bucket-2/src/variables.tf
+++ b/terraform-modules/nightly-nightly-terraform-s3-bucket-2/src/variables.tf
@@ -1,0 +1,22 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "versioning" {
+  description = "Enable versioning"
+  type        = bool
+  default     = true
+}
+
+variable "block_public_access" {
+  description = "Enable public access block"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to apply to the bucket"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform-modules/nightly-nightly-terraform-s3-bucket-2/tests/test_module.py
+++ b/terraform-modules/nightly-nightly-terraform-s3-bucket-2/tests/test_module.py
@@ -1,0 +1,23 @@
+import unittest
+import pathlib
+
+class TestTerraformS3Module(unittest.TestCase):
+    def setUp(self):
+        # Path to the src directory relative to this test file
+        self.module_path = pathlib.Path(__file__).parent.parent / "src"
+
+    def test_main_contains_s3_bucket(self):
+        content = (self.module_path / "main.tf").read_text()
+        self.assertIn('resource "aws_s3_bucket" "this"', content)
+
+    def test_versioning_logic(self):
+        content = (self.module_path / "main.tf").read_text()
+        self.assertIn('status = var.versioning ? "Enabled" : "Suspended"', content)
+
+    def test_outputs_defined(self):
+        outputs = (self.module_path / "outputs.tf").read_text()
+        self.assertIn('output "bucket_id"', outputs)
+        self.assertIn('output "bucket_arn"', outputs)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-terraform-s3-bucket
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-terraform-s3-bucket-2`
- **Files Created**: 5
- **Description**: Terraform module to provision a secure, versioned S3 bucket with optional public access block.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-terraform-s3-bucket-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-terraform-s3-bucket-2/README.md`
- Run tests located in `terraform-modules/nightly-nightly-terraform-s3-bucket-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.