### PR TITLE
feat(groq): A whimsical Rust CLI that estimates barter prices for post‑apocalyptic items using deterministic modifiers.

### DIFF
--- a/rust-utils/nightly-nightly-barter-price-estimat/README.md
+++ b/rust-utils/nightly-nightly-barter-price-estimat/README.md
@@ -1,0 +1,37 @@
+# Nightly Barter Price Estimator
+
+A tiny Rust command‑line utility that gives you a deterministic "barter price" (in caps) for common post‑apocalypse items.  The price is calculated from a hard‑coded base value plus a deterministic modifier derived from the item name, so the same input always yields the same output – perfect for offline testing and fun role‑playing.
+
+## Build
+```bash
+# Requires Rust toolchain (rustc, cargo)
+cargo build --release
+```
+
+The binary will be placed at `target/release/nightly-barter-price-estimator`.
+
+## Usage
+```bash
+nightly-barter-price-estimator <item-name>
+```
+Example:
+```bash
+$ nightly-barter-price-estimator water
+Estimated barter price for 'water' is 12 caps
+```
+
+### Known items
+- `water`
+- `canned-food`
+- `medicine`
+- `ammo`
+- `fuel`
+- `scrap-metal`
+
+If an unknown item is supplied, the program exits with an error and lists the known items.
+
+## Testing
+```bash
+cargo test
+```
+All tests are deterministic and run offline.

--- a/rust-utils/nightly-nightly-barter-price-estimat/src/main.rs
+++ b/rust-utils/nightly-nightly-barter-price-estimat/src/main.rs
@@ -1,0 +1,41 @@
+use std::collections::HashMap;
+use std::env;
+
+fn base_prices() -> HashMap<&'static str, u32> {
+    let mut m = HashMap::new();
+    m.insert("water", 10);
+    m.insert("canned-food", 15);
+    m.insert("medicine", 30);
+    m.insert("ammo", 25);
+    m.insert("fuel", 20);
+    m.insert("scrap-metal", 5);
+    m
+}
+
+/// Deterministic modifier based on the sum of the UTF‑8 bytes of the item name.
+/// The sum modulo 5 yields a value in 0..4, which translates to a 0‑40% increase.
+fn price_for(item: &str) -> Option<u32> {
+    let base = base_prices().get(item)?;
+    let sum: u32 = item.bytes().map(|b| b as u32).sum();
+    let modifier = 1.0 + (sum % 5) as f64 * 0.1; // 1.0, 1.1, …, 1.4
+    Some((*base as f64 * modifier).round() as u32)
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: {} <item-name>", args[0]);
+        std::process::exit(1);
+    }
+    let item = args[1].as_str();
+    match price_for(item) {
+        Some(p) => println!("Estimated barter price for '{}' is {} caps", item, p),
+        None => {
+            eprintln!(
+                "Unknown item '{}'. Known items: water, canned-food, medicine, ammo, fuel, scrap-metal",
+                item
+            );
+            std::process::exit(1);
+        }
+    }
+}

--- a/rust-utils/nightly-nightly-barter-price-estimat/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-barter-price-estimat/tests/test_main.rs
@@ -1,0 +1,20 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_known_items() {
+        // Expected values are pre‑computed using the same algorithm as price_for.
+        assert_eq!(price_for("water"), Some(12)); // (10 * 1.2)
+        assert_eq!(price_for("canned-food"), Some(17)); // (15 * 1.1)
+        assert_eq!(price_for("medicine"), Some(30)); // (30 * 1.0)
+        assert_eq!(price_for("ammo"), Some(28)); // (25 * 1.1)
+        assert_eq!(price_for("fuel"), Some(26)); // (20 * 1.3)
+        assert_eq!(price_for("scrap-metal"), Some(7)); // (5 * 1.3)
+    }
+
+    #[test]
+    fn test_unknown_item() {
+        assert_eq!(price_for("gold"), None);
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-barter-price-estimator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-barter-price-estimat`
- **Files Created**: 3
- **Description**: A whimsical Rust CLI that estimates barter prices for post‑apocalyptic items using deterministic modifiers.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-barter-price-estimat`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-barter-price-estimat/README.md`
- Run tests located in `rust-utils/nightly-nightly-barter-price-estimat/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.