### PR TITLE
feat(groq): A whimsical Dockerized HTTP server that serves random apocalyptic prophecies.

### DIFF
--- a/docker-tools/nightly-nightly-docker-cryptic-chron/Dockerfile
+++ b/docker-tools/nightly-nightly-docker-cryptic-chron/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY src/main.go .
+RUN go build -o chronicle .
+
+# Runtime stage
+FROM alpine:3.18
+WORKDIR /app
+COPY --from=builder /app/chronicle /usr/local/bin/chronicle
+EXPOSE 8080
+ENTRYPOINT ["chronicle"]

--- a/docker-tools/nightly-nightly-docker-cryptic-chron/README.md
+++ b/docker-tools/nightly-nightly-docker-cryptic-chron/README.md
@@ -1,0 +1,27 @@
+# Cryptic Chronicle Docker
+
+A whimsical Dockerized HTTP server that serves random apocalyptic prophecies.
+
+## Build
+
+```sh
+docker build -t cryptic-chronicle .
+```
+
+## Run
+
+```sh
+docker run -p 8080:8080 cryptic-chronicle
+```
+
+Visit `http://localhost:8080` to receive a prophecy in JSON.
+
+## Deterministic testing
+
+Set the `FORTUNE_SEED` environment variable to control the output.
+
+```sh
+docker run -p 8080:8080 -e FORTUNE_SEED=5 cryptic-chronicle
+```
+
+Will always return the same prophecy.

--- a/docker-tools/nightly-nightly-docker-cryptic-chron/src/main.go
+++ b/docker-tools/nightly-nightly-docker-cryptic-chron/src/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+    "encoding/json"
+    "log"
+    "math/rand"
+    "net/http"
+    "os"
+    "strconv"
+    "time"
+)
+
+var prophecies = []string{
+    "The sun will rise in the west.",
+    "Rats will inherit the throne.",
+    "Silence will echo louder than thunder.",
+    "The moon will melt into cheese.",
+}
+
+func getProphecy() string {
+    seedStr := os.Getenv("FORTUNE_SEED")
+    if seedStr != "" {
+        if s, err := strconv.ParseInt(seedStr, 10, 64); err == nil {
+            idx := int(s) % len(prophecies)
+            return prophecies[idx]
+        }
+    }
+    rand.Seed(time.Now().UnixNano())
+    return prophecies[rand.Intn(len(prophecies))]
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+    resp := map[string]string{"prophecy": getProphecy()}
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(resp)
+}
+
+func main() {
+    http.HandleFunc("/", handler)
+    log.Println("Starting server on :8080")
+    if err := http.ListenAndServe(":8080", nil); err != nil {
+        log.Fatalf("Server failed: %v", err)
+    }
+}

--- a/docker-tools/nightly-nightly-docker-cryptic-chron/tests/test.sh
+++ b/docker-tools/nightly-nightly-docker-cryptic-chron/tests/test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+# Build the Docker image
+docker build -t cryptic-chronicle-test . > /dev/null
+
+# Run container in background with deterministic seed
+container_id=$(docker run -d -p 8081:8080 -e FORTUNE_SEED=5 cryptic-chronicle-test)
+
+# Give server time to start
+sleep 1
+
+# Fetch prophecy
+output=$(curl -s http://localhost:8081)
+
+# Expected JSON (seed 5 -> index 1)
+expected='{"prophecy":"Rats will inherit the throne."}'
+
+if [ "$output" != "$expected" ]; then
+    echo "Test failed: expected $expected but got $output"
+    docker rm -f "$container_id"
+    exit 1
+fi
+
+# Cleanup
+docker rm -f "$container_id"
+docker rmi -f cryptic-chronicle-test > /dev/null
+
+echo "All tests passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-docker-cryptic-chronicle
- **Provider**: groq
- **Location**: `docker-tools/nightly-nightly-docker-cryptic-chron`
- **Files Created**: 4
- **Description**: A whimsical Dockerized HTTP server that serves random apocalyptic prophecies.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `docker-tools/nightly-nightly-docker-cryptic-chron`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `docker-tools/nightly-nightly-docker-cryptic-chron/README.md`
- Run tests located in `docker-tools/nightly-nightly-docker-cryptic-chron/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.