### PR TITLE
feat(groq): Estimates cumulative radiation dose from intensity and exposure time, warning if it exceeds safe limits.

### DIFF
--- a/rust-utils/nightly-nightly-radiation-calc/Cargo.toml
+++ b/rust-utils/nightly-nightly-radiation-calc/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "radiation_calc"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.4", features = ["derive"] }
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.0"

--- a/rust-utils/nightly-nightly-radiation-calc/README.md
+++ b/rust-utils/nightly-nightly-radiation-calc/README.md
@@ -1,0 +1,28 @@
+# Nightly Radiation Calc
+
+A tiny Rust CLI tool that computes the total radiation dose (in millisieverts) given an intensity (mSv/h) and exposure duration (hours). It warns when the dose exceeds the commonly referenced safe limit of 100 mSv.
+
+## Usage
+
+```sh
+cargo run -- <intensity> <hours>
+```
+
+Example:
+
+```sh
+cargo run -- 0.5 48
+# => Total dose: 24.00 mSv (safe)
+```
+
+## Build
+
+```sh
+cargo build --release
+```
+
+## Test
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-radiation-calc/src/main.rs
+++ b/rust-utils/nightly-nightly-radiation-calc/src/main.rs
@@ -1,0 +1,44 @@
+use clap::Parser;
+
+/// Simple radiation dose calculator
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Radiation intensity in millisieverts per hour (mSv/h)
+    intensity: f64,
+    /// Exposure duration in hours
+    hours: f64,
+}
+
+const SAFE_LIMIT: f64 = 100.0;
+
+fn compute_dose(intensity: f64, hours: f64) -> f64 {
+    intensity * hours
+}
+
+fn main() {
+    let args = Args::parse();
+    let dose = compute_dose(args.intensity, args.hours);
+    if dose > SAFE_LIMIT {
+        println!("Total dose: {:.2} mSv (EXCEEDS safe limit of {:.0} mSv!)", dose, SAFE_LIMIT);
+    } else {
+        println!("Total dose: {:.2} mSv (safe)", dose);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_dose() {
+        assert_eq!(compute_dose(0.5, 10.0), 5.0);
+        assert_eq!(compute_dose(2.0, 25.0), 50.0);
+    }
+
+    #[test]
+    fn test_safe_limit_boundary() {
+        let dose = compute_dose(10.0, 10.0);
+        assert_eq!(dose, 100.0);
+    }
+}

--- a/rust-utils/nightly-nightly-radiation-calc/tests/integration_test.rs
+++ b/rust-utils/nightly-nightly-radiation-calc/tests/integration_test.rs
@@ -1,0 +1,20 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn cli_outputs_safe() {
+    let mut cmd = Command::cargo_bin("radiation_calc").unwrap();
+    cmd.arg("0.5").arg("48");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Total dose: 24.00 mSv (safe)"));
+}
+
+#[test]
+fn cli_outputs_exceeds() {
+    let mut cmd = Command::cargo_bin("radiation_calc").unwrap();
+    cmd.arg("5").arg("30");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("EXCEEDS safe limit"));
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-radiation-calc
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-radiation-calc`
- **Files Created**: 4
- **Description**: Estimates cumulative radiation dose from intensity and exposure time, warning if it exceeds safe limits.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-radiation-calc`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-radiation-calc/README.md`
- Run tests located in `rust-utils/nightly-nightly-radiation-calc/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.