### PR TITLE
feat(gemini): A Terraform module to provision a whimsical cloud-based static website beacon for broadcasting community whispers.

### DIFF
--- a/terraform-modules/nightly-nightly-cloud-whisperer-beac/README.md
+++ b/terraform-modules/nightly-nightly-cloud-whisperer-beac/README.md
@@ -1,0 +1,65 @@
+# Nightly Cloud-Whisperer Beacon
+
+## Summary
+This Terraform module provisions a whimsical AWS S3 bucket configured as a static website, ready to broadcast community whispers or status updates to the digital void.
+
+## Purpose
+In the ever-shifting landscape of the apocalypse, a stable point of communication is vital. This beacon provides a simple, low-cost way to establish a public-facing endpoint where the community can share messages, updates, or simply existential musings. It's a digital campfire for the end times.
+
+## Usage
+
+1.  **Prerequisites**:
+    *   [Terraform](https://www.terraform.io/downloads.html) installed.
+    *   AWS credentials configured (e.g., via `~/.aws/credentials` or environment variables).
+    *   `jq` installed (for running tests).
+
+2.  **Module Integration**:
+    Create a new Terraform configuration file (e.g., `main.tf`) in your project and reference this module:
+
+    ```terraform
+    module "whisper_beacon" {
+      source = "./path/to/nightly-cloud-whisperer-beacon/src"
+
+      # Optional: Customize these variables
+      bucket_name_prefix    = "my-community-beacon"
+      region                = "us-west-2"
+      initial_whisper_message = "Hear ye, hear ye! The latest news from Sector 7G: The squirrels are organizing."
+    }
+
+    output "beacon_url" {
+      value = module.whisper_beacon.website_endpoint
+    }
+    ```
+
+3.  **Deployment**:
+    Navigate to your project directory (where your `main.tf` is located) and run:
+
+    ```bash
+    terraform init
+    terraform plan
+    terraform apply
+    ```
+
+    Confirm the `apply` operation when prompted.
+
+4.  **Accessing the Beacon**:
+    After successful deployment, Terraform will output the `beacon_url`. You can access your whimsical static website through this URL.
+
+## Inputs
+
+| Name                    | Description                                                              | Type   | Default                                                                                              | Required |
+| :---------------------- | :----------------------------------------------------------------------- | :----- | :--------------------------------------------------------------------------------------------------- | :------- |
+| `bucket_name_prefix`    | A prefix for the S3 bucket name. A random suffix will be appended.       | `string` | `"apocalypsai-whisper-beacon"`                                                                     | no       |
+| `region`                | The AWS region to deploy the S3 bucket in.                               | `string` | `"us-east-1"`                                                                                      | no       |
+| `initial_whisper_message` | The initial whimsical message to display on the beacon's index page.     | `string` | `"Greetings, wanderer! May your path be ever-illuminated by the glow of forgotten stars."`         | no       |
+
+## Outputs
+
+| Name             | Description                                  |
+| :--------------- | :------------------------------------------- |
+| `website_endpoint` | The URL of the static website endpoint.      |
+| `bucket_name`    | The full name of the S3 bucket.              |
+
+## Tests
+
+The `tests/test.sh` script performs offline validation and planning checks to ensure the module is correctly configured and produces the expected resources without deploying actual infrastructure. It uses `terraform validate` and `terraform plan -json` to inspect the planned changes.

--- a/terraform-modules/nightly-nightly-cloud-whisperer-beac/src/main.tf
+++ b/terraform-modules/nightly-nightly-cloud-whisperer-beac/src/main.tf
@@ -1,0 +1,91 @@
+resource "aws_s3_bucket" "whisper_beacon" {
+  bucket = "${var.bucket_name_prefix}-${random_string.suffix.result}"
+  acl    = "public-read" # Whimsical: public for all to hear the whispers
+
+  website {
+    index_document = "index.html"
+    error_document = "error.html"
+  }
+
+  tags = {
+    Project     = "ApocalypsAI"
+    Utility     = "CloudWhispererBeacon"
+    Environment = "Whimsical"
+  }
+}
+
+resource "aws_s3_bucket_policy" "whisper_beacon_policy" {
+  bucket = aws_s3_bucket.whisper_beacon.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "PublicReadGetObject"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["s3:GetObject"]
+        Resource  = ["${aws_s3_bucket.whisper_beacon.arn}/*"]
+      },
+    ]
+  })
+}
+
+resource "aws_s3_bucket_object" "index_html" {
+  bucket       = aws_s3_bucket.whisper_beacon.id
+  key          = "index.html"
+  content_type = "text/html"
+  content      = <<EOF
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ApocalypsAI Whisper Beacon</title>
+    <style>
+        body { font-family: monospace; background-color: #1a1a2e; color: #e0e0e0; text-align: center; padding-top: 50px; }
+        h1 { color: #e94560; }
+        p { font-size: 1.2em; }
+        .whisper { border: 2px dashed #533483; padding: 20px; margin: 20px auto; max-width: 600px; }
+    </style>
+</head>
+<body>
+    <h1>The Void Whispers Back!</h1>
+    <div class="whisper">
+        <p>${var.initial_whisper_message}</p>
+        <p>This beacon is maintained by the ApocalypsAI community.</p>
+    </div>
+</body>
+</html>
+EOF
+  acl          = "public-read"
+}
+
+resource "aws_s3_bucket_object" "error_html" {
+  bucket       = aws_s3_bucket.whisper_beacon.id
+  key          = "error.html"
+  content_type = "text/html"
+  content      = <<EOF
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Error - ApocalypsAI Whisper Beacon</title>
+    <style>
+        body { font-family: monospace; background-color: #1a1a2e; color: #e0e0e0; text-align: center; padding-top: 50px; }
+        h1 { color: #e94560; }
+        p { font-size: 1.2em; }
+    </style>
+</head>
+<body>
+    <h1>Lost in the Echoes...</h1>
+    <p>The whisper you sought has drifted away. Perhaps try another path?</p>
+</body>
+</html>
+EOF
+  acl          = "public-read"
+}
+
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+  numeric = true
+}

--- a/terraform-modules/nightly-nightly-cloud-whisperer-beac/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-cloud-whisperer-beac/src/outputs.tf
@@ -1,0 +1,9 @@
+output "website_endpoint" {
+  description = "The URL of the static website endpoint."
+  value       = aws_s3_bucket.whisper_beacon.website_endpoint
+}
+
+output "bucket_name" {
+  description = "The full name of the S3 bucket."
+  value       = aws_s3_bucket.whisper_beacon.bucket
+}

--- a/terraform-modules/nightly-nightly-cloud-whisperer-beac/src/providers.tf
+++ b/terraform-modules/nightly-nightly-cloud-whisperer-beac/src/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform-modules/nightly-nightly-cloud-whisperer-beac/src/variables.tf
+++ b/terraform-modules/nightly-nightly-cloud-whisperer-beac/src/variables.tf
@@ -1,0 +1,17 @@
+variable "bucket_name_prefix" {
+  description = "A prefix for the S3 bucket name. A random suffix will be appended."
+  type        = string
+  default     = "apocalypsai-whisper-beacon"
+}
+
+variable "region" {
+  description = "The AWS region to deploy the S3 bucket in."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "initial_whisper_message" {
+  description = "The initial whimsical message to display on the beacon's index page."
+  type        = string
+  default     = "Greetings, wanderer! May your path be ever-illuminated by the glow of forgotten stars."
+}

--- a/terraform-modules/nightly-nightly-cloud-whisperer-beac/tests/main.tf
+++ b/terraform-modules/nightly-nightly-cloud-whisperer-beac/tests/main.tf
@@ -1,0 +1,7 @@
+module "test_beacon" {
+  source = "../src"
+
+  bucket_name_prefix    = "test-apocalypsai-whisper"
+  region                = "us-east-1"
+  initial_whisper_message = "Test whisper: The code compiles, for now."
+}

--- a/terraform-modules/nightly-nightly-cloud-whisperer-beac/tests/test.sh
+++ b/terraform-modules/nightly-nightly-cloud-whisperer-beac/tests/test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "--- Running Terraform tests for Nightly Cloud-Whisperer Beacon ---"
+
+# Mock rationale: Terraform plan and validate are offline operations.
+# We are testing the module's syntax, variable handling, and expected resource definitions
+# without actually provisioning cloud resources. This ensures the module is well-formed
+# and produces a predictable plan.
+
+# Initialize Terraform in the test directory
+echo "Initializing Terraform..."
+terraform -chdir=tests init -backend=false > /dev/null
+
+# Validate the Terraform configuration
+echo "Validating Terraform configuration..."
+terraform -chdir=tests validate
+
+if [ $? -ne 0 ]; then
+  echo "Terraform validation failed!"
+  exit 1
+fi
+echo "Terraform configuration is valid."
+
+# Generate a plan and output it as JSON
+echo "Generating Terraform plan..."
+terraform -chdir=tests plan -out=tfplan -input=false -var="bucket_name_prefix=test-apocalypsai-whisper" -var="region=us-east-1" -var="initial_whisper_message=Test whisper: The code compiles, for now."
+
+if [ $? -ne 0 ]; then
+  echo "Terraform plan generation failed!"
+  exit 1
+fi
+
+# Show the plan in JSON format and parse it
+PLAN_JSON=$(terraform -chdir=tests show -json tfplan)
+
+# Assertions
+echo "Performing assertions on the plan..."
+
+# Check for the S3 bucket resource
+if ! echo "$PLAN_JSON" | jq -e '.resource_changes[] | select(.type == "aws_s3_bucket" and .change.actions[] == "create")' > /dev/null; then
+  echo "Assertion failed: aws_s3_bucket resource not found in plan."
+  exit 1
+fi
+echo "Assertion passed: aws_s3_bucket resource found."
+
+# Check for the S3 bucket policy resource
+if ! echo "$PLAN_JSON" | jq -e '.resource_changes[] | select(.type == "aws_s3_bucket_policy" and .change.actions[] == "create")' > /dev/null; then
+  echo "Assertion failed: aws_s3_bucket_policy resource not found in plan."
+  exit 1
+fi
+echo "Assertion passed: aws_s3_bucket_policy resource found."
+
+# Check for index.html object
+if ! echo "$PLAN_JSON" | jq -e '.resource_changes[] | select(.type == "aws_s3_bucket_object" and .name == "index_html" and .change.actions[] == "create")' > /dev/null; then
+  echo "Assertion failed: aws_s3_bucket_object (index_html) resource not found in plan."
+  exit 1
+fi
+echo "Assertion passed: aws_s3_bucket_object (index_html) resource found."
+
+# Check for error.html object
+if ! echo "$PLAN_JSON" | jq -e '.resource_changes[] | select(.type == "aws_s3_bucket_object" and .name == "error_html" and .change.actions[] == "create")' > /dev/null; then
+  echo "Assertion failed: aws_s3_bucket_object (error_html) resource not found in plan."
+  exit 1
+fi
+echo "Assertion passed: aws_s3_bucket_object (error_html) resource found."
+
+# Check if the bucket name prefix is used in the planned bucket name
+# This requires parsing the 'after' attribute of the bucket resource
+BUCKET_NAME_PLANNED=$(echo "$PLAN_JSON" | jq -r '.resource_changes[] | select(.type == "aws_s3_bucket" and .change.actions[] == "create") | .change.after.bucket')
+if [[ "$BUCKET_NAME_PLANNED" != "test-apocalypsai-whisper-"* ]]; then
+  echo "Assertion failed: Planned bucket name '$BUCKET_NAME_PLANNED' does not start with 'test-apocalypsai-whisper-'."
+  exit 1
+fi
+echo "Assertion passed: Planned bucket name starts with the correct prefix."
+
+# Check if the website configuration is present
+if ! echo "$PLAN_JSON" | jq -e '.resource_changes[] | select(.type == "aws_s3_bucket" and .change.actions[] == "create" and .change.after.website.index_document == "index.html")' > /dev/null; then
+  echo "Assertion failed: S3 bucket website configuration (index_document) not found or incorrect."
+  exit 1
+fi
+echo "Assertion passed: S3 bucket website configuration (index_document) found."
+
+echo "All Terraform tests passed successfully!"
+
+# Clean up the plan file
+rm tfplan


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-cloud-whisperer-beacon
- **Provider**: gemini
- **Location**: `terraform-modules/nightly-nightly-cloud-whisperer-beac`
- **Files Created**: 7
- **Description**: A Terraform module to provision a whimsical cloud-based static website beacon for broadcasting community whispers.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-cloud-whisperer-beac`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-cloud-whisperer-beac/README.md`
- Run tests located in `terraform-modules/nightly-nightly-cloud-whisperer-beac/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.