### PR TITLE
feat(groq): Concurrent port scanner that quickly discovers open TCP ports on a host

### DIFF
--- a/go-utils/nightly-nightly-portal-ping-pong-3/README.md
+++ b/go-utils/nightly-nightly-portal-ping-pong-3/README.md
@@ -1,0 +1,26 @@
+# nightly-portal-ping-pong
+
+A whimsical concurrent port scanner that darts across a range of ports and reports which ones are open. Perfect for quick network checks in a post‑apocalyptic bunker.
+
+## Usage
+
+```sh
+go run src/main.go -host localhost -ports 8000,8001,8080
+```
+
+The program prints a list of open ports, e.g.:
+
+```
+Open ports on localhost: 8000 8080
+```
+
+## How it works
+
+- Parses a comma‑separated list of ports.
+- Launches a goroutine per port (limited by a semaphore to avoid overwhelming the system).
+- Uses a short TCP dial timeout (default 500 ms) to test each port.
+- Collects results via channels and prints the open ports.
+
+## Testing
+
+Run `go test ./...` to execute the deterministic unit tests which spin up local listeners.

--- a/go-utils/nightly-nightly-portal-ping-pong-3/src/main.go
+++ b/go-utils/nightly-nightly-portal-ping-pong-3/src/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+    "flag"
+    "fmt"
+    "net"
+    "strconv"
+    "strings"
+    "sync"
+    "time"
+)
+
+// ScanPorts concurrently checks a list of TCP ports on the given host.
+// It returns a slice of ports that responded within the timeout.
+func ScanPorts(host string, ports []int, timeout time.Duration) []int {
+    var wg sync.WaitGroup
+    // semaphore to limit concurrent connections (avoid exhausting resources)
+    sem := make(chan struct{}, 100)
+    results := make(chan int, len(ports))
+
+    for _, p := range ports {
+        wg.Add(1)
+        go func(port int) {
+            defer wg.Done()
+            sem <- struct{}{}
+            defer func() { <-sem }()
+            address := net.JoinHostPort(host, strconv.Itoa(port))
+            conn, err := net.DialTimeout("tcp", address, timeout)
+            if err == nil {
+                conn.Close()
+                results <- port
+            }
+        }(p)
+    }
+
+    wg.Wait()
+    close(results)
+
+    openPorts := make([]int, 0, len(ports))
+    for p := range results {
+        openPorts = append(openPorts, p)
+    }
+    return openPorts
+}
+
+func parsePorts(portStr string) ([]int, error) {
+    parts := strings.Split(portStr, ",")
+    ports := make([]int, 0, len(parts))
+    for _, part := range parts {
+        p, err := strconv.Atoi(strings.TrimSpace(part))
+        if err != nil {
+            return nil, fmt.Errorf("invalid port %q: %w", part, err)
+        }
+        ports = append(ports, p)
+    }
+    return ports, nil
+}
+
+func main() {
+    host := flag.String("host", "localhost", "target host to scan")
+    portsStr := flag.String("ports", "", "comma‑separated list of ports to scan (e.g., 80,443,8080)")
+    timeoutMs := flag.Int("timeout", 500, "dial timeout in milliseconds")
+    flag.Parse()
+
+    if *portsStr == "" {
+        fmt.Println("error: -ports flag is required")
+        return
+    }
+
+    ports, err := parsePorts(*portsStr)
+    if err != nil {
+        fmt.Printf("error parsing ports: %v\n", err)
+        return
+    }
+
+    open := ScanPorts(*host, ports, time.Duration(*timeoutMs)*time.Millisecond)
+    if len(open) == 0 {
+        fmt.Printf("No open ports on %s\n", *host)
+        return
+    }
+    fmt.Printf("Open ports on %s: ", *host)
+    for i, p := range open {
+        if i > 0 {
+            fmt.Print(" ")
+        }
+        fmt.Print(p)
+    }
+    fmt.Println()
+}

--- a/go-utils/nightly-nightly-portal-ping-pong-3/tests/main_test.go
+++ b/go-utils/nightly-nightly-portal-ping-pong-3/tests/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+    "net"
+    "testing"
+    "time"
+)
+
+// Helper to start a temporary TCP listener on an available port.
+func startTestListener(t *testing.T) (int, func()) {
+    ln, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        t.Fatalf("failed to start listener: %v", err)
+    }
+    // Extract the chosen port.
+    addr := ln.Addr().(*net.TCPAddr)
+    port := addr.Port
+    // Close function to clean up after test.
+    closeFn := func() { ln.Close() }
+    return port, closeFn
+}
+
+func TestScanPortsDetectsOpenPort(t *testing.T) {
+    openPort, closeFn := startTestListener(t)
+    defer closeFn()
+
+    // Choose a port that is guaranteed to be closed.
+    closedPort := openPort + 1
+
+    ports := []int{openPort, closedPort}
+    open := ScanPorts("127.0.0.1", ports, 200*time.Millisecond)
+
+    if len(open) != 1 {
+        t.Fatalf("expected exactly one open port, got %d", len(open))
+    }
+    if open[0] != openPort {
+        t.Fatalf("expected open port %d, got %d", openPort, open[0])
+    }
+}
+
+func TestScanPortsEmptyInput(t *testing.T) {
+    open := ScanPorts("127.0.0.1", []int{}, 200*time.Millisecond)
+    if len(open) != 0 {
+        t.Fatalf("expected no open ports for empty input, got %d", len(open))
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-portal-ping-pong
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-portal-ping-pong-3`
- **Files Created**: 3
- **Description**: Concurrent port scanner that quickly discovers open TCP ports on a host

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-portal-ping-pong-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-portal-ping-pong-3/README.md`
- Run tests located in `go-utils/nightly-nightly-portal-ping-pong-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.