### PR TITLE
feat(groq): Reusable GitHub Action that auto‑labels pull requests based on title keywords.

### DIFF
--- a/github-actions/nightly-nightly-pr-labeler-8/README.md
+++ b/github-actions/nightly-nightly-pr-labeler-8/README.md
@@ -1,0 +1,38 @@
+# PR Labeler Action
+
+Automatically adds labels to pull requests based on keywords in the PR title.
+
+## Usage
+
+```yaml
+name: Auto label PRs
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./  # assuming the action is in the repository root
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The action looks for the following keywords (case‑insensitive):
+
+- `fix`, `bug` → **bug**
+- `feat`, `feature` → **enhancement**
+- `doc`, `docs` → **documentation**
+
+Multiple labels can be applied if multiple keywords are present.
+
+## Development
+
+Run tests with:
+
+```sh
+npm install
+npm test
+```

--- a/github-actions/nightly-nightly-pr-labeler-8/action.yml
+++ b/github-actions/nightly-nightly-pr-labeler-8/action.yml
@@ -1,0 +1,9 @@
+name: PR Labeler
+description: Auto‑label pull requests based on title keywords
+inputs:
+  token:
+    description: GitHub token
+    required: true
+runs:
+  using: node12
+  main: src/index.js

--- a/github-actions/nightly-nightly-pr-labeler-8/package.json
+++ b/github-actions/nightly-nightly-pr-labeler-8/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "nightly-pr-labeler",
+  "version": "1.0.0",
+  "description": "GitHub Action to auto-label PRs",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "@actions/core": "^1.10.0",
+    "@actions/github": "^5.1.1"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/github-actions/nightly-nightly-pr-labeler-8/src/index.js
+++ b/github-actions/nightly-nightly-pr-labeler-8/src/index.js
@@ -1,0 +1,46 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+
+function getLabelsFromTitle(title) {
+  const lower = title.toLowerCase();
+  const labels = new Set();
+  if (lower.includes('fix') || lower.includes('bug')) labels.add('bug');
+  if (lower.includes('feat') || lower.includes('feature')) labels.add('enhancement');
+  if (lower.includes('doc') || lower.includes('docs')) labels.add('documentation');
+  return Array.from(labels);
+}
+
+async function run() {
+  try {
+    const token = core.getInput('token', { required: true });
+    const octokit = github.getOctokit(token);
+    const context = github.context;
+    if (!context.payload.pull_request) {
+      core.setFailed('No pull request payload');
+      return;
+    }
+    const title = context.payload.pull_request.title;
+    const owner = context.repo.owner;
+    const repo = context.repo.repo;
+    const number = context.payload.pull_request.number;
+    const labels = getLabelsFromTitle(title);
+    if (labels.length === 0) {
+      core.info('No matching labels found');
+      return;
+    }
+    await octokit.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number: number,
+      labels,
+    });
+    core.info(`Added labels: ${labels.join(', ')}`);
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+}
+
+module.exports = { getLabelsFromTitle, run };
+if (require.main === module) {
+  run();
+}

--- a/github-actions/nightly-nightly-pr-labeler-8/tests/test_index.js
+++ b/github-actions/nightly-nightly-pr-labeler-8/tests/test_index.js
@@ -1,0 +1,21 @@
+const { getLabelsFromTitle } = require('../src/index');
+
+test('detect bug label', () => {
+  const labels = getLabelsFromTitle('Fix typo in README');
+  expect(labels).toContain('bug');
+});
+
+test('detect enhancement label', () => {
+  const labels = getLabelsFromTitle('Add new feature for export');
+  expect(labels).toContain('enhancement');
+});
+
+test('detect documentation label', () => {
+  const labels = getLabelsFromTitle('Update docs for API');
+  expect(labels).toContain('documentation');
+});
+
+test('multiple labels', () => {
+  const labels = getLabelsFromTitle('Fix bug and add docs');
+  expect(labels).toEqual(expect.arrayContaining(['bug', 'documentation']));
+});


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-pr-labeler
- **Provider**: groq
- **Location**: `github-actions/nightly-nightly-pr-labeler-8`
- **Files Created**: 5
- **Description**: Reusable GitHub Action that auto‑labels pull requests based on title keywords.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `github-actions/nightly-nightly-pr-labeler-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `github-actions/nightly-nightly-pr-labeler-8/README.md`
- Run tests located in `github-actions/nightly-nightly-pr-labeler-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.