### PR TITLE
feat(groq): Deterministic CLI that reports a whimsical radiation level for any location.

### DIFF
--- a/go-utils/nightly-nightly-radiation-meter/README.md
+++ b/go-utils/nightly-nightly-radiation-meter/README.md
@@ -1,0 +1,26 @@
+# Nightly Radiation Meter
+
+A whimsical CLI tool that reports a deterministic "radiation level" for any given location. Useful for post‑apocalyptic role‑playing games or just for fun.
+
+## Installation
+
+```sh
+go build -o radiation-meter ./src
+```
+
+## Usage
+
+```sh
+./radiation-meter "Chernobyl"
+# Output: Radiation level at Chernobyl: 433 mSv
+```
+
+## How it works
+
+The tool sums the Unicode code points of the input string (case‑sensitive) and takes the result modulo 501 to produce a value between 0 and 500 mSv.
+
+## Testing
+
+```sh
+go test ./...
+```

--- a/go-utils/nightly-nightly-radiation-meter/go.mod
+++ b/go-utils/nightly-nightly-radiation-meter/go.mod
@@ -1,0 +1,3 @@
+module nightly-radiation-meter
+
+go 1.21

--- a/go-utils/nightly-nightly-radiation-meter/src/main.go
+++ b/go-utils/nightly-nightly-radiation-meter/src/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+    "fmt"
+    "os"
+    "strings"
+)
+
+func radiationLevel(loc string) int {
+    sum := 0
+    for _, r := range loc {
+        sum += int(r)
+    }
+    return sum % 501
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("Usage: radiation-meter <location>")
+        os.Exit(1)
+    }
+    location := strings.Join(os.Args[1:], " ")
+    level := radiationLevel(location)
+    fmt.Printf("Radiation level at %s: %d mSv\n", location, level)
+}

--- a/go-utils/nightly-nightly-radiation-meter/tests/main_test.go
+++ b/go-utils/nightly-nightly-radiation-meter/tests/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+func TestRadiationLevel(t *testing.T) {
+    cases := []struct {
+        loc      string
+        expected int
+    }{
+        {"Chernobyl", 433},
+        {"Safe Haven", 412},
+        {"", 0},
+    }
+    for _, c := range cases {
+        got := radiationLevel(c.loc)
+        if got != c.expected {
+            t.Fatalf("radiationLevel(%q) = %d; want %d", c.loc, got, c.expected)
+        }
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-radiation-meter
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-radiation-meter`
- **Files Created**: 4
- **Description**: Deterministic CLI that reports a whimsical radiation level for any location.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-radiation-meter`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-radiation-meter/README.md`
- Run tests located in `go-utils/nightly-nightly-radiation-meter/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.