### PR TITLE
feat(gemini): An Ansible playbook to help maintain a digital garden or knowledge base by identifying and suggesting actions for stale or unlinked notes.

### DIFF
--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/README.md
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/README.md
@@ -1,0 +1,83 @@
+# Nightly Digital Garden Weeder
+
+This Ansible playbook helps you maintain a tidy digital garden or personal knowledge base by identifying notes that are either 'stale' (not modified recently) or 'unlinked' (not referenced by other notes).
+
+It generates a report and can optionally move identified files to a 'quarantine' directory, allowing you to review them for deletion, archiving, or integration.
+
+## Features
+
+*   **Staleness Detection**: Identifies markdown files that haven't been modified within a configurable threshold.
+*   **Unlinked Note Detection**: Scans other markdown files to see if a note's filename (without extension) is referenced, helping find orphaned content.
+*   **Comprehensive Report**: Generates a detailed report listing stale files, unlinked files, and those that are both (quarantine candidates).
+*   **Optional Quarantine**: Safely moves identified 'quarantine candidates' to a designated directory for review, rather than immediate deletion.
+
+## Prerequisites
+
+*   Ansible (version 2.9 or newer recommended)
+*   A local or remote system with markdown files to manage.
+
+## Usage
+
+1.  **Clone the repository** (or copy this utility's folder).
+2.  **Configure your inventory**: The `src/inventory.ini` file is set up for `localhost` by default. If you want to run this on a remote machine, update the inventory accordingly.
+3.  **Adjust variables**: Modify `src/vars/main.yml` to define your `garden_path`, `quarantine_path`, `stale_threshold_days`, and whether to `perform_quarantine`.
+4.  **Run the playbook (check mode first)**:
+
+    It's highly recommended to run in check mode first to see what actions would be taken without actually modifying your files:
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/weeder.yml --check
+    ```
+
+5.  **Review the report**: A report will be generated in your `quarantine_path` (e.g., `/tmp/digital_garden_quarantine/weeder_report_YYYYMMDDTHHMMSSZ.txt`). Examine its contents to understand which files are identified.
+
+6.  **Run the playbook (with quarantine, if desired)**:
+
+    If you are satisfied with the report and want to move the identified files to quarantine, set `perform_quarantine: true` in `src/vars/main.yml` and run:
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/weeder.yml
+    ```
+
+## Configuration (`src/vars/main.yml`)
+
+*   `garden_path`: The absolute path to your digital garden or knowledge base directory. (e.g., `"/home/user/notes"`)
+*   `quarantine_path`: The absolute path where identified files will be moved if `perform_quarantine` is `true`. (e.g., `"/home/user/notes_quarantine"`)
+*   `stale_threshold_days`: The number of days after which a file is considered 'stale' if not modified. (e.g., `90`)
+*   `perform_quarantine`: Set to `true` to enable moving files to the `quarantine_path`. Set to `false` (default) to only generate a report. (e.g., `true`)
+
+## How "Unlinked" is Determined
+
+A note is considered "unlinked" if its filename (without the `.md` extension) does not appear as a whole word within the content of any other markdown file in the garden. This is a heuristic and might not cover all linking conventions (e.g., complex graph databases or specific wiki-link syntaxes), but it's effective for simple markdown-based gardens.
+
+## Example Report Output
+
+```text
+Digital Garden Weeder Report - 2023-10-27T10:30:00Z
+
+Garden Path: /tmp/digital_garden
+Quarantine Path: /tmp/digital_garden_quarantine
+Stale Threshold: 30 days
+Perform Quarantine: false
+
+---
+Total Markdown Files Found: 5
+
+---
+Stale Files (Modified over 30 days ago):
+- /tmp/digital_garden/stale_linked_note.md (Last Modified: 2023-09-01 10:00:00)
+- /tmp/digital_garden/stale_unlinked_note.md (Last Modified: 2023-09-05 14:30:00)
+
+---
+Unlinked Files (Not referenced by other notes):
+- /tmp/digital_garden/stale_unlinked_note.md
+- /tmp/digital_garden/fresh_unlinked_note.md
+
+---
+Quarantine Candidates (Stale AND Unlinked):
+- /tmp/digital_garden/stale_unlinked_note.md
+
+---
+Action Taken:
+Quarantine is disabled. No files were moved.
+```

--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/inventory.ini
@@ -1,0 +1,2 @@
+[localhost]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/templates/weeder_report.j2
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/templates/weeder_report.j2
@@ -1,0 +1,49 @@
+Digital Garden Weeder Report - {{ ansible_date_time.iso8601 }}
+
+Garden Path: {{ garden_path }}
+Quarantine Path: {{ quarantine_path }}
+Stale Threshold: {{ stale_threshold_days }} days
+Perform Quarantine: {{ perform_quarantine }}
+
+---
+Total Markdown Files Found: {{ processed_files | length }}
+
+---
+Stale Files (Modified over {{ stale_threshold_days }} days ago):
+{% if stale_files %}
+{% for file in stale_files %}
+- {{ file.path }} (Last Modified: {{ file.mtime | ansible.builtin.strftime('%Y-%m-%d %H:%M:%S') }})
+{% endfor %}
+{% else %}
+No stale files found.
+{% endif %}
+
+---
+Unlinked Files (Not referenced by other notes):
+{% if unlinked_files %}
+{% for file in unlinked_files %}
+- {{ file.path }}
+{% endfor %}
+{% else %}
+No unlinked files found.
+{% endif %}
+
+---
+Quarantine Candidates (Stale AND Unlinked):
+{% if quarantine_files %}
+{% for file in quarantine_files %}
+- {{ file.path }}
+{% endfor %}
+{% else %}
+No files identified for quarantine.
+{% endif %}
+
+---
+Action Taken:
+{% if perform_quarantine and quarantine_files %}
+{{ quarantine_files | length }} files moved to {{ quarantine_path }}.
+{% elif perform_quarantine and not quarantine_files %}
+Quarantine enabled, but no files met the criteria.
+{% else %}
+Quarantine is disabled. No files were moved.
+{% endif %}

--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/vars/main.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/vars/main.yml
@@ -1,0 +1,5 @@
+---
+garden_path: "/tmp/digital_garden"
+quarantine_path: "/tmp/digital_garden_quarantine"
+stale_threshold_days: 30 # Files not modified in the last 30 days are considered stale
+perform_quarantine: false # Set to true to actually move files

--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/weeder.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/weeder.yml
@@ -1,0 +1,91 @@
+---
+- name: Digital Garden Weeder
+  hosts: localhost
+  connection: local
+  gather_facts: no
+
+  vars_files:
+    - vars/main.yml
+
+  tasks:
+    - name: Ensure garden path exists
+      ansible.builtin.file:
+        path: "{{ garden_path }}"
+        state: directory
+        mode: '0755'
+
+    - name: Ensure quarantine path exists
+      ansible.builtin.file:
+        path: "{{ quarantine_path }}"
+        state: directory
+        mode: '0755'
+
+    - name: Find all markdown files in the garden
+      ansible.builtin.find:
+        paths: "{{ garden_path }}"
+        patterns: "*.md"
+        recurse: yes
+      register: md_files_result
+
+    - name: Get current timestamp for staleness calculation
+      ansible.builtin.command: date +%s
+      register: current_timestamp_result
+      changed_when: false
+
+    - name: Set current timestamp fact
+      ansible.builtin.set_fact:
+        current_timestamp: "{{ current_timestamp_result.stdout | int }}"
+
+    - name: Process each markdown file to get content and initial status
+      ansible.builtin.set_fact:
+        processed_files: "{{ processed_files | default([]) + [
+          {
+            'path': item.path,
+            'filename': item.path | basename,
+            'basename_no_ext': item.path | basename | splitext | first,
+            'mtime': item.mtime,
+            'content': (item.path | ansible.builtin.slurp | b64decode).decode('utf-8', errors='ignore'),
+            'is_stale': ((current_timestamp - item.mtime) > (stale_threshold_days * 24 * 3600)),
+            'is_linked': false # Placeholder, will be updated
+          }
+        ] }}"
+      loop: "{{ md_files_result.files }}"
+      loop_control:
+        label: "{{ item.path }}"
+
+    - name: Determine linked status for each file
+      ansible.builtin.set_fact:
+        processed_files: >
+          {% set updated_files = [] %}
+          {% for file_data in processed_files %}
+            {% set is_linked = false %}
+            {% for other_file_data in processed_files %}
+              {% if file_data.basename_no_ext != other_file_data.basename_no_ext %}
+                {% if other_file_data.content is search('\\b' + file_data.basename_no_ext + '\\b') %}
+                  {% set is_linked = true %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+            {% set _ = updated_files.append(file_data | combine({'is_linked': is_linked})) %}
+          {% endfor %}
+          {{ updated_files }}
+
+    - name: Identify files for quarantine (stale AND unlinked)
+      ansible.builtin.set_fact:
+        quarantine_candidates: "{{ processed_files | selectattr('is_stale', 'equalto', true) | selectattr('is_linked', 'equalto', false) | list }}"
+
+    - name: Generate weeder report
+      ansible.builtin.template:
+        src: templates/weeder_report.j2
+        dest: "{{ quarantine_path }}/weeder_report_{{ ansible_date_time.iso8601_basic }}.txt"
+      vars:
+        stale_files: "{{ processed_files | selectattr('is_stale', 'equalto', true) | list }}"
+        unlinked_files: "{{ processed_files | selectattr('is_linked', 'equalto', false) | list }}"
+        quarantine_files: "{{ quarantine_candidates }}"
+
+    - name: Move identified files to quarantine (if enabled)
+      ansible.builtin.command: mv "{{ item.path }}" "{{ quarantine_path }}/{{ item.filename }}"
+      loop: "{{ quarantine_candidates }}"
+      when: perform_quarantine
+      loop_control:
+        label: "Moving {{ item.filename }}"

--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/tests/test_weeder.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/tests/test_weeder.yml
@@ -1,0 +1,176 @@
+---
+- name: Test Digital Garden Weeder
+  hosts: localhost
+  connection: local
+  gather_facts: no
+
+  vars:
+    test_garden_path: "/tmp/test_garden_weeder_garden"
+    test_quarantine_path: "/tmp/test_garden_weeder_quarantine"
+    test_stale_threshold_days: 1 # Make files stale quickly for testing
+
+  tasks:
+    - name: Clean up previous test runs
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ test_garden_path }}"
+        - "{{ test_quarantine_path }}"
+
+    - name: Create test garden directory
+      ansible.builtin.file:
+        path: "{{ test_garden_path }}"
+        state: directory
+        mode: '0755'
+
+    - name: Create test quarantine directory
+      ansible.builtin.file:
+        path: "{{ test_quarantine_path }}"
+        state: directory
+        mode: '0755'
+
+    # Mock rationale: We create files with specific content and mtimes to simulate different scenarios.
+    # This makes the test deterministic and independent of the actual system clock or external file changes.
+
+    - name: Create a fresh, linked note
+      ansible.builtin.copy:
+        dest: "{{ test_garden_path }}/fresh_linked_note.md"
+        content: |
+          # Fresh Linked Note
+          This note is fresh and links to stale_unlinked_note.
+          It also mentions another_fresh_note.
+        mode: '0644'
+    - name: Set mtime for fresh_linked_note
+      ansible.builtin.command: touch -m "{{ ansible_date_time.iso8601_basic | ansible.builtin.strftime('%Y%m%d%H%M.%S') }}" "{{ test_garden_path }}/fresh_linked_note.md"
+      changed_when: false
+
+    - name: Create another fresh, linked note
+      ansible.builtin.copy:
+        dest: "{{ test_garden_path }}/another_fresh_note.md"
+        content: |
+          # Another Fresh Note
+          This note is also fresh and links to fresh_linked_note.
+        mode: '0644'
+    - name: Set mtime for another_fresh_note
+      ansible.builtin.command: touch -m "{{ ansible_date_time.iso8601_basic | ansible.builtin.strftime('%Y%m%d%H%M.%S') }}" "{{ test_garden_path }}/another_fresh_note.md"
+      changed_when: false
+
+    - name: Create a stale, linked note
+      ansible.builtin.copy:
+        dest: "{{ test_garden_path }}/stale_linked_note.md"
+        content: |
+          # Stale Linked Note
+          This note is stale but linked by fresh_linked_note.
+        mode: '0644'
+    - name: Set mtime for stale_linked_note (past date)
+      ansible.builtin.command: touch -m "{{ (ansible_date_time.epoch | int - (test_stale_threshold_days + 1) * 24 * 3600) | ansible.builtin.strftime('%Y%m%d%H%M.%S') }}" "{{ test_garden_path }}/stale_linked_note.md"
+      changed_when: false
+
+    - name: Create a stale, unlinked note (quarantine candidate)
+      ansible.builtin.copy:
+        dest: "{{ test_garden_path }}/stale_unlinked_note.md"
+        content: |
+          # Stale Unlinked Note
+          This note is stale and not linked by anything.
+        mode: '0644'
+    - name: Set mtime for stale_unlinked_note (past date)
+      ansible.builtin.command: touch -m "{{ (ansible_date_time.epoch | int - (test_stale_threshold_days + 1) * 24 * 3600) | ansible.builtin.strftime('%Y%m%d%H%M.%S') }}" "{{ test_garden_path }}/stale_unlinked_note.md"
+      changed_when: false
+
+    - name: Create a fresh, unlinked note
+      ansible.builtin.copy:
+        dest: "{{ test_garden_path }}/fresh_unlinked_note.md"
+        content: |
+          # Fresh Unlinked Note
+          This note is fresh but not linked by anything.
+        mode: '0644'
+    - name: Set mtime for fresh_unlinked_note
+      ansible.builtin.command: touch -m "{{ ansible_date_time.iso8601_basic | ansible.builtin.strftime('%Y%m%d%H%M.%S') }}" "{{ test_garden_path }}/fresh_unlinked_note.md"
+      changed_when: false
+
+    - name: Run the weeder playbook in check mode (no quarantine)
+      ansible.builtin.include_tasks: src/weeder.yml
+      vars:
+        garden_path: "{{ test_garden_path }}"
+        quarantine_path: "{{ test_quarantine_path }}"
+        stale_threshold_days: "{{ test_stale_threshold_days }}"
+        perform_quarantine: false
+
+    - name: Get current date for report filename matching
+      ansible.builtin.command: date +%Y%m%d
+      register: current_date_result
+      changed_when: false
+
+    - name: Assert report file exists
+      ansible.builtin.stat:
+        path: "{{ test_quarantine_path }}/weeder_report_{{ current_date_result.stdout }}*.txt"
+      register: report_stat
+    - ansible.builtin.assert:
+        that:
+          - report_stat.stat.exists
+        fail_msg: "Report file was not generated."
+
+    - name: Read the generated report
+      ansible.builtin.slurp:
+        src: "{{ report_stat.stat.path }}"
+      register: report_content_b64
+
+    - name: Decode report content
+      ansible.builtin.set_fact:
+        report_content: "{{ report_content_b64.content | b64decode | decode('utf-8') }}"
+
+    - name: Assert report content for stale and unlinked files (check mode)
+      ansible.builtin.assert:
+        that:
+          - "'stale_linked_note.md' in report_content"
+          - "'stale_unlinked_note.md' in report_content"
+          - "'fresh_linked_note.md' not in report_content"
+          - "'another_fresh_note.md' not in report_content"
+          - "'fresh_unlinked_note.md' in report_content" # Fresh but unlinked
+          - "'stale_unlinked_note.md' in report_content and 'Quarantine Candidates' in report_content"
+          - "'Quarantine is disabled. No files were moved.' in report_content"
+        fail_msg: "Report content is incorrect in check mode."
+
+    - name: Assert no files were moved in check mode
+      ansible.builtin.stat:
+        path: "{{ test_garden_path }}/stale_unlinked_note.md"
+      register: original_file_stat
+    - ansible.builtin.assert:
+        that:
+          - original_file_stat.stat.exists
+        fail_msg: "File was moved when quarantine was disabled."
+
+    - name: Run the weeder playbook in normal mode (with quarantine)
+      ansible.builtin.include_tasks: src/weeder.yml
+      vars:
+        garden_path: "{{ test_garden_path }}"
+        quarantine_path: "{{ test_quarantine_path }}"
+        stale_threshold_days: "{{ test_stale_threshold_days }}"
+        perform_quarantine: true
+
+    - name: Assert stale_unlinked_note.md was moved
+      ansible.builtin.stat:
+        path: "{{ test_garden_path }}/stale_unlinked_note.md"
+      register: moved_from_garden_stat
+    - ansible.builtin.assert:
+        that:
+          - not moved_from_garden_stat.stat.exists
+        fail_msg: "stale_unlinked_note.md was not moved from garden."
+
+    - name: Assert stale_unlinked_note.md is in quarantine
+      ansible.builtin.stat:
+        path: "{{ test_quarantine_path }}/stale_unlinked_note.md"
+      register: moved_to_quarantine_stat
+    - ansible.builtin.assert:
+        that:
+          - moved_to_quarantine_stat.stat.exists
+        fail_msg: "stale_unlinked_note.md was not moved to quarantine."
+
+    - name: Clean up test directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ test_garden_path }}"
+        - "{{ test_quarantine_path }}"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-digital-garden-weeder
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-digital-garden-weede-2`
- **Files Created**: 6
- **Description**: An Ansible playbook to help maintain a digital garden or knowledge base by identifying and suggesting actions for stale or unlinked notes.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-digital-garden-weede-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-digital-garden-weede-2/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-digital-garden-weede-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.