### PR TITLE
feat(groq): Terraform module that provisions a version‑enabled, encrypted S3 bucket with optional random name suffix for post‑apocalypse data storage.

### DIFF
--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/README.md
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/README.md
@@ -1,0 +1,31 @@
+# Apocalyptic Safehouse S3 Terraform Module
+
+Creates an S3 bucket with versioning, server‑side encryption, a lifecycle rule to delete old versions after 30 days, and an optional random suffix to avoid name collisions. Ideal for storing post‑apocalypse data backups.
+
+## Usage
+
+```hcl
+module "safehouse" {
+  source = "git::https://github.com/yourorg/apocalypsai.git//terraform-modules/nightly-apocalypse-safehouse-s3"
+
+  bucket_name = "apocalypse-data"
+}
+```
+
+## Inputs
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `bucket_name` | string | Base name for the bucket. | n/a |
+| `enable_random_suffix` | bool | Append a random suffix to avoid collisions. | `true` |
+| `aws_region` | string | AWS region for the bucket. | `"us-east-1"` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `bucket_id` | The ID of the created bucket. |
+| `bucket_arn` | The ARN of the created bucket. |
+| `bucket_name` | The final bucket name (with suffix if enabled). |
+
+Run `terraform init && terraform apply` to create the safehouse.

--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/src/main.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/src/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "random_pet" "suffix" {
+  count  = var.enable_random_suffix ? 1 : 0
+  length = 2
+}
+
+resource "aws_s3_bucket" "safehouse" {
+  bucket = var.enable_random_suffix ? "${var.bucket_name}-${random_pet.suffix[0].id}" : var.bucket_name
+
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "expire-old-versions"
+    enabled = true
+
+    noncurrent_version_expiration {
+      days = 30
+    }
+  }
+
+  tags = {
+    Purpose = "Apocalypse Safehouse"
+  }
+}
+
+output "bucket_id" {
+  value = aws_s3_bucket.safehouse.id
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.safehouse.arn
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.safehouse.bucket
+}

--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/src/variables.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/src/variables.tf
@@ -1,0 +1,16 @@
+variable "bucket_name" {
+  description = "Base name for the S3 bucket."
+  type        = string
+}
+
+variable "enable_random_suffix" {
+  description = "Whether to append a random suffix to avoid name collisions."
+  type        = bool
+  default     = true
+}
+
+variable "aws_region" {
+  description = "AWS region."
+  type        = string
+  default     = "us-east-1"
+}

--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/tests/test_main.sh
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/tests/test_main.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# Initialize Terraform without a remote backend
+terraform -chdir=src init -backend=false -input=false > /dev/null
+
+# Validate the configuration; will exit non‑zero on errors
+terraform -chdir=src validate
+
+echo "Terraform module validation passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-apocalypse-safehouse-s3
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-apocalypse-safehouse-6`
- **Files Created**: 4
- **Description**: Terraform module that provisions a version‑enabled, encrypted S3 bucket with optional random name suffix for post‑apocalypse data storage.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-apocalypse-safehouse-6`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-apocalypse-safehouse-6/README.md`
- Run tests located in `terraform-modules/nightly-nightly-apocalypse-safehouse-6/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.