### PR TITLE
feat(groq): A whimsical CLI tool that estimates remaining device battery life based on current capacity and consumption rate.

### DIFF
--- a/rust-utils/nightly-nightly-battery-life-estimat/Cargo.toml
+++ b/rust-utils/nightly-nightly-battery-life-estimat/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "battery-life-estimator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-battery-life-estimat/README.md
+++ b/rust-utils/nightly-nightly-battery-life-estimat/README.md
@@ -1,0 +1,30 @@
+# Battery Life Estimator
+
+A whimsical CLI tool for the post‑apocalyptic wanderer to estimate how many hours of power remain on a device.
+
+## Build
+
+```sh
+cargo build --release
+```
+
+## Usage
+
+```sh
+./target/release/battery-life-estimator <current_mAh> <consumption_mA>
+```
+
+Example:
+
+```sh
+./battery-life-estimator 5000 250
+# => Estimated remaining time: 20.00 hours
+```
+
+If the consumption is `0`, the tool reports "infinite".
+
+## Tests
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-battery-life-estimat/src/lib.rs
+++ b/rust-utils/nightly-nightly-battery-life-estimat/src/lib.rs
@@ -1,0 +1,7 @@
+pub fn estimate_hours(current: f64, consumption: f64) -> f64 {
+    if consumption == 0.0 {
+        f64::INFINITY
+    } else {
+        current / consumption
+    }
+}

--- a/rust-utils/nightly-nightly-battery-life-estimat/src/main.rs
+++ b/rust-utils/nightly-nightly-battery-life-estimat/src/main.rs
@@ -1,0 +1,35 @@
+use std::env;
+use std::process;
+use battery_life_estimator::estimate_hours;
+
+fn print_usage() {
+    eprintln!("Usage: battery-life-estimator <current_mAh> <consumption_mA>");
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        print_usage();
+        process::exit(1);
+    }
+    let current: f64 = match args[1].parse() {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("Error: current_mAh must be a number");
+            process::exit(1);
+        }
+    };
+    let consumption: f64 = match args[2].parse() {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("Error: consumption_mA must be a number");
+            process::exit(1);
+        }
+    };
+    let hours = estimate_hours(current, consumption);
+    if hours.is_infinite() {
+        println!("Estimated remaining time: infinite hours");
+    } else {
+        println!("Estimated remaining time: {:.2} hours", hours);
+    }
+}

--- a/rust-utils/nightly-nightly-battery-life-estimat/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-battery-life-estimat/tests/test_main.rs
@@ -1,0 +1,16 @@
+#[cfg(test)]
+mod tests {
+    use battery_life_estimator::estimate_hours;
+
+    #[test]
+    fn test_normal() {
+        let hours = estimate_hours(5000.0, 250.0);
+        assert!((hours - 20.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_zero_consumption() {
+        let hours = estimate_hours(5000.0, 0.0);
+        assert!(hours.is_infinite());
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-battery-life-estimator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-battery-life-estimat`
- **Files Created**: 5
- **Description**: A whimsical CLI tool that estimates remaining device battery life based on current capacity and consumption rate.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-battery-life-estimat`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-battery-life-estimat/README.md`
- Run tests located in `rust-utils/nightly-nightly-battery-life-estimat/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.