### PR TITLE
feat(groq): CLI tool that estimates battery runtime from capacity and consumption values

### DIFF
--- a/rust-utils/nightly-nightly-battery-life-estimat/Cargo.toml
+++ b/rust-utils/nightly-nightly-battery-life-estimat/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "battery-life"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-battery-life-estimat/README.md
+++ b/rust-utils/nightly-nightly-battery-life-estimat/README.md
@@ -1,0 +1,28 @@
+# nightly-battery-life-estimator
+
+Estimate how long a battery will last given its capacity and device consumption.
+
+## Usage
+
+```sh
+battery-life <capacity_mAh> <consumption_mA>
+```
+
+Example:
+
+```sh
+battery-life 5000 250
+# Output: Estimated runtime: 20.00 hours
+```
+
+## Build
+
+```sh
+cargo build --release
+```
+
+## Test
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-battery-life-estimat/src/lib.rs
+++ b/rust-utils/nightly-nightly-battery-life-estimat/src/lib.rs
@@ -1,0 +1,21 @@
+pub fn estimate_hours(capacity_mah: f64, consumption_ma: f64) -> f64 {
+    if consumption_ma == 0.0 {
+        return f64::INFINITY;
+    }
+    capacity_mah / consumption_ma
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_estimate() {
+        let hrs = estimate_hours(5000.0, 250.0);
+        assert!((hrs - 20.0).abs() < 1e-6);
+    }
+    #[test]
+    fn test_zero_consumption() {
+        let hrs = estimate_hours(1000.0, 0.0);
+        assert!(hrs.is_infinite());
+    }
+}

--- a/rust-utils/nightly-nightly-battery-life-estimat/src/main.rs
+++ b/rust-utils/nightly-nightly-battery-life-estimat/src/main.rs
@@ -1,0 +1,34 @@
+use std::env;
+use battery_life::estimate_hours;
+
+fn print_usage() {
+    eprintln!("Usage: battery-life <capacity_mAh> <consumption_mA>");
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        print_usage();
+        std::process::exit(1);
+    }
+    let capacity: f64 = match args[1].parse() {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("Invalid capacity value");
+            std::process::exit(1);
+        }
+    };
+    let consumption: f64 = match args[2].parse() {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("Invalid consumption value");
+            std::process::exit(1);
+        }
+    };
+    let hours = estimate_hours(capacity, consumption);
+    if hours.is_infinite() {
+        println!("Estimated runtime: infinite (zero consumption)");
+    } else {
+        println!("Estimated runtime: {:.2} hours", hours);
+    }
+}

--- a/rust-utils/nightly-nightly-battery-life-estimat/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-battery-life-estimat/tests/test_main.rs
@@ -1,0 +1,7 @@
+use battery_life::estimate_hours;
+
+#[test]
+fn integration_estimate() {
+    let hrs = estimate_hours(3000.0, 150.0);
+    assert!((hrs - 20.0).abs() < 1e-6);
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-battery-life-estimator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-battery-life-estimat`
- **Files Created**: 5
- **Description**: CLI tool that estimates battery runtime from capacity and consumption values

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-battery-life-estimat`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-battery-life-estimat/README.md`
- Run tests located in `rust-utils/nightly-nightly-battery-life-estimat/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.