### PR TITLE
feat(groq): A tiny Rust CLI that maps common color names to their ANSI escape codes for terminal styling.

### DIFF
--- a/rust-utils/nightly-nightly-ansi-color-palette-3/Cargo.toml
+++ b/rust-utils/nightly-nightly-ansi-color-palette-3/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ansi_color_palette"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-ansi-color-palette-3/README.md
+++ b/rust-utils/nightly-nightly-ansi-color-palette-3/README.md
@@ -1,0 +1,47 @@
+# nightly-ansi-color-palette
+
+A tiny Rust CLI that translates common color names into their ANSI escape codes for terminal text styling.
+
+## Usage
+
+```sh
+cargo run --quiet -- <color>
+```
+
+Example:
+
+```sh
+$ cargo run --quiet -- red
+31
+```
+
+## Supported colors
+
+- black
+- red
+- green
+- yellow
+- blue
+- magenta
+- cyan
+- white
+- bright_black
+- bright_red
+- bright_green
+- bright_yellow
+- bright_blue
+- bright_magenta
+- bright_cyan
+- bright_white
+
+## Build
+
+```sh
+cargo build --release
+```
+
+## Test
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-ansi-color-palette-3/src/lib.rs
+++ b/rust-utils/nightly-nightly-ansi-color-palette-3/src/lib.rs
@@ -1,0 +1,21 @@
+pub fn get_ansi_code(color: &str) -> Option<&'static str> {
+    match color.to_ascii_lowercase().as_str() {
+        "black" => Some("30"),
+        "red" => Some("31"),
+        "green" => Some("32"),
+        "yellow" => Some("33"),
+        "blue" => Some("34"),
+        "magenta" => Some("35"),
+        "cyan" => Some("36"),
+        "white" => Some("37"),
+        "bright_black" => Some("90"),
+        "bright_red" => Some("91"),
+        "bright_green" => Some("92"),
+        "bright_yellow" => Some("93"),
+        "bright_blue" => Some("94"),
+        "bright_magenta" => Some("95"),
+        "bright_cyan" => Some("96"),
+        "bright_white" => Some("97"),
+        _ => None,
+    }
+}

--- a/rust-utils/nightly-nightly-ansi-color-palette-3/src/main.rs
+++ b/rust-utils/nightly-nightly-ansi-color-palette-3/src/main.rs
@@ -1,0 +1,18 @@
+use ansi_color_palette::get_ansi_code;
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("Usage: <color>");
+        std::process::exit(1);
+    }
+    let color = &args[0];
+    match get_ansi_code(color) {
+        Some(code) => println!("{}", code),
+        None => {
+            eprintln!("Unsupported color: {}", color);
+            std::process::exit(1);
+        }
+    }
+}

--- a/rust-utils/nightly-nightly-ansi-color-palette-3/tests/integration_test.rs
+++ b/rust-utils/nightly-nightly-ansi-color-palette-3/tests/integration_test.rs
@@ -1,0 +1,13 @@
+use ansi_color_palette::get_ansi_code;
+
+#[test]
+fn test_known_colors() {
+    assert_eq!(get_ansi_code("red"), Some("31"));
+    assert_eq!(get_ansi_code("Bright_Blue"), Some("94"));
+    assert_eq!(get_ansi_code("WHITE"), Some("37"));
+}
+
+#[test]
+fn test_unknown_color() {
+    assert_eq!(get_ansi_code("chartreuse"), None);
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansi-color-palette
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-ansi-color-palette-3`
- **Files Created**: 5
- **Description**: A tiny Rust CLI that maps common color names to their ANSI escape codes for terminal styling.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-ansi-color-palette-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-ansi-color-palette-3/README.md`
- Run tests located in `rust-utils/nightly-nightly-ansi-color-palette-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.