### PR TITLE
feat(gemini): An Ansible playbook to sweep away digital dust bunnies (old, temporary, and unused files) across your systems, freeing up space and decluttering.

### DIFF
--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/README.md
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/README.md
@@ -1,0 +1,90 @@
+# Nightly Digital Dust Bunny Sweeper
+
+## Summary
+This Ansible playbook helps you combat the insidious accumulation of "digital dust bunnies" – those old, temporary, and forgotten files that silently consume disk space and clutter your systems. It's designed to be a whimsical yet effective tool for maintaining digital hygiene across your infrastructure.
+
+## What it Does
+The playbook identifies and removes files and directories based on configurable criteria such as age, name patterns, and emptiness. It targets common locations where digital clutter tends to gather, helping to free up valuable disk space and improve system performance.
+
+## How it Works
+The main playbook `src/dust_bunny_sweeper.yml` orchestrates the cleanup by iterating through a list of defined `cleanup_targets` (from `src/vars/cleanup_targets.yml`). For each target, it includes `src/tasks/main.yml` which contains the core logic for finding and removing files and empty directories based on the specified criteria.
+
+## Usage
+
+### Prerequisites
+- Ansible installed on your control machine.
+- SSH access to your target hosts (if not running locally).
+
+### 1. Define Your Inventory
+Create an `inventory.ini` file (or use an existing one) listing the hosts you want to clean.
+
+```ini
+[servers]
+server1.example.com
+server2.example.com
+
+[local]
+localhost ansible_connection=local
+```
+
+### 2. Configure Cleanup Targets
+Edit `src/vars/cleanup_targets.yml` to specify the paths and criteria for what constitutes a "digital dust bunny."
+
+```yaml
+# src/vars/cleanup_targets.yml
+cleanup_targets:
+  - path: /tmp
+    age_days: 7
+    patterns:
+      - "*.log"
+      - "*.tmp"
+    description: "Temporary files older than 7 days in /tmp"
+  - path: "{{ ansible_env.HOME }}/Downloads"
+    age_days: 30
+    patterns:
+      - "*.old"
+      - "*.bak"
+    description: "Old downloads and backup files in user's Downloads folder"
+  - path: "{{ ansible_env.HOME }}/.cache"
+    age_days: 60
+    description: "Cache files older than 60 days in user's cache directory"
+  - path: "/var/log"
+    age_days: 14
+    patterns:
+      - "*.gz"
+      - "*.1"
+    description: "Archived logs in /var/log"
+  - path: "/opt/old_projects"
+    empty_dirs: true
+    description: "Empty directories in /opt/old_projects"
+```
+
+### 3. Run the Sweeper
+Execute the playbook using the `ansible-playbook` command:
+
+```bash
+ansible-playbook -i src/inventory.ini src/dust_bunny_sweeper.yml
+```
+
+**Important**: It's highly recommended to run in `check_mode` first to see what *would* be removed:
+
+```bash
+ansible-playbook -i src/inventory.ini src/dust_bunny_sweeper.yml --check --diff
+```
+
+This will show you a detailed report of files and directories that match the cleanup criteria without actually deleting them.
+
+## Automated Tests
+
+To run the tests, ensure you have Ansible installed. The tests create temporary files and directories on `localhost` and then verify the playbook correctly identifies and removes them.
+
+```bash
+ansible-playbook -i src/inventory.ini tests/test_dust_bunny_sweeper.yml
+```
+
+The `test_dust_bunny_sweeper.yml` playbook will:
+1. Create a temporary directory.
+2. Populate it with dummy "dust bunny" files and directories that match the cleanup criteria.
+3. Run the core cleanup tasks (`src/tasks/main.yml`) against this temporary location with test-specific variables.
+4. Verify that the dummy files/directories have been removed.
+5. Clean up the temporary directory.

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/dust_bunny_sweeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/dust_bunny_sweeper.yml
@@ -1,0 +1,18 @@
+---
+- name: Sweep Digital Dust Bunnies
+  hosts: all
+  gather_facts: false
+  vars_files:
+    - vars/cleanup_targets.yml
+
+  tasks:
+    - name: Ensure cleanup_targets variable is defined
+      ansible.builtin.fail:
+        msg: "The 'cleanup_targets' variable is not defined in vars/cleanup_targets.yml"
+      when: cleanup_targets is not defined or cleanup_targets | length == 0
+
+    - name: Execute cleanup tasks
+      ansible.builtin.include_tasks: tasks/main.yml
+      loop: "{{ cleanup_targets }}"
+      loop_control:
+        loop_var: current_target

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/inventory.ini
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/tasks/main.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: "Find files for cleanup in {{ current_target.path }} ({{ current_target.description | default('no description') }})"
+  ansible.builtin.find:
+    paths: "{{ current_target.path }}"
+    age: "{{ current_target.age_days | default(omit) }}d"
+    patterns: "{{ current_target.patterns | default([]) }}"
+    file_type: file
+    recurse: true
+  register: files_to_clean
+  when: current_target.age_days is defined or (current_target.patterns is defined and current_target.patterns | length > 0)
+
+- name: "Remove found files in {{ current_target.path }}"
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ files_to_clean.files | default([]) }}"
+  when: files_to_clean.files is defined and files_to_clean.files | length > 0
+
+- name: "Find all directories in {{ current_target.path }} for potential empty directory cleanup"
+  ansible.builtin.find:
+    paths: "{{ current_target.path }}"
+    file_type: directory
+    recurse: true
+  register: all_dirs_in_path
+  when: current_target.empty_dirs | default(false)
+
+- name: "Attempt to remove empty directories in {{ current_target.path }}"
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ all_dirs_in_path.files | default([]) | sort(attribute='path', reverse=true) }}"
+  when: current_target.empty_dirs | default(false) and all_dirs_in_path.files is defined

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/vars/cleanup_targets.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/vars/cleanup_targets.yml
@@ -1,0 +1,37 @@
+# Default cleanup targets. Customize these to fit your needs.
+#
+# Each item in the list can have:
+# - path: The base directory to search.
+# - age_days: Files/directories older than this many days will be targeted.
+# - patterns: A list of glob patterns (e.g., "*.log", "temp_*").
+# - empty_dirs: Set to true to target empty directories within the path.
+# - description: A human-readable description of the target.
+#
+# Note: age_days and patterns are for files. empty_dirs is for directories.
+# If both age_days/patterns and empty_dirs are specified, they act independently.
+
+cleanup_targets:
+  - path: /tmp
+    age_days: 7
+    patterns:
+      - "*.log"
+      - "*.tmp"
+    description: "Temporary files older than 7 days in /tmp"
+  - path: "{{ ansible_env.HOME }}/Downloads"
+    age_days: 30
+    patterns:
+      - "*.old"
+      - "*.bak"
+    description: "Old downloads and backup files in user's Downloads folder"
+  - path: "{{ ansible_env.HOME }}/.cache"
+    age_days: 60
+    description: "Cache files older than 60 days in user's cache directory"
+  - path: "/var/log"
+    age_days: 14
+    patterns:
+      - "*.gz"
+      - "*.1"
+    description: "Archived logs in /var/log"
+  - path: "/opt/old_projects"
+    empty_dirs: true
+    description: "Empty directories in /opt/old_projects"

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/test_dust_bunny_sweeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/test_dust_bunny_sweeper.yml
@@ -1,0 +1,102 @@
+---
+- name: Test Digital Dust Bunny Sweeper
+  hosts: localhost
+  gather_facts: true
+  vars:
+    test_base_dir: "/tmp/ansible_test_dust_bunnies_{{ lookup('pipe', 'date +%s%N') }}" # Unique temp dir
+
+  tasks:
+    - name: Create a temporary test directory
+      ansible.builtin.file:
+        path: "{{ test_base_dir }}"
+        state: directory
+        mode: '0755'
+
+    - name: Set cleanup_targets for testing
+      ansible.builtin.set_fact:
+        cleanup_targets:
+          - path: "{{ test_base_dir }}"
+            age_days: 1 # Target files older than 1 day
+            patterns:
+              - "*.log"
+              - "*.tmp"
+            description: "Test files"
+          - path: "{{ test_base_dir }}/empty_dir_test"
+            empty_dirs: true
+            description: "Test empty directories"
+          - path: "{{ test_base_dir }}/nested_empty_dir_test"
+            empty_dirs: true
+            description: "Test nested empty directories"
+
+    - name: Create dummy files and directories for cleanup (older than 1 day)
+      ansible.builtin.shell: |
+        # Calculate timestamp for 2 days ago
+        {% set two_days_ago = (ansible_date_time.epoch | int - 86400 * 2) | int %}
+        {% set timestamp_str = two_days_ago | to_datetime | strftime('%Y%m%d%H%M.%S') %}
+        touch -t {{ timestamp_str }} {{ test_base_dir }}/old_log_file.log
+        touch -t {{ timestamp_str }} {{ test_base_dir }}/old_tmp_file.tmp
+        touch {{ test_base_dir }}/recent_file.txt # Should not be deleted
+      args:
+        creates: "{{ test_base_dir }}/old_log_file.log"
+      # Mock rationale: These files are created specifically for the test,
+      # simulating "dust bunnies" that the playbook should remove.
+      # `ansible_date_time.epoch` is a fact, making the timestamp deterministic relative to test run.
+
+    - name: Create dummy files and directories for empty directory test
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: '0755'
+      loop:
+        - "{{ test_base_dir }}/empty_dir_test/sub_empty"
+        - "{{ test_base_dir }}/empty_dir_test"
+        - "{{ test_base_dir }}/nested_empty_dir_test/level1/level2"
+        - "{{ test_base_dir }}/nested_empty_dir_test/level1"
+        - "{{ test_base_dir }}/nested_empty_dir_test"
+      # Mock rationale: These directories are created to test the empty directory cleanup logic.
+
+    - name: Execute cleanup tasks with test targets
+      ansible.builtin.include_tasks: ../src/tasks/main.yml
+      loop: "{{ cleanup_targets }}"
+      loop_control:
+        loop_var: current_target
+
+    - name: Verify old log file is absent
+      ansible.builtin.stat:
+        path: "{{ test_base_dir }}/old_log_file.log"
+      register: old_log_file_stat
+      failed_when: old_log_file_stat.stat.exists
+      # Mock rationale: Verifies the playbook's action on a mock file.
+
+    - name: Verify old tmp file is absent
+      ansible.builtin.stat:
+        path: "{{ test_base_dir }}/old_tmp_file.tmp"
+      register: old_tmp_file_stat
+      failed_when: old_tmp_file_stat.stat.exists
+      # Mock rationale: Verifies the playbook's action on a mock file.
+
+    - name: Verify recent file is present (not deleted)
+      ansible.builtin.stat:
+        path: "{{ test_base_dir }}/recent_file.txt"
+      register: recent_file_stat
+      failed_when: not recent_file_stat.stat.exists
+      # Mock rationale: Verifies the playbook's selectivity on mock files.
+
+    - name: Verify empty directories are absent
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      register: dir_stat
+      failed_when: dir_stat.stat.exists
+      loop:
+        - "{{ test_base_dir }}/empty_dir_test/sub_empty"
+        - "{{ test_base_dir }}/empty_dir_test"
+        - "{{ test_base_dir }}/nested_empty_dir_test/level1/level2"
+        - "{{ test_base_dir }}/nested_empty_dir_test/level1"
+        - "{{ test_base_dir }}/nested_empty_dir_test"
+      # Mock rationale: Verifies the playbook's action on mock directories.
+
+    - name: Clean up the temporary test directory
+      ansible.builtin.file:
+        path: "{{ test_base_dir }}"
+        state: absent
+      # Mock rationale: Ensures test isolation and cleans up mock environment.


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-digital-dust-bunny-sweeper
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8`
- **Files Created**: 6
- **Description**: An Ansible playbook to sweep away digital dust bunnies (old, temporary, and unused files) across your systems, freeing up space and decluttering.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.