### PR TITLE
feat(groq): CLI tool that encodes input into Base64 and renders it as colorful ANSI block art.

### DIFF
--- a/go-utils/nightly-nightly-base64-art/README.md
+++ b/go-utils/nightly-nightly-base64-art/README.md
@@ -1,0 +1,25 @@
+# nightly-base64-art
+
+A whimsical command‑line utility that takes a string, encodes it in Base64 and displays each character as a colored block in the terminal. Useful for quick visual checks or adding a splash of color to logs.
+
+## Installation
+
+```sh
+go build -o nightly-base64-art ./src
+```
+
+## Usage
+
+```sh
+echo "Hello, world!" | nightly-base64-art
+# or
+nightly-base64-art "some text"
+```
+
+## How it works
+
+Each Base64 character is mapped to one of 64 ANSI colors. The program prints a full‑block character (`█`) with the corresponding foreground color.
+
+## License
+
+MIT

--- a/go-utils/nightly-nightly-base64-art/go.mod
+++ b/go-utils/nightly-nightly-base64-art/go.mod
@@ -1,0 +1,3 @@
+module nightly-base64-art
+
+go 1.20

--- a/go-utils/nightly-nightly-base64-art/src/main.go
+++ b/go-utils/nightly-nightly-base64-art/src/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+    "encoding/base64"
+    "fmt"
+    "os"
+)
+
+var colorMap = []int{
+    31, 32, 33, 34, 35, 36, 91, 92,
+    93, 94, 95, 96, 101, 102, 103, 104,
+    105, 106, 111, 112, 113, 114, 115, 116,
+    117, 118, 121, 122, 123, 124, 125, 126,
+    131, 132, 133, 134, 135, 136, 141, 142,
+    143, 144, 145, 146, 147, 148, 151, 152,
+    153, 154, 155, 156, 157, 158, 161, 162,
+    163, 164, 165, 166, 167, 168, 171, 172,
+}
+
+const base64Charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+func indexInBase64(c byte) int {
+    for i := 0; i < len(base64Charset); i++ {
+        if base64Charset[i] == c {
+            return i
+        }
+    }
+    return -1 // not a Base64 character (e.g., padding '=')
+}
+
+func colorForChar(c byte) int {
+    idx := indexInBase64(c)
+    if idx == -1 || idx >= len(colorMap) {
+        return 37 // default white for padding or unknown chars
+    }
+    return colorMap[idx]
+}
+
+func main() {
+    var input string
+    if len(os.Args) > 1 {
+        input = os.Args[1]
+    } else {
+        data, err := os.ReadFile("/dev/stdin")
+        if err != nil {
+            fmt.Fprintln(os.Stderr, "failed to read stdin")
+            os.Exit(1)
+        }
+        input = string(data)
+    }
+
+    encoded := base64.StdEncoding.EncodeToString([]byte(input))
+    for i := 0; i < len(encoded); i++ {
+        c := encoded[i]
+        color := colorForChar(c)
+        fmt.Printf("\x1b[%dm█\x1b[0m", color)
+    }
+    fmt.Println()
+}

--- a/go-utils/nightly-nightly-base64-art/tests/main_test.go
+++ b/go-utils/nightly-nightly-base64-art/tests/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestIndexInBase64(t *testing.T) {
+    if idx := indexInBase64('A'); idx != 0 {
+        t.Fatalf("expected 0, got %d", idx)
+    }
+    if idx := indexInBase64('a'); idx != 26 {
+        t.Fatalf("expected 26, got %d", idx)
+    }
+    if idx := indexInBase64('+'); idx != 62 {
+        t.Fatalf("expected 62, got %d", idx)
+    }
+    if idx := indexInBase64('/'); idx != 63 {
+        t.Fatalf("expected 63, got %d", idx)
+    }
+    if idx := indexInBase64('='); idx != -1 {
+        t.Fatalf("expected -1 for padding, got %d", idx)
+    }
+}
+
+func TestColorForChar(t *testing.T) {
+    // 'A' maps to index 0 -> colorMap[0] = 31
+    if c := colorForChar('A'); c != 31 {
+        t.Fatalf("expected color 31, got %d", c)
+    }
+    // padding character should default to white (37)
+    if c := colorForChar('='); c != 37 {
+        t.Fatalf("expected default color 37, got %d", c)
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-base64-art
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-base64-art`
- **Files Created**: 4
- **Description**: CLI tool that encodes input into Base64 and renders it as colorful ANSI block art.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-base64-art`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-base64-art/README.md`
- Run tests located in `go-utils/nightly-nightly-base64-art/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.