### PR TITLE
feat(gemini): An Ansible playbook to prune stale or untagged Markdown notes from a digital garden.

### DIFF
--- a/ansible-playbooks/nightly-nightly-bloom-pruner/README.md
+++ b/ansible-playbooks/nightly-nightly-bloom-pruner/README.md
@@ -1,0 +1,69 @@
+# Nightly Bloom Pruner
+
+## Summary
+
+This Ansible playbook helps maintain a tidy digital garden by identifying and pruning (moving) Markdown notes that are considered 'stale' or lack an 'evergreen' tag. It's designed to prevent digital clutter and encourage focused knowledge management.
+
+## Features
+
+*   **Staleness Detection**: Identifies notes older than a configurable number of days.
+*   **Evergreen Tagging**: Skips notes containing a specified 'evergreen' tag, preserving valuable content regardless of age.
+*   **Dry Run Mode**: Safely preview which notes would be pruned without making any changes.
+*   **Configurable Pruning**: Define the source directory for notes, the destination for pruned notes, and the criteria for staleness.
+
+## Usage
+
+1.  **Define your inventory**: Create an `inventory.ini` file (or use an existing one) that targets the host where your digital garden resides. This can be `localhost`.
+
+    ```ini
+    [garden_servers]
+    localhost ansible_connection=local
+    ```
+
+2.  **Configure variables**: Adjust the `vars/main.yml` file to match your digital garden's setup.
+
+    ```yaml
+    # vars/main.yml
+    notes_path: "/path/to/your/digital/garden/notes"
+    prune_destination: "/path/to/your/digital/garden/archive/pruned_blooms"
+    stale_age_days: 90
+    evergreen_tag: "#evergreen"
+    dry_run: true # Set to 'false' to perform actual pruning
+    ```
+
+3.  **Run the playbook (Dry Run first!):**
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/prune_blooms.yml
+    ```
+
+    Review the output to see which files would be pruned.
+
+4.  **Perform actual pruning (if satisfied with dry run):**
+
+    Change `dry_run: false` in `vars/main.yml` and run again:
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/prune_blooms.yml
+    ```
+
+## Requirements
+
+*   Ansible (version 2.9 or higher recommended)
+*   Access to the target host (e.g., `localhost` for local gardens).
+
+## Directory Structure
+
+```
+. 
+├── README.md
+├── src/
+│   ├── prune_blooms.yml
+│   ├── inventory.ini
+│   └── vars/
+│       └── main.yml
+└── tests/
+    ├── test_prune_blooms.yml
+    ├── test_inventory.ini
+    └── test_vars.yml
+```

--- a/ansible-playbooks/nightly-nightly-bloom-pruner/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-bloom-pruner/src/inventory.ini
@@ -1,0 +1,2 @@
+[garden_servers]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-bloom-pruner/src/prune_blooms.yml
+++ b/ansible-playbooks/nightly-nightly-bloom-pruner/src/prune_blooms.yml
@@ -1,0 +1,70 @@
+---
+- name: Prune stale or untagged Markdown notes from a digital garden
+  hosts: garden_servers
+  gather_facts: true
+  vars_files:
+    - vars/main.yml
+
+  tasks:
+    - name: Ensure prune destination directory exists
+      ansible.builtin.file:
+        path: "{{ prune_destination }}"
+        state: directory
+        mode: '0755'
+
+    - name: Find all Markdown files in the notes path
+      ansible.builtin.find:
+        paths: "{{ notes_path }}"
+        patterns: "*.md"
+        recurse: true
+      register: markdown_files
+
+    - name: Process each Markdown file
+      ansible.builtin.block:
+        - name: Get file stats
+          ansible.builtin.stat:
+            path: "{{ item.path }}"
+          register: file_stat
+
+        - name: Read file content
+          ansible.builtin.slurp:
+            src: "{{ item.path }}"
+          register: file_content
+          when: file_stat.stat.exists
+
+        - name: Decode file content
+          ansible.builtin.set_fact:
+            decoded_content: "{{ file_content.content | b64decode | string }}"
+          when: file_stat.stat.exists
+
+        - name: Determine if file is stale and not evergreen
+          ansible.builtin.set_fact:
+            is_stale: >-
+              {{ (ansible_date_time.epoch | int - file_stat.stat.mtime | int) / (60 * 60 * 24) > stale_age_days }}
+            is_evergreen: >-
+              {{ decoded_content is defined and evergreen_tag in decoded_content }}
+          when: file_stat.stat.exists
+
+        - name: Report file to be pruned (Dry Run)
+          ansible.builtin.debug:
+            msg: "[DRY RUN] Would prune: {{ item.path }} (Stale: {{ is_stale }}, Evergreen: {{ is_evergreen }})"
+          when: >-
+            dry_run and is_stale and not is_evergreen and file_stat.stat.exists
+
+        - name: Prune file (move to archive)
+          ansible.builtin.command: >-
+            mv "{{ item.path }}" "{{ prune_destination }}/{{ item.path | basename }}"
+          when: >-
+            not dry_run and is_stale and not is_evergreen and file_stat.stat.exists
+          args:
+            creates: "{{ prune_destination }}/{{ item.path | basename }}"
+          changed_when: true
+
+        - name: Report file pruned
+          ansible.builtin.debug:
+            msg: "Pruned: {{ item.path }} -> {{ prune_destination }}/{{ item.path | basename }}"
+          when: >-
+            not dry_run and is_stale and not is_evergreen and file_stat.stat.exists
+      loop: "{{ markdown_files.files }}"
+      loop_control:
+        label: "{{ item.path }}"

--- a/ansible-playbooks/nightly-nightly-bloom-pruner/src/vars/main.yml
+++ b/ansible-playbooks/nightly-nightly-bloom-pruner/src/vars/main.yml
@@ -1,0 +1,6 @@
+---
+notes_path: "/tmp/digital_garden_notes"
+prune_destination: "/tmp/digital_garden_archive/pruned_blooms"
+stale_age_days: 30
+evergreen_tag: "#evergreen"
+dry_run: true

--- a/ansible-playbooks/nightly-nightly-bloom-pruner/tests/test_inventory.ini
+++ b/ansible-playbooks/nightly-nightly-bloom-pruner/tests/test_inventory.ini
@@ -1,0 +1,2 @@
+[localhost]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-bloom-pruner/tests/test_prune_blooms.yml
+++ b/ansible-playbooks/nightly-nightly-bloom-pruner/tests/test_prune_blooms.yml
@@ -1,0 +1,168 @@
+---
+- name: Test Nightly Bloom Pruner
+  hosts: localhost
+  gather_facts: true
+  vars:
+    test_garden_path: "/tmp/test_digital_garden"
+    test_prune_destination: "/tmp/test_digital_garden_archive"
+    test_stale_age_days: 1
+    test_evergreen_tag: "#evergreen"
+
+  pre_tasks:
+    - name: Clean up previous test runs
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ test_garden_path }}"
+        - "{{ test_prune_destination }}"
+      # Mock rationale: Cleaning up test directories ensures a clean slate for deterministic testing.
+
+    - name: Create test garden directory
+      ansible.builtin.file:
+        path: "{{ test_garden_path }}"
+        state: directory
+        mode: '0755'
+      # Mock rationale: Creating a mock directory for the digital garden to simulate the target environment.
+
+    - name: Create test prune destination directory
+      ansible.builtin.file:
+        path: "{{ test_prune_destination }}"
+        state: directory
+        mode: '0755'
+      # Mock rationale: Creating a mock directory for pruned files to simulate the archive.
+
+    - name: Create old stale note (should be pruned)
+      ansible.builtin.copy:
+        dest: "{{ test_garden_path }}/old_stale_note.md"
+        content: "This is an old, stale note."
+        mode: '0644'
+      # Mock rationale: Creating a mock file with specific content for testing pruning logic.
+
+    - name: Set modification time for old stale note
+      ansible.builtin.command: >-
+        touch -d "{{ ansible_date_time.date }} -{{ test_stale_age_days + 1 }} days" "{{ test_garden_path }}/old_stale_note.md"
+      changed_when: true
+      # Mock rationale: Manually setting modification time to simulate an old file, crucial for staleness detection.
+
+    - name: Create old evergreen note (should NOT be pruned)
+      ansible.builtin.copy:
+        dest: "{{ test_garden_path }}/old_evergreen_note.md"
+        content: "This is an old, evergreen note. {{ test_evergreen_tag }}"
+        mode: '0644'
+      # Mock rationale: Creating a mock file with specific content for testing evergreen tag detection.
+
+    - name: Set modification time for old evergreen note
+      ansible.builtin.command: >-
+        touch -d "{{ ansible_date_time.date }} -{{ test_stale_age_days + 1 }} days" "{{ test_garden_path }}/old_evergreen_note.md"
+      changed_when: true
+      # Mock rationale: Manually setting modification time to simulate an old file.
+
+    - name: Create new stale note (should NOT be pruned)
+      ansible.builtin.copy:
+        dest: "{{ test_garden_path }}/new_stale_note.md"
+        content: "This is a new, stale note."
+        mode: '0644'
+      # Mock rationale: Creating a mock file with specific content for testing staleness detection.
+
+    - name: Create new evergreen note (should NOT be pruned)
+      ansible.builtin.copy:
+        dest: "{{ test_garden_path }}/new_evergreen_note.md"
+        content: "This is a new, evergreen note. {{ test_evergreen_tag }}"
+        mode: '0644'
+      # Mock rationale: Creating a mock file with specific content for testing evergreen tag detection.
+
+  tasks:
+    - name: Run playbook in DRY RUN mode and capture output
+      ansible.builtin.shell: >-
+        ansible-playbook -i {{ playbook_dir }}/test_inventory.ini
+        -e notes_path={{ test_garden_path }}
+        -e prune_destination={{ test_prune_destination }}
+        -e stale_age_days={{ test_stale_age_days | string }}
+        -e evergreen_tag={{ test_evergreen_tag }}
+        -e dry_run=true
+        {{ playbook_dir }}/../src/prune_blooms.yml
+      register: dry_run_result
+      changed_when: false
+      # Mock rationale: Running the main playbook with test-specific variables and in dry-run mode to verify reporting without actual changes. Capturing stdout allows assertion of debug messages.
+
+    - name: Assert old_stale_note.md is reported in dry run
+      ansible.builtin.assert:
+        that: "'Would prune: {{ test_garden_path }}/old_stale_note.md' in dry_run_result.stdout"
+        fail_msg: "old_stale_note.md was not reported for pruning in dry run."
+      # Mock rationale: Verifying the debug output from the dry run to ensure the correct files are identified for pruning.
+
+    - name: Assert old_stale_note.md still exists after dry run
+      ansible.builtin.stat:
+        path: "{{ test_garden_path }}/old_stale_note.md"
+      register: old_stale_original_stat_after_dry_run
+      # Mock rationale: Verifying the file still exists after a dry run, confirming no actual changes were made.
+    - ansible.builtin.assert:
+        that: "old_stale_original_stat_after_dry_run.stat.exists"
+        fail_msg: "old_stale_note.md was unexpectedly pruned during dry run."
+
+    - name: Run playbook in ACTUAL PRUNE mode
+      ansible.builtin.include_tasks:
+        file: ../src/prune_blooms.yml
+      vars:
+        notes_path: "{{ test_garden_path }}"
+        prune_destination: "{{ test_prune_destination }}"
+        stale_age_days: "{{ test_stale_age_days }}"
+        evergreen_tag: "{{ test_evergreen_tag }}"
+        dry_run: false
+      # Mock rationale: Running the main playbook with test-specific variables and in actual prune mode to verify file system changes.
+
+    - name: Assert old_stale_note.md is pruned (moved)
+      ansible.builtin.stat:
+        path: "{{ test_garden_path }}/old_stale_note.md"
+      register: old_stale_original_stat
+      # Mock rationale: Verifying the original file is no longer in its source location.
+    - ansible.builtin.assert:
+        that: "not old_stale_original_stat.stat.exists"
+        fail_msg: "old_stale_note.md was not pruned from original location."
+
+    - name: Assert old_stale_note.md exists in prune destination
+      ansible.builtin.stat:
+        path: "{{ test_prune_destination }}/old_stale_note.md"
+      register: old_stale_pruned_stat
+      # Mock rationale: Verifying the file has been moved to the correct prune destination.
+    - ansible.builtin.assert:
+        that: "old_stale_pruned_stat.stat.exists"
+        fail_msg: "old_stale_note.md was not moved to prune destination."
+
+    - name: Assert old_evergreen_note.md is NOT pruned
+      ansible.builtin.stat:
+        path: "{{ test_garden_path }}/old_evergreen_note.md"
+      register: old_evergreen_stat
+      # Mock rationale: Verifying that files with the evergreen tag are not pruned, even if stale.
+    - ansible.builtin.assert:
+        that: "old_evergreen_stat.stat.exists"
+        fail_msg: "old_evergreen_note.md was unexpectedly pruned."
+
+    - name: Assert new_stale_note.md is NOT pruned
+      ansible.builtin.stat:
+        path: "{{ test_garden_path }}/new_stale_note.md"
+      register: new_stale_stat
+      # Mock rationale: Verifying that new files are not pruned, even if they lack the evergreen tag.
+    - ansible.builtin.assert:
+        that: "new_stale_stat.stat.exists"
+        fail_msg: "new_stale_note.md was unexpectedly pruned."
+
+    - name: Assert new_evergreen_note.md is NOT pruned
+      ansible.builtin.stat:
+        path: "{{ test_garden_path }}/new_evergreen_note.md"
+      register: new_evergreen_stat
+      # Mock rationale: Verifying that new evergreen files are not pruned.
+    - ansible.builtin.assert:
+        that: "new_evergreen_stat.stat.exists"
+        fail_msg: "new_evergreen_note.md was unexpectedly pruned."
+
+  post_tasks:
+    - name: Clean up test directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ test_garden_path }}"
+        - "{{ test_prune_destination }}"
+      # Mock rationale: Cleaning up test directories after the test run to leave no artifacts.

--- a/ansible-playbooks/nightly-nightly-bloom-pruner/tests/test_vars.yml
+++ b/ansible-playbooks/nightly-nightly-bloom-pruner/tests/test_vars.yml
@@ -1,0 +1,8 @@
+---
+# These variables are overridden in test_prune_blooms.yml for specific test scenarios.
+# They are here for documentation/context only.
+notes_path: "/tmp/test_digital_garden"
+prune_destination: "/tmp/test_digital_garden_archive"
+stale_age_days: 1
+evergreen_tag: "#evergreen"
+dry_run: true


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-bloom-pruner
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-bloom-pruner`
- **Files Created**: 7
- **Description**: An Ansible playbook to prune stale or untagged Markdown notes from a digital garden.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-bloom-pruner`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-bloom-pruner/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-bloom-pruner/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.