### PR TITLE
feat(gemini): A Go-based concurrent TCP server that receives messages, adds a whimsical 'cosmic timestamp' and 'starlight signature', and broadcasts them to all connected clients.

### DIFF
--- a/go-utils/nightly-nightly-starlight-signal-rel/README.md
+++ b/go-utils/nightly-nightly-starlight-signal-rel/README.md
@@ -1,0 +1,73 @@
+# Nightly Starlight Signal Relay
+
+## Summary
+
+The `nightly-starlight-signal-relay` is a whimsical-yet-useful Go-based TCP server designed to act as a central hub for broadcasting messages across a network. When a client sends a message, the relay imbues it with a 'cosmic timestamp' (a precise UTC timestamp) and a unique 'starlight signature' (a short, deterministic hash of the message and its context) before broadcasting it to all other connected clients. It's perfect for low-bandwidth, high-imagination communication networks in the post-apocalyptic era.
+
+## How it Works
+
+1.  **Server Startup**: The Go server listens on a specified TCP port (defaulting to `8080`).
+2.  **Client Connection**: Any TCP client can connect to the server.
+3.  **Message Reception**: When a client sends a newline-terminated message, the server receives it.
+4.  **Cosmic Imbuement**: The server processes the message by:
+    *   Adding a `[Cosmic Timestamp]` indicating when the message was received.
+    *   Generating a `[Starlight Signature]` – a unique, short hash derived from the message content, timestamp, and sender ID.
+5.  **Broadcast**: The newly imbued message is then broadcast to *all* currently connected clients, including the sender.
+6.  **Concurrency**: The server handles multiple client connections concurrently using Go's goroutines, ensuring smooth operation even under heavy celestial traffic.
+
+## Usage
+
+### 1. Build the Server
+
+Navigate to the `src` directory and build the Go executable:
+
+```bash
+cd nightly-starlight-signal-relay/src
+go build -o starlight-relay .
+```
+
+### 2. Run the Server
+
+Execute the compiled binary. You can optionally specify a port using the `PORT` environment variable.
+
+```bash
+./starlight-relay
+# Or to specify a port:
+PORT=9000 ./starlight-relay
+```
+
+The server will start listening and log its activity.
+
+### 3. Connect Clients
+
+You can use `netcat` (nc) or any other TCP client to connect to the relay.
+
+```bash
+nc localhost 8080
+```
+
+Once connected, type your message and press Enter. The server will process it and send it back to you, and to any other connected clients, with its cosmic enhancements.
+
+**Example Client Interaction (using `nc` in two separate terminals):**
+
+**Terminal 1 (Client A):**
+
+```
+nc localhost 8080
+[Starlight Signal] 127.0.0.1:54321 has joined the relay.
+Hello from Client A!
+[2023-10-27T10:30:00.123456789Z] (From: 127.0.0.1:54321) Hello from Client A! [Signature: a1b2c3d4e5f6]
+```
+
+**Terminal 2 (Client B):**
+
+```
+nc localhost 8080
+[Starlight Signal] 127.0.0.1:54321 has joined the relay.
+[Starlight Signal] 127.0.0.1:54322 has joined the relay.
+[2023-10-27T10:30:00.123456789Z] (From: 127.0.0.1:54321) Hello from Client A! [Signature: a1b2c3d4e5f6]
+Message from Client B!
+[2023-10-27T10:30:05.987654321Z] (From: 127.0.0.1:54322) Message from Client B! [Signature: f6e5d4c3b2a1]
+```
+
+(Note: IP addresses and timestamps will vary based on your system and connection.)

--- a/go-utils/nightly-nightly-starlight-signal-rel/src/main.go
+++ b/go-utils/nightly-nightly-starlight-signal-rel/src/main.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultPort = "8080"
+)
+
+// Client represents a connected client
+type Client struct {
+	conn net.Conn
+	id   string
+}
+
+// Server holds the server state
+type Server struct {
+	clients    map[string]Client
+	mu         sync.Mutex
+	broadcast  chan string
+	listener   net.Listener
+	wg         sync.WaitGroup
+	running    bool
+	port       string
+}
+
+// NewServer creates a new Server instance
+func NewServer(port string) *Server {
+	return &Server{
+		clients:   make(map[string]Client),
+		broadcast: make(chan string),
+		running:   false,
+		port:      port,
+	}
+}
+
+// Start begins listening for incoming connections
+func (s *Server) Start() error {
+	var err error
+	s.listener, err = net.Listen("tcp", ":"+s.port)
+	if err != nil {
+		return fmt.Errorf("failed to listen on port %s: %w", s.port, err)
+	}
+	s.running = true
+	log.Printf("Starlight Signal Relay listening on port %s...", s.port)
+
+	s.wg.Add(1)
+	go s.handleBroadcasts()
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for s.running {
+			conn, err := s.listener.Accept()
+			if err != nil {
+				if !s.running { // Server was intentionally shut down
+					return
+				}
+				log.Printf("Error accepting connection: %v", err)
+				continue
+			}
+			s.wg.Add(1)
+			go s.handleClient(conn)
+		}
+	}()
+	return nil
+}
+
+// Stop shuts down the server
+func (s *Server) Stop() {
+	// Signal that the server is no longer running
+	s.running = false
+	// Close the listener to unblock Accept()
+	if s.listener != nil {
+		s.listener.Close()
+	}
+	// Close the broadcast channel to signal handleBroadcasts to exit
+	close(s.broadcast)
+	// Wait for all goroutines to finish
+	s.wg.Wait()
+	log.Println("Starlight Signal Relay stopped.")
+}
+
+// handleClient manages a single client connection
+func (s *Server) handleClient(conn net.Conn) {
+	defer s.wg.Done()
+	defer conn.Close()
+
+	clientID := conn.RemoteAddr().String()
+	log.Printf("New client connected: %s", clientID)
+
+	s.mu.Lock()
+	s.clients[clientID] = Client{conn: conn, id: clientID}
+	s.mu.Unlock()
+
+	// Announce new client
+	s.broadcast <- fmt.Sprintf("[Starlight Signal] %s has joined the relay.", clientID)
+
+	reader := bufio.NewReader(conn)
+	for {
+		message, err := reader.ReadString('\n')
+		if err != nil {
+			log.Printf("Client %s disconnected or error: %v", clientID, err)
+			break
+		}
+
+		processedMessage := s.processMessage(clientID, strings.TrimSpace(message))
+		s.broadcast <- processedMessage
+	}
+
+	s.mu.Lock()
+	delete(s.clients, clientID)
+	s.mu.Unlock()
+	log.Printf("Client %s disconnected.", clientID)
+	// Announce client departure
+	s.broadcast <- fmt.Sprintf("[Starlight Signal] %s has left the relay.", clientID)
+}
+
+// handleBroadcasts sends messages to all connected clients
+func (s *Server) handleBroadcasts() {
+	defer s.wg.Done()
+	for msg := range s.broadcast {
+		s.mu.Lock()
+		for _, client := range s.clients {
+			_, err := client.conn.Write([]byte(msg + "\n"))
+			if err != nil {
+				log.Printf("Error sending to client %s: %v", client.id, err)
+				// In a real-world scenario, you might want to remove clients that fail to write
+				// For this utility, we'll just log the error.
+			}
+		}
+		s.mu.Unlock()
+	}
+}
+
+// processMessage adds cosmic timestamp and starlight signature
+func (s *Server) processMessage(senderID, originalMessage string) string {
+	cosmicTimestamp := time.Now().UTC().Format(time.RFC3339Nano)
+	
+	// Generate starlight signature (deterministic hash for testing)
+	hasher := sha256.New()
+	hasher.Write([]byte(originalMessage + cosmicTimestamp + senderID))
+	starlightSignature := hex.EncodeToString(hasher.Sum(nil))[:12] // Take first 12 chars for brevity
+
+	return fmt.Sprintf("[%s] (From: %s) %s [Signature: %s]", cosmicTimestamp, senderID, originalMessage, starlightSignature)
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = defaultPort
+	}
+
+	server := NewServer(port)
+	if err := server.Start(); err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
+
+	// Keep main goroutine alive until interrupted (e.g., Ctrl+C)
+	select {}
+}

--- a/go-utils/nightly-nightly-starlight-signal-rel/tests/main_test.go
+++ b/go-utils/nightly-nightly-starlight-signal-rel/tests/main_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Mock rationale: For deterministic testing of a network service, we use actual `net.Listen`
+// and `net.Dial` on `localhost` to simulate network interactions. This provides a realistic
+// test environment without relying on external services. Timing is managed with `time.Sleep`
+// to allow goroutines to schedule and network buffers to clear, and `SetReadDeadline` for
+// non-blocking reads with timeouts. The `processMessage` function's outputs (timestamp and
+// signature) are deterministic for a given input, allowing for predictable verification.
+
+func TestServerStartAndStop(t *testing.T) {
+	server := NewServer("8081") // Use a different port for tests
+	err := server.Start()
+	if err != nil {
+		t.Fatalf("Server failed to start: %v", err)
+	}
+	if !server.running {
+		t.Error("Server should be running after Start()")
+	}
+
+	server.Stop()
+	if server.running {
+		t.Error("Server should not be running after Stop()")
+	}
+}
+
+func TestSingleClientMessageBroadcast(t *testing.T) {
+	server := NewServer("8082")
+	err := server.Start()
+	if err != nil {
+		t.Fatalf("Server failed to start: %v", err)
+	}
+	defer server.Stop()
+
+	// Give server a moment to start listening
+	time.Sleep(10 * time.Millisecond)
+
+	clientConn, err := net.Dial("tcp", "localhost:8082")
+	if err != nil {
+		t.Fatalf("Client failed to connect: %v", err)
+	}
+	defer clientConn.Close()
+
+	reader := bufio.NewReader(clientConn)
+	writer := bufio.NewWriter(clientConn)
+
+	// Wait for the "client joined" message
+	joinedMsg, _ := reader.ReadString('\n')
+	if !strings.Contains(joinedMsg, "has joined the relay.") {
+		t.Errorf("Expected join message, got: %s", joinedMsg)
+	}
+
+	testMessage := "Hello Starlight!"
+	_, err = writer.WriteString(testMessage + "\n")
+	if err != nil {
+		t.Fatalf("Failed to write message: %v", err)
+	}
+	writer.Flush()
+
+	// The server broadcasts the message back to the sender (and all others)
+	// We need to read until we get the actual broadcast message, skipping any other join messages
+	timeout := time.After(2 * time.Second)
+	var receivedMessage string
+	for {
+		select {
+		case <-timeout:
+			t.Fatalf("Client timed out waiting for broadcast message")
+		default:
+			clientConn.SetReadDeadline(time.Now().Add(100 * time.Millisecond)) // Short deadline for non-blocking read
+			msg, err := reader.ReadString('\n')
+			if err != nil {
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					continue // Keep trying
+				}
+				if err.Error() == "EOF" { // Connection closed
+					break
+				}
+				t.Fatalf("Failed to read message: %v", err)
+			}
+			if strings.Contains(msg, testMessage) && strings.Contains(msg, "Signature:") {
+				receivedMessage = msg
+				goto FoundMessage // Exit loop and continue test
+			}
+		}
+	}
+FoundMessage:
+
+	if !strings.Contains(receivedMessage, testMessage) {
+		t.Errorf("Received message does not contain original message. Got: %s, Expected to contain: %s", receivedMessage, testMessage)
+	}
+	if !strings.Contains(receivedMessage, "Signature:") {
+		t.Errorf("Received message missing starlight signature. Got: %s", receivedMessage)
+	}
+	if !strings.Contains(receivedMessage, "From:") {
+		t.Errorf("Received message missing sender ID. Got: %s", receivedMessage)
+	}
+	// Check for the presence of a timestamp pattern (e.g., YYYY-MM-DDTHH:MM:SS)
+	if !strings.Contains(receivedMessage, time.Now().UTC().Format("2006-01-02T")) {
+		t.Errorf("Received message missing cosmic timestamp. Got: %s", receivedMessage)
+	}
+}
+
+func TestMultipleClientsBroadcast(t *testing.T) {
+	server := NewServer("8083")
+	err := server.Start()
+	if err != nil {
+		t.Fatalf("Server failed to start: %v", err)
+	}
+	defer server.Stop()
+
+	time.Sleep(10 * time.Millisecond) // Give server a moment to start
+
+	var wg sync.WaitGroup
+	numClients := 3
+	clientConns := make([]net.Conn, numClients)
+	clientReaders := make([]*bufio.Reader, numClients)
+	clientWriters := make([]*bufio.Writer, numClients)
+
+	for i := 0; i < numClients; i++ {
+		conn, err := net.Dial("tcp", "localhost:8083")
+		if err != nil {
+			t.Fatalf("Client %d failed to connect: %v", i, err)
+		}
+		clientConns[i] = conn
+		clientReaders[i] = bufio.NewReader(conn)
+		clientWriters[i] = bufio.NewWriter(conn)
+		defer conn.Close()
+
+		// Read initial join messages (one for self, others for other clients joining)
+		// We'll just read until we get a message that's not a join message from another client.
+		// For simplicity, let's just read the first message (self-join)
+		_, _ = clientReaders[i].ReadString('\n') // Read self-join message
+	}
+
+	// Wait for all clients to connect and for their join messages to propagate
+	time.Sleep(50 * time.Millisecond)
+
+	testMessage := "Broadcast from Client 0"
+	_, err = clientWriters[0].WriteString(testMessage + "\n")
+	if err != nil {
+		t.Fatalf("Client 0 failed to write message: %v", err)
+	}
+	clientWriters[0].Flush()
+
+	// Each client should receive the broadcast message
+	for i := 0; i < numClients; i++ {
+		wg.Add(1)
+		go func(clientIdx int) {
+			defer wg.Done()
+			// Read messages until we find the one we sent, or timeout
+			timeout := time.After(2 * time.Second)
+			for {
+				select {
+				case <-timeout:
+					t.Errorf("Client %d timed out waiting for message", clientIdx)
+					return
+				default:
+					clientConns[clientIdx].SetReadDeadline(time.Now().Add(100 * time.Millisecond)) // Short deadline for non-blocking read
+					receivedMessage, err := clientReaders[clientIdx].ReadString('\n')
+					if err != nil {
+						if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+							continue // Keep trying
+						}
+						if err.Error() == "EOF" { // Connection closed
+							return
+						}
+						t.Errorf("Client %d failed to read message: %v", clientIdx, err)
+						return
+					}
+
+					if strings.Contains(receivedMessage, testMessage) {
+						if !strings.Contains(receivedMessage, "Signature:") {
+							t.Errorf("Client %d: Received message missing starlight signature. Got: %s", clientIdx, receivedMessage)
+						}
+						if !strings.Contains(receivedMessage, "From:") {
+							t.Errorf("Client %d: Received message missing sender ID. Got: %s", clientIdx, receivedMessage)
+						}
+						if !strings.Contains(receivedMessage, time.Now().UTC().Format("2006-01-02T")) {
+							t.Errorf("Client %d: Received message missing cosmic timestamp. Got: %s", clientIdx, receivedMessage)
+						}
+						return // Found the message
+					}
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestClientDisconnect(t *testing.T) {
+	server := NewServer("8084")
+	err := server.Start()
+	if err != nil {
+		t.Fatalf("Server failed to start: %v", err)
+	}
+	defer server.Stop()
+
+	time.Sleep(10 * time.Millisecond)
+
+	client1, err := net.Dial("tcp", "localhost:8084")
+	if err != nil {
+		t.Fatalf("Client 1 failed to connect: %v", err)
+	}
+	reader1 := bufio.NewReader(client1)
+	_, _ = reader1.ReadString('\n') // Read join message
+
+	client2, err := net.Dial("tcp", "localhost:8084")
+	if err != nil {
+		t.Fatalf("Client 2 failed to connect: %v", err)
+	}
+	reader2 := bufio.NewReader(client2)
+	_, _ = reader2.ReadString('\n') // Read join message
+
+	// Client 2 should receive client 1's join message
+	// Read until client 1's join message is received by client 2
+	timeout := time.After(1 * time.Second)
+	foundJoin := false
+	for {
+		select {
+		case <-timeout:
+			t.Fatalf("Client 2 timed out waiting for client 1's join message")
+		default:
+			client2.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			msg, err := reader2.ReadString('\n')
+			if err != nil {
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					continue
+				}
+				if err.Error() == "EOF" { // Connection closed
+					break
+				}
+				t.Fatalf("Client 2 error reading: %v", err)
+			}
+			if strings.Contains(msg, client1.RemoteAddr().String()+" has joined the relay.") {
+				foundJoin = true
+				break
+			}
+		}
+	}
+	if !foundJoin {
+		t.Fatal("Client 2 did not receive client 1's join message.")
+	}
+
+	// Now, client 1 disconnects
+	client1.Close()
+
+	// Client 2 should receive a disconnect message from client 1
+	timeout = time.After(1 * time.Second)
+	foundDisconnect := false
+	for {
+		select {
+		case <-timeout:
+			t.Fatalf("Client 2 timed out waiting for client 1's disconnect message")
+		default:
+			client2.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			msg, err := reader2.ReadString('\n')
+			if err != nil {
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					continue
+				}
+				if err.Error() == "EOF" {
+					break
+				}
+				t.Fatalf("Client 2 error reading: %v", err)
+			}
+			if strings.Contains(msg, client1.RemoteAddr().String()+" has left the relay.") {
+				foundDisconnect = true
+				break
+			}
+		}
+	}
+	if !foundDisconnect {
+		t.Error("Client 2 did not receive client 1's disconnect message.")
+	}
+	client2.Close()
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-starlight-signal-relay
- **Provider**: gemini
- **Location**: `go-utils/nightly-nightly-starlight-signal-rel`
- **Files Created**: 3
- **Description**: A Go-based concurrent TCP server that receives messages, adds a whimsical 'cosmic timestamp' and 'starlight signature', and broadcasts them to all connected clients.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-starlight-signal-rel`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-starlight-signal-rel/README.md`
- Run tests located in `go-utils/nightly-nightly-starlight-signal-rel/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.