### PR TITLE
feat(gemini): A Terraform module to provision a versioned AWS S3 bucket, creating 'chronos echoes' of data for temporal resilience and managed decay.

### DIFF
--- a/terraform-modules/nightly-nightly-chronos-cache/README.md
+++ b/terraform-modules/nightly-nightly-chronos-cache/README.md
@@ -1,0 +1,73 @@
+# Nightly Chronos Cache
+
+A whimsical-yet-useful Terraform module for provisioning an AWS S3 bucket configured as a "Chronos Cache" – a temporal echo chamber for your data. This module ensures your data is versioned, creating echoes of its past states, and automatically manages older versions to balance resilience with storage costs.
+
+## Features
+
+*   **Temporal Echoes**: Automatically enables S3 Versioning to keep a history of all changes to your objects.
+*   **Echo Decay**: Configurable lifecycle rules to transition noncurrent (older) versions to cheaper storage classes (e.g., S3 Standard-IA, Glacier) and eventually expire them, preventing infinite storage growth while retaining historical echoes.
+*   **Secure by Default**: Applies a public access block to ensure the bucket is not publicly accessible.
+*   **Customizable**: Easily configure bucket name, ACL, and echo retention policies.
+
+## Usage
+
+To deploy your own Chronos Cache, create a `main.tf` file in your Terraform project:
+
+```terraform
+module "my_chronos_cache" {
+  source = "./path/to/nightly-chronos-cache/src" # Adjust path as needed
+
+  bucket_name = "my-apocalypsai-chronos-cache-unique-name" # IMPORTANT: Must be globally unique!
+  bucket_acl  = "private" # Recommended for security
+  noncurrent_transition_days = 45 # Transition noncurrent versions to IA after 45 days
+  noncurrent_expiration_days = 180 # Expire noncurrent versions after 180 days
+  tags = {
+    Project     = "ApocalypsAI-Survival"
+    Environment = "Production"
+  }
+}
+
+output "cache_bucket_arn" {
+  value = module.my_chronos_cache.bucket_arn
+}
+```
+
+Then, run the standard Terraform commands:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+## Module Inputs
+
+| Name                                | Description                                                               | Type        | Default       | Required |
+| :---------------------------------- | :------------------------------------------------------------------------ | :---------- | :------------ | :------- |
+| `bucket_name`                       | The name of the S3 bucket to create. Must be globally unique.             | `string`    | n/a           | yes      |
+| `bucket_acl`                        | The ACL to apply to the bucket. Recommended: 'private'.                   | `string`    | `"private"`   | no       |
+| `noncurrent_transition_days`        | Number of days after which noncurrent versions transition to a different storage class. | `number` | `30`          | no       |
+| `noncurrent_transition_storage_class` | The storage class to transition noncurrent versions to (e.g., GLACIER, STANDARD_IA). | `string` | `"STANDARD_IA"` | no       |
+| `noncurrent_expiration_days`        | Number of days after which noncurrent versions expire and are permanently deleted. | `number` | `90`          | no       |
+| `tags`                              | A map of tags to assign to the bucket.                                    | `map(string)` | `{}`          | no       |
+| `aws_region`                        | The AWS region to deploy the S3 bucket in.                                | `string`    | `"us-east-1"` | no       |
+
+## Module Outputs
+
+| Name               | Description                               |
+| :----------------- | :---------------------------------------- |
+| `bucket_id`        | The ID of the S3 bucket.                  |
+| `bucket_arn`       | The ARN of the S3 bucket.                 |
+| `bucket_domain_name` | The S3 bucket regional domain name.       |
+
+## Testing
+
+The module includes a test configuration in the `tests/` directory. To validate the module's syntax and variable definitions offline:
+
+```bash
+cd tests
+terraform init
+terraform validate
+```
+
+This will check the HCL syntax and ensure all required variables are provided to the module without attempting to provision any actual cloud resources.

--- a/terraform-modules/nightly-nightly-chronos-cache/src/main.tf
+++ b/terraform-modules/nightly-nightly-chronos-cache/src/main.tf
@@ -1,0 +1,40 @@
+resource "aws_s3_bucket" "chronos_cache" {
+  bucket = var.bucket_name
+  acl    = var.bucket_acl
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    id = "chronos-echo-retention"
+
+    enabled = true
+
+    noncurrent_version_transition {
+      days          = var.noncurrent_transition_days
+      storage_class = var.noncurrent_transition_storage_class
+    }
+
+    noncurrent_version_expiration {
+      days = var.noncurrent_expiration_days
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      "ManagedBy" = "ApocalypsAI-ChronosCache"
+      "Purpose"   = "TemporalEchoChamber"
+    }
+  )
+}
+
+resource "aws_s3_bucket_public_access_block" "chronos_cache_public_access_block" {
+  bucket = aws_s3_bucket.chronos_cache.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/terraform-modules/nightly-nightly-chronos-cache/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-chronos-cache/src/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_id" {
+  description = "The ID of the S3 bucket."
+  value       = aws_s3_bucket.chronos_cache.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the S3 bucket."
+  value       = aws_s3_bucket.chronos_cache.arn
+}
+
+output "bucket_domain_name" {
+  description = "The S3 bucket regional domain name."
+  value       = aws_s3_bucket.chronos_cache.bucket_regional_domain_name
+}

--- a/terraform-modules/nightly-nightly-chronos-cache/src/variables.tf
+++ b/terraform-modules/nightly-nightly-chronos-cache/src/variables.tf
@@ -1,0 +1,40 @@
+variable "bucket_name" {
+  description = "The name of the S3 bucket to create. Must be globally unique."
+  type        = string
+}
+
+variable "bucket_acl" {
+  description = "The ACL to apply to the bucket. Recommended: 'private'."
+  type        = string
+  default     = "private"
+}
+
+variable "noncurrent_transition_days" {
+  description = "Number of days after which noncurrent versions transition to a different storage class."
+  type        = number
+  default     = 30
+}
+
+variable "noncurrent_transition_storage_class" {
+  description = "The storage class to transition noncurrent versions to (e.g., GLACIER, STANDARD_IA)."
+  type        = string
+  default     = "STANDARD_IA"
+}
+
+variable "noncurrent_expiration_days" {
+  description = "Number of days after which noncurrent versions expire and are permanently deleted."
+  type        = number
+  default     = 90
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the bucket."
+  type        = map(string)
+  default     = {}
+}
+
+variable "aws_region" {
+  description = "The AWS region to deploy the S3 bucket in."
+  type        = string
+  default     = "us-east-1"
+}

--- a/terraform-modules/nightly-nightly-chronos-cache/tests/main.tf
+++ b/terraform-modules/nightly-nightly-chronos-cache/tests/main.tf
@@ -1,0 +1,10 @@
+module "test_chronos_cache" {
+  source = "../src"
+
+  bucket_name = "apocalypsai-test-chronos-cache-12345" # Unique name for testing
+  bucket_acl  = "private"
+  tags = {
+    Environment = "Test"
+    Project     = "ApocalypsAI"
+  }
+}

--- a/terraform-modules/nightly-nightly-chronos-cache/tests/versions.tf
+++ b/terraform-modules/nightly-nightly-chronos-cache/tests/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1" # Mock rationale: Required for terraform validate to parse provider block, actual credentials not needed for syntax check.
+  # No credentials configured here, as this is for offline validation only.
+  # Running `terraform apply` would require AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, etc.
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-chronos-cache
- **Provider**: gemini
- **Location**: `terraform-modules/nightly-nightly-chronos-cache`
- **Files Created**: 6
- **Description**: A Terraform module to provision a versioned AWS S3 bucket, creating 'chronos echoes' of data for temporal resilience and managed decay.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-chronos-cache`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-chronos-cache/README.md`
- Run tests located in `terraform-modules/nightly-nightly-chronos-cache/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.