### PR TITLE
feat(gemini): An Ansible playbook to identify and optionally prune stale files and empty directories in a digital garden (server).

### DIFF
--- a/ansible-playbooks/nightly-nightly-digital-garden-prune/README.md
+++ b/ansible-playbooks/nightly-nightly-digital-garden-prune/README.md
@@ -1,0 +1,83 @@
+# Nightly Digital Garden Pruner
+
+## Summary
+This Ansible playbook helps maintain a tidy 'digital garden' (your server or specific directories) by identifying and optionally pruning stale files and empty directories. It generates a report detailing what it found and what actions it would take (or has taken).
+
+## Features
+- Scans specified paths for files older than a configured age.
+- Scans specified paths for truly empty directories.
+- Supports dry-run mode to report findings without making changes.
+- Generates a clear, concise pruning report.
+
+## Usage
+
+### Prerequisites
+- Ansible installed on your control machine.
+- SSH access (or `ansible_connection=local`) to the target servers.
+
+### 1. Configure Inventory
+Create an `inventory.ini` file (or use an existing one) that lists your 'garden servers'.
+
+```ini
+[garden_servers]
+localhost ansible_connection=local
+# Add other servers here, e.g.:
+# webserver.example.com
+# dbserver.example.com
+```
+
+### 2. Configure Pruning Rules
+Edit `src/vars/pruner_config.yml` to define the paths to scan, age thresholds for files, file patterns, and whether to perform a dry run or actual pruning.
+
+```yaml
+---
+pruner_paths:
+  - path: "/var/log"
+    max_age_days: 30
+    file_patterns: ["*.log", "*.gz"]
+    age_stamp: mtime # Use 'mtime' (modification time) or 'atime' (access time)
+  - path: "/tmp"
+    max_age_days: 7
+    file_patterns: ["*"]
+    age_stamp: mtime
+  - path: "/home/{{ ansible_user }}/digital_garden/temp_notes"
+    max_age_days: 60
+    file_patterns: ["*.txt", "*.md"]
+    age_stamp: mtime
+
+pruner_empty_dirs_paths:
+  - "/home/{{ ansible_user }}/digital_garden/empty_folders"
+  - "/var/tmp"
+
+pruner_dry_run: true # Set to false to actually remove files/dirs
+pruner_report_path: "/tmp/digital_garden_pruning_report.txt"
+```
+
+### 3. Run the Playbook
+To run the playbook in dry-run mode (recommended for initial runs):
+
+```bash
+ansible-playbook -i inventory.ini src/prune_garden.yml -e "pruner_dry_run=true"
+```
+
+To perform actual pruning (be careful!):
+
+```bash
+ansible-playbook -i inventory.ini src/prune_garden.yml -e "pruner_dry_run=false"
+```
+
+The report will be displayed in the console and saved to the path specified by `pruner_report_path`.
+
+## Automated Tests
+
+To run the tests for this utility, navigate to the `nightly-digital-garden-pruner` directory and execute:
+
+```bash
+ansible-playbook -i tests/inventory_test.ini tests/test_prune_garden.yml
+```
+
+This will:
+1. Create a temporary test directory structure with files and directories of varying ages and emptiness.
+2. Run the `prune_garden.yml` playbook in dry-run mode and assert the contents of the generated report.
+3. Run the `prune_garden.yml` playbook in actual pruning mode and assert that the expected files and directories have been removed.
+4. Clean up the temporary test environment.

--- a/ansible-playbooks/nightly-nightly-digital-garden-prune/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-digital-garden-prune/src/inventory.ini
@@ -1,0 +1,5 @@
+[garden_servers]
+localhost ansible_connection=local
+# Add other servers here, e.g.:
+# webserver.example.com
+# dbserver.example.com

--- a/ansible-playbooks/nightly-nightly-digital-garden-prune/src/prune_garden.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-prune/src/prune_garden.yml
@@ -1,0 +1,120 @@
+---
+- name: Nightly Digital Garden Pruner
+  hosts: garden_servers
+  gather_facts: false
+  vars_files:
+    - vars/pruner_config.yml
+
+  tasks:
+    - name: Ensure report directory exists locally
+      ansible.builtin.file:
+        path: "{{ pruner_report_path | dirname }}"
+        state: directory
+        mode: '0755'
+      delegate_to: localhost # Report is generated locally
+
+    - name: Initialize pruning report
+      ansible.builtin.copy:
+        content: |
+          Digital Garden Pruning Report - {{ ansible_date_time.iso8601_micro }}
+          --------------------------------------------------------------------
+          Dry Run: {{ pruner_dry_run }}
+          --------------------------------------------------------------------
+        dest: "{{ pruner_report_path }}"
+        mode: '0644'
+      delegate_to: localhost
+
+    - name: Find and report/prune old files
+      block:
+        - name: Find old files in {{ item.path }}
+          ansible.builtin.find:
+            paths: "{{ item.path }}"
+            patterns: "{{ item.file_patterns | join(',') }}"
+            age: "{{ item.max_age_days }}d"
+            age_stamp: "{{ item.age_stamp | default('mtime') }}"
+            recurse: true
+          register: old_files_result
+          ignore_errors: true # Path might not exist
+
+        - name: Add old files to report
+          ansible.builtin.lineinfile:
+            path: "{{ pruner_report_path }}"
+            line: "- File: {{ found_file.path }} (Last modified: {{ found_file.mtime | to_datetime('%Y%m%d%H%M%S') | community.general.strftime('%Y-%m-%d %H:%M:%S') }})"
+            insertafter: "--------------------------------------------------------------------"
+          loop: "{{ old_files_result.files | default([]) }}"
+          loop_control:
+            loop_var: found_file
+          when: old_files_result.files is defined and old_files_result.files | length > 0
+          delegate_to: localhost
+
+        - name: Prune old files (if not dry run)
+          ansible.builtin.file:
+            path: "{{ found_file.path }}"
+            state: absent
+          loop: "{{ old_files_result.files | default([]) }}"
+          loop_control:
+            loop_var: found_file
+          when: not pruner_dry_run and old_files_result.files is defined and old_files_result.files | length > 0
+      loop: "{{ pruner_paths }}"
+      loop_control:
+        loop_var: item
+      tags: files
+
+    - name: Find and report/prune empty directories
+      block:
+        - name: Initialize empty_dirs_found list
+          ansible.builtin.set_fact:
+            empty_dirs_found: []
+
+        - name: Find all directories in {{ item }}
+          ansible.builtin.find:
+            paths: "{{ item }}"
+            file_type: directory
+            recurse: true
+            get_checksum: false
+          register: all_dirs_result
+          ignore_errors: true
+
+        - name: Filter for truly empty directories
+          ansible.builtin.set_fact:
+            empty_dirs_found: "{{ empty_dirs_found + [found_dir.path] }}"
+          loop: "{{ all_dirs_result.files | default([]) }}"
+          loop_control:
+            loop_var: found_dir
+          when: found_dir.isdir and found_dir.files | length == 0
+
+        - name: Add empty directories to report
+          ansible.builtin.lineinfile:
+            path: "{{ pruner_report_path }}"
+            line: "- Empty Directory: {{ empty_dir }}"
+            insertafter: "--------------------------------------------------------------------"
+          loop: "{{ empty_dirs_found | default([]) }}"
+          loop_control:
+            loop_var: empty_dir
+          when: empty_dirs_found is defined and empty_dirs_found | length > 0
+          delegate_to: localhost
+
+        - name: Prune empty directories (if not dry run)
+          ansible.builtin.file:
+            path: "{{ empty_dir }}"
+            state: absent
+          loop: "{{ empty_dirs_found | default([]) }}"
+          loop_control:
+            loop_var: empty_dir
+          when: not pruner_dry_run and empty_dirs_found is defined and empty_dirs_found | length > 0
+      loop: "{{ pruner_empty_dirs_paths }}"
+      loop_control:
+        loop_var: item
+      tags: empty_dirs
+
+    - name: Read and display pruning report
+      ansible.builtin.slurp:
+        src: "{{ pruner_report_path }}"
+      register: final_report
+      delegate_to: localhost
+      changed_when: false
+
+    - name: Display final report
+      ansible.builtin.debug:
+        msg: "{{ final_report.content | b64decode }}"
+      delegate_to: localhost

--- a/ansible-playbooks/nightly-nightly-digital-garden-prune/src/vars/pruner_config.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-prune/src/vars/pruner_config.yml
@@ -1,0 +1,21 @@
+---
+pruner_paths:
+  - path: "/var/log"
+    max_age_days: 30
+    file_patterns: ["*.log", "*.gz"]
+    age_stamp: mtime
+  - path: "/tmp"
+    max_age_days: 7
+    file_patterns: ["*"]
+    age_stamp: mtime
+  - path: "/home/{{ ansible_user | default('ansible') }}/digital_garden/temp_notes"
+    max_age_days: 60
+    file_patterns: ["*.txt", "*.md"]
+    age_stamp: mtime
+
+pruner_empty_dirs_paths:
+  - "/home/{{ ansible_user | default('ansible') }}/digital_garden/empty_folders"
+  - "/var/tmp"
+
+pruner_dry_run: true # Set to false to actually remove files/dirs
+pruner_report_path: "/tmp/digital_garden_pruning_report.txt"

--- a/ansible-playbooks/nightly-nightly-digital-garden-prune/tests/inventory_test.ini
+++ b/ansible-playbooks/nightly-nightly-digital-garden-prune/tests/inventory_test.ini
@@ -1,0 +1,2 @@
+[localhost]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-digital-garden-prune/tests/test_prune_garden.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-prune/tests/test_prune_garden.yml
@@ -1,0 +1,187 @@
+---
+- name: Test Nightly Digital Garden Pruner
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars_files:
+    - vars/test_pruner_config.yml # Use test-specific config
+
+  vars:
+    test_base_path: "/tmp/ansible_test_garden"
+    report_path: "{{ test_base_path }}/pruning_report.txt"
+
+  tasks:
+    - name: Clean up previous test artifacts (if any)
+      ansible.builtin.file:
+        path: "{{ test_base_path }}"
+        state: absent
+      when: test_base_path is defined and test_base_path != '/' # Safety check
+      tags: cleanup
+
+    - name: Ensure test base path exists
+      ansible.builtin.file:
+        path: "{{ test_base_path }}"
+        state: directory
+        mode: '0755'
+
+    - name: Create test environment
+      block:
+        - name: Create directories
+          ansible.builtin.file:
+            path: "{{ item }}"
+            state: directory
+            mode: '0755'
+          loop:
+            - "{{ test_base_path }}/logs/old"
+            - "{{ test_base_path }}/logs/new"
+            - "{{ test_base_path }}/notes/stale"
+            - "{{ test_base_path }}/notes/fresh"
+            - "{{ test_base_path }}/empty_dir_1"
+            - "{{ test_base_path }}/empty_dir_2"
+            - "{{ test_base_path }}/not_empty_dir"
+
+        - name: Create old log file
+          ansible.builtin.copy:
+            content: "Old log entry"
+            dest: "{{ test_base_path }}/logs/old/app.log"
+        - name: Set old log file mtime
+          ansible.builtin.command: "touch -d '35 days ago' {{ test_base_path }}/logs/old/app.log"
+          changed_when: true # Mock rationale: Simulate an old file by setting its modification time using 'touch'. This is a deterministic, offline way to create test fixtures for age-based file discovery.
+
+        - name: Create new log file
+          ansible.builtin.copy:
+            content: "New log entry"
+            dest: "{{ test_base_path }}/logs/new/current.log"
+
+        - name: Create stale note file
+          ansible.builtin.copy:
+            content: "Stale note content"
+            dest: "{{ test_base_path }}/notes/stale/idea.md"
+        - name: Set stale note file mtime
+          ansible.builtin.command: "touch -d '70 days ago' {{ test_base_path }}/notes/stale/idea.md"
+          changed_when: true # Mock rationale: Similar to above, setting mtime for a stale file.
+
+        - name: Create fresh note file
+          ansible.builtin.copy:
+            content: "Fresh note content"
+            dest: "{{ test_base_path }}/notes/fresh/new_idea.md"
+
+        - name: Create file in not_empty_dir
+          ansible.builtin.copy:
+            content: "Some content"
+            dest: "{{ test_base_path }}/not_empty_dir/file.txt"
+      tags: setup
+
+    - name: Run pruner playbook in dry-run mode
+      ansible.builtin.include_tasks: ../src/prune_garden.yml
+      vars:
+        pruner_dry_run: true
+        pruner_report_path: "{{ report_path }}"
+      tags: dry_run
+
+    - name: Assert dry-run report content
+      ansible.builtin.slurp:
+        src: "{{ report_path }}"
+      register: dry_run_report_content
+      changed_when: false
+      delegate_to: localhost
+
+    - name: Check for expected files in dry-run report
+      ansible.builtin.assert:
+        that:
+          - "'File: {{ test_base_path }}/logs/old/app.log' in dry_run_report_content.content | b64decode"
+          - "'File: {{ test_base_path }}/notes/stale/idea.md' in dry_run_report_content.content | b64decode"
+          - "'Empty Directory: {{ test_base_path }}/empty_dir_1' in dry_run_report_content.content | b64decode"
+          - "'Empty Directory: {{ test_base_path }}/empty_dir_2' in dry_run_report_content.content | b64decode"
+          - "'File: {{ test_base_path }}/logs/new/current.log' not in dry_run_report_content.content | b64decode"
+          - "'File: {{ test_base_path }}/notes/fresh/new_idea.md' not in dry_run_report_content.content | b64decode"
+          - "'Empty Directory: {{ test_base_path }}/not_empty_dir' not in dry_run_report_content.content | b64decode"
+        msg: "Dry-run report did not contain expected findings or contained unexpected ones."
+      delegate_to: localhost
+
+    - name: Run pruner playbook for actual pruning
+      ansible.builtin.include_tasks: ../src/prune_garden.yml
+      vars:
+        pruner_dry_run: false
+        pruner_report_path: "{{ report_path }}"
+      tags: actual_prune
+
+    - name: Assert files are removed
+      block:
+        - name: Check if old log file exists
+          ansible.builtin.stat:
+            path: "{{ test_base_path }}/logs/old/app.log"
+          register: old_log_stat
+        - name: Assert old log file is absent
+          ansible.builtin.assert:
+            that:
+              - not old_log_stat.stat.exists
+            msg: "Old log file was not removed."
+
+        - name: Check if stale note file exists
+          ansible.builtin.stat:
+            path: "{{ test_base_path }}/notes/stale/idea.md"
+          register: stale_note_stat
+        - name: Assert stale note file is absent
+          ansible.builtin.assert:
+            that:
+              - not stale_note_stat.stat.exists
+            msg: "Stale note file was not removed."
+
+        - name: Check if empty_dir_1 exists
+          ansible.builtin.stat:
+            path: "{{ test_base_path }}/empty_dir_1"
+          register: empty_dir_1_stat
+        - name: Assert empty_dir_1 is absent
+          ansible.builtin.assert:
+            that:
+              - not empty_dir_1_stat.stat.exists
+            msg: "Empty directory 1 was not removed."
+
+        - name: Check if empty_dir_2 exists
+          ansible.builtin.stat:
+            path: "{{ test_base_path }}/empty_dir_2"
+          register: empty_dir_2_stat
+        - name: Assert empty_dir_2 is absent
+          ansible.builtin.assert:
+            that:
+              - not empty_dir_2_stat.stat.exists
+            msg: "Empty directory 2 was not removed."
+
+        - name: Check if new log file exists
+          ansible.builtin.stat:
+            path: "{{ test_base_path }}/logs/new/current.log"
+          register: new_log_stat
+        - name: Assert new log file still exists
+          ansible.builtin.assert:
+            that:
+              - new_log_stat.stat.exists
+            msg: "New log file was unexpectedly removed."
+
+        - name: Check if fresh note file exists
+          ansible.builtin.stat:
+            path: "{{ test_base_path }}/notes/fresh/new_idea.md"
+          register: fresh_note_stat
+        - name: Assert fresh note file still exists
+          ansible.builtin.assert:
+            that:
+              - fresh_note_stat.stat.exists
+            msg: "Fresh note file was unexpectedly removed."
+
+        - name: Check if not_empty_dir exists
+          ansible.builtin.stat:
+            path: "{{ test_base_path }}/not_empty_dir"
+          register: not_empty_dir_stat
+        - name: Assert not_empty_dir still exists
+          ansible.builtin.assert:
+            that:
+              - not not_empty_dir_stat.stat.exists
+            msg: "Non-empty directory was unexpectedly removed."
+      tags: verify_prune
+
+    - name: Clean up test environment
+      ansible.builtin.file:
+        path: "{{ test_base_path }}"
+        state: absent
+      when: test_base_path is defined and test_base_path != '/' # Safety check
+      tags: cleanup

--- a/ansible-playbooks/nightly-nightly-digital-garden-prune/tests/vars/test_pruner_config.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-prune/tests/vars/test_pruner_config.yml
@@ -1,0 +1,18 @@
+---
+pruner_paths:
+  - path: "/tmp/ansible_test_garden/logs"
+    max_age_days: 30
+    file_patterns: ["*.log"]
+    age_stamp: mtime
+  - path: "/tmp/ansible_test_garden/notes"
+    max_age_days: 60
+    file_patterns: ["*.md"]
+    age_stamp: mtime
+
+pruner_empty_dirs_paths:
+  - "/tmp/ansible_test_garden/empty_dir_1"
+  - "/tmp/ansible_test_garden/empty_dir_2"
+  - "/tmp/ansible_test_garden/not_empty_dir"
+
+pruner_dry_run: true # This will be overridden by the test playbook
+pruner_report_path: "/tmp/ansible_test_garden/pruning_report.txt"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-digital-garden-pruner
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-digital-garden-prune`
- **Files Created**: 7
- **Description**: An Ansible playbook to identify and optionally prune stale files and empty directories in a digital garden (server).

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-digital-garden-prune`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-digital-garden-prune/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-digital-garden-prune/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.