### PR TITLE
feat(gemini): Provisions an AWS S3 bucket configured to temporarily store community whispers and echoes, with automatic cleanup.

### DIFF
--- a/terraform-modules/nightly-nightly-temporal-echo-chambe-3/README.md
+++ b/terraform-modules/nightly-nightly-temporal-echo-chambe-3/README.md
@@ -1,0 +1,55 @@
+# Nightly Temporal Echo Chamber
+
+This Terraform module provisions an AWS S3 bucket designed to serve as a temporary "echo chamber" for community messages, logs, or ephemeral data. It's configured with a lifecycle rule to automatically expire objects after a specified number of days, ensuring that echoes fade gracefully into the digital void.
+
+While the bucket's public access block is configured to *allow* public access (should you choose to apply a bucket policy for it), it does not inherently make the bucket or its contents public. It merely sets the stage for an open "echo chamber" if desired.
+
+## Usage
+
+To deploy your own Temporal Echo Chamber, include this module in your Terraform configuration:
+
+```terraform
+module "echo_chamber" {
+  source = "./nightly-temporal-echo-chamber" # Adjust path if used as a local module
+  # For a remote module, use:
+  # source = "polsala/ApocalypsAI//terraform-modules/nightly-temporal-echo-chamber"
+
+  bucket_name_prefix = "apocalypsai-echo-chamber"
+  retention_days     = 7
+  environment        = "community-dev"
+}
+
+output "echo_chamber_bucket_id" {
+  value = module.echo_chamber.bucket_id
+}
+
+output "echo_chamber_bucket_arn" {
+  value = module.echo_chamber.bucket_arn
+}
+
+output "echo_chamber_bucket_regional_domain_name" {
+  value = module.echo_chamber.bucket_regional_domain_name
+}
+```
+
+Run `terraform init`, `terraform plan`, and `terraform apply` to provision the bucket.
+
+## Inputs
+
+| Name                 | Description                                                               | Type   | Default       | Required |
+|----------------------|---------------------------------------------------------------------------|--------|---------------|----------|
+| `bucket_name_prefix` | A unique prefix for the S3 bucket name. A random suffix will be added.    | `string` | `null`        | yes      |
+| `retention_days`     | Number of days after which objects in the bucket will be automatically expired. | `number` | `7`           | no       |
+| `environment`        | Environment tag for the bucket.                                           | `string` | `"development"` | no       |
+
+## Outputs
+
+| Name                               | Description                               |
+|------------------------------------|-------------------------------------------|
+| `bucket_id`                        | The ID of the S3 bucket.                  |
+| `bucket_arn`                       | The ARN of the S3 bucket.                 |
+| `bucket_regional_domain_name`      | The regional domain name of the S3 bucket.|
+
+## Testing
+
+The module includes a `tests/` directory with a `main.tf` that calls the module and a `test.sh` script. The `test.sh` script performs an offline `terraform plan` and asserts expected configurations using `terraform show -json` and `jq`. This ensures the module's syntax and planned resource attributes are correct without requiring AWS credentials or actual resource deployment.

--- a/terraform-modules/nightly-nightly-temporal-echo-chambe-3/src/main.tf
+++ b/terraform-modules/nightly-nightly-temporal-echo-chambe-3/src/main.tf
@@ -1,0 +1,42 @@
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+  numeric = true
+}
+
+resource "aws_s3_bucket" "echo_chamber" {
+  bucket = "${var.bucket_name_prefix}-${random_string.suffix.result}"
+
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "ApocalypsAI-Integrator"
+    Utility     = "TemporalEchoChamber"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "echo_chamber_pab" {
+  bucket = aws_s3_bucket.echo_chamber.id
+
+  # Whimsical rationale: This module is designed for an "echo chamber"
+  # where public access might be desired. These settings allow public
+  # access to be granted via bucket policies, rather than blocking it
+  # outright. Users should be aware of the implications.
+  block_public_acls       = false
+  ignore_public_acls      = false
+  block_public_policy     = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "echo_chamber_lifecycle" {
+  bucket = aws_s3_bucket.echo_chamber.id
+
+  rule {
+    id     = "expire-old-echoes"
+    status = "Enabled"
+
+    expiration {
+      days = var.retention_days
+    }
+  }
+}

--- a/terraform-modules/nightly-nightly-temporal-echo-chambe-3/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-temporal-echo-chambe-3/src/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_id" {
+  description = "The ID of the S3 bucket."
+  value       = aws_s3_bucket.echo_chamber.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the S3 bucket."
+  value       = aws_s3_bucket.echo_chamber.arn
+}
+
+output "bucket_regional_domain_name" {
+  description = "The regional domain name of the S3 bucket."
+  value       = aws_s3_bucket.echo_chamber.bucket_regional_domain_name
+}

--- a/terraform-modules/nightly-nightly-temporal-echo-chambe-3/src/variables.tf
+++ b/terraform-modules/nightly-nightly-temporal-echo-chambe-3/src/variables.tf
@@ -1,0 +1,16 @@
+variable "bucket_name_prefix" {
+  description = "A unique prefix for the S3 bucket name. A random suffix will be added."
+  type        = string
+}
+
+variable "retention_days" {
+  description = "Number of days after which objects in the bucket will be automatically expired."
+  type        = number
+  default     = 7
+}
+
+variable "environment" {
+  description = "Environment tag for the bucket."
+  type        = string
+  default     = "development"
+}

--- a/terraform-modules/nightly-nightly-temporal-echo-chambe-3/tests/main.tf
+++ b/terraform-modules/nightly-nightly-temporal-echo-chambe-3/tests/main.tf
@@ -1,0 +1,30 @@
+# Mock rationale: This configuration is for testing the module's plan output
+# without requiring actual AWS credentials or resource provisioning.
+# The random_string resource ensures a unique bucket name for plan validation.
+
+resource "random_string" "test_suffix" {
+  length  = 8
+  special = false
+  upper   = false
+  numeric = true
+}
+
+module "test_echo_chamber" {
+  source = "../src" # Path to the module being tested
+
+  bucket_name_prefix = "test-echo-chamber-${random_string.test_suffix.result}"
+  retention_days     = 14
+  environment        = "test"
+}
+
+output "test_bucket_id" {
+  value = module.test_echo_chamber.bucket_id
+}
+
+output "test_bucket_arn" {
+  value = module.test_echo_chamber.bucket_arn
+}
+
+output "test_bucket_regional_domain_name" {
+  value = module.test_echo_chamber.bucket_regional_domain_name
+}

--- a/terraform-modules/nightly-nightly-temporal-echo-chambe-3/tests/test.sh
+++ b/terraform-modules/nightly-nightly-temporal-echo-chambe-3/tests/test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+# Mock rationale: This test script performs an offline 'terraform plan'
+# and inspects its JSON output. It does not interact with AWS APIs,
+# ensuring determinism and independence from cloud credentials.
+# 'jq' is used to parse the JSON plan for assertions.
+
+echo "--- Running Terraform module tests ---"
+
+# Initialize Terraform in the test directory
+echo "Initializing Terraform..."
+terraform -chdir=tests init -backend=false > /dev/null
+
+# Generate a plan file
+echo "Generating Terraform plan..."
+terraform -chdir=tests plan -out=tests/tfplan -no-color > /dev/null
+
+# Convert the plan to JSON for inspection
+echo "Converting plan to JSON..."
+terraform -chdir=tests show -json tests/tfplan > tests/tfplan.json
+
+# Assertions using jq
+echo "Performing assertions..."
+
+# 1. Check if aws_s3_bucket resource is planned
+if ! jq -e '.resource_changes[] | select(.type == "aws_s3_bucket" and .change.actions[] == "create")' tests/tfplan.json > /dev/null; then
+  echo "Test Failed: aws_s3_bucket resource not found in plan."
+  exit 1
+fi
+echo "  ✓ aws_s3_bucket resource found."
+
+# 2. Check if aws_s3_bucket_public_access_block is planned and configured
+if ! jq -e '.resource_changes[] | select(.type == "aws_s3_bucket_public_access_block" and .change.actions[] == "create") | .change.after | select(.block_public_acls == false and .ignore_public_acls == false and .block_public_policy == false and .restrict_public_buckets == false)' tests/tfplan.json > /dev/null; then
+  echo "Test Failed: aws_s3_bucket_public_access_block not configured as expected (allowing public access)."
+  exit 1
+fi
+echo "  ✓ aws_s3_bucket_public_access_block configured to allow public access."
+
+# 3. Check if aws_s3_bucket_lifecycle_configuration is planned and has an expiration rule
+if ! jq -e '.resource_changes[] | select(.type == "aws_s3_bucket_lifecycle_configuration" and .change.actions[] == "create") | .change.after.rule[] | select(.id == "expire-old-echoes" and .status == "Enabled" and .expiration.days == 14)' tests/tfplan.json > /dev/null; then
+  echo "Test Failed: aws_s3_bucket_lifecycle_configuration with 'expire-old-echoes' rule and 14 days not found."
+  exit 1
+fi
+echo "  ✓ aws_s3_bucket_lifecycle_configuration with expiration rule found."
+
+# 4. Check for expected outputs
+if ! jq -e '.outputs.test_bucket_id.value' tests/tfplan.json > /dev/null; then
+  echo "Test Failed: Output 'test_bucket_id' not found."
+  exit 1
+fi
+if ! jq -e '.outputs.test_bucket_arn.value' tests/tfplan.json > /dev/null; then
+  echo "Test Failed: Output 'test_bucket_arn' not found."
+  exit 1
+}
+if ! jq -e '.outputs.test_bucket_regional_domain_name.value' tests/tfplan.json > /dev/null; then
+  echo "Test Failed: Output 'test_bucket_regional_domain_name' not found."
+  exit 1
+fi
+echo "  ✓ All expected outputs found."
+
+echo "--- All Terraform module tests passed! ---"
+
+# Clean up generated files
+rm tests/tfplan tests/tfplan.json


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-temporal-echo-chamber
- **Provider**: gemini
- **Location**: `terraform-modules/nightly-nightly-temporal-echo-chambe-3`
- **Files Created**: 6
- **Description**: Provisions an AWS S3 bucket configured to temporarily store community whispers and echoes, with automatic cleanup.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-temporal-echo-chambe-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-temporal-echo-chambe-3/README.md`
- Run tests located in `terraform-modules/nightly-nightly-temporal-echo-chambe-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.