### PR TITLE
feat(groq): A tiny Rust CLI that turns any text into an ASCII QR‑code, perfect for terminal‑only sharing.

### DIFF
--- a/rust-utils/nightly-nightly-qr-artefact/Cargo.toml
+++ b/rust-utils/nightly-nightly-qr-artefact/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "nightly-qr-artefact"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }
+qrcodegen = "1.8"

--- a/rust-utils/nightly-nightly-qr-artefact/README.md
+++ b/rust-utils/nightly-nightly-qr-artefact/README.md
@@ -1,0 +1,53 @@
+# nightly‑qr‑artefact
+
+**What it does**
+
+`nightly‑qr‑artefact` is a small, zero‑dependency (aside from the pure‑Rust `qrcodegen` crate) command‑line tool that converts an arbitrary string into a QR‑code rendered as ASCII art.  The output can be copied‑and‑pasted into any terminal, chat, or markdown document.
+
+**Why it’s useful**
+
+* Share URLs, passwords, or any short text without leaving your terminal.
+* No external image viewers – the QR‑code is pure text.
+* Fun for demos, teaching, or just impressing friends.
+
+**Installation**
+
+```bash
+# Clone the repository (or let the ApocalypsAI bot add it under rust‑utils/)
+git clone https://github.com/polsala/ApocalypsAI.git
+cd rust-utils/nightly-qr-artefact
+
+# Build the binary
+cargo build --release
+```
+
+**Usage**
+
+```bash
+# Print the QR‑code for a string (e.g., a URL)
+cargo run --release -- "https://example.com"
+```
+
+The program writes the QR‑code to STDOUT.  Each black module is rendered as `██` and each white module as two spaces, preserving the square aspect ratio.
+
+**Example output**
+
+```
+████████████████████████████████
+██  ██  ██  ██  ██  ██  ██  ██
+██  ████  ████  ████  ████  ██
+██  ██  ██  ██  ██  ██  ██  ██
+████████████████████████████████
+```
+
+*(The actual pattern will differ based on the input string.)*
+
+**Testing**
+
+Run the bundled tests with:
+
+```bash
+cargo test --quiet
+```
+
+The tests verify that the same input always yields the same ASCII output and that different inputs produce different outputs.

--- a/rust-utils/nightly-nightly-qr-artefact/src/main.rs
+++ b/rust-utils/nightly-nightly-qr-artefact/src/main.rs
@@ -1,0 +1,65 @@
+use clap::Parser;
+use qrcodegen::{QrCode, QrCodeEcc};
+
+/// Simple CLI to render a QR‑code as ASCII art.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// The text to encode into a QR‑code.
+    #[arg(value_name = "TEXT")]
+    text: String,
+}
+
+fn generate_qr_ascii(text: &str) -> String {
+    // Encode the text with low error correction (sufficient for terminal display).
+    let qr = QrCode::encode_text(text, QrCodeEcc::Low).expect("Failed to encode QR");
+    let size = qr.size();
+    let mut lines = Vec::with_capacity(size);
+    for y in 0..size {
+        let mut line = String::with_capacity(size * 2);
+        for x in 0..size {
+            if qr.get_module(x, y) {
+                line.push_str("██"); // black module
+            } else {
+                line.push_str("  "); // white module
+            }
+        }
+        lines.push(line);
+    }
+    lines.join("\n")
+}
+
+fn main() {
+    let args = Args::parse();
+    let ascii_qr = generate_qr_ascii(&args.text);
+    println!("{}", ascii_qr);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::generate_qr_ascii;
+
+    #[test]
+    fn same_input_produces_same_output() {
+        let a = generate_qr_ascii("https://example.com");
+        let b = generate_qr_ascii("https://example.com");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn different_inputs_produce_different_outputs() {
+        let a = generate_qr_ascii("foo");
+        let b = generate_qr_ascii("bar");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn output_is_non_empty_and_has_expected_chars() {
+        let out = generate_qr_ascii("test");
+        assert!(!out.is_empty(), "Output should not be empty");
+        // Only spaces and block characters are allowed.
+        for ch in out.chars() {
+            assert!(ch == ' ' || ch == '\u{2588}' || ch == '\n', "Unexpected character in output");
+        }
+    }
+}

--- a/rust-utils/nightly-nightly-qr-artefact/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-qr-artefact/tests/test_main.rs
@@ -1,0 +1,20 @@
+// Integration test that runs the compiled binary and checks exit status.
+// This test does not depend on external services – it is fully deterministic.
+
+use std::process::Command;
+
+#[test]
+fn cli_returns_success_and_non_empty_output() {
+    // Build the binary first (cargo test builds it automatically).
+    let output = Command::new(env!("CARGO_BIN_EXE_nightly-qr-artefact"))
+        .arg("hello world")
+        .output()
+        .expect("Failed to execute binary");
+    assert!(output.status.success(), "Binary should exit with 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.trim().is_empty(), "STDOUT should contain the ASCII QR code");
+    // Ensure only allowed characters are present.
+    for ch in stdout.chars() {
+        assert!(ch == ' ' || ch == '\u{2588}' || ch == '\n', "Unexpected character in CLI output");
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-qr-artefact
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-qr-artefact`
- **Files Created**: 4
- **Description**: A tiny Rust CLI that turns any text into an ASCII QR‑code, perfect for terminal‑only sharing.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-qr-artefact`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-qr-artefact/README.md`
- Run tests located in `rust-utils/nightly-nightly-qr-artefact/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.