### PR TITLE
feat(groq): CLI tool to log your mood with an emoji and view simple statistics.

### DIFF
--- a/node-utils/nightly-nightly-emoji-mood-tracker-5/README.md
+++ b/node-utils/nightly-nightly-emoji-mood-tracker-5/README.md
@@ -1,0 +1,29 @@
+# nightly-emoji-mood-tracker
+
+A whimsical CLI utility to log your daily mood with an emoji and view simple statistics.
+
+## Installation
+
+```sh
+npm install -g .
+```
+
+## Usage
+
+Add a mood:
+
+```sh
+node src/index.js add happy
+```
+
+Show stats:
+
+```sh
+node src/index.js stats
+```
+
+Supported moods: happy, sad, angry, excited, neutral.
+
+## How it works
+
+Entries are stored in a JSON file in your home directory (`~/.emoji_mood_log.json`). Each entry contains a timestamp, the mood string, and its corresponding emoji.

--- a/node-utils/nightly-nightly-emoji-mood-tracker-5/src/index.js
+++ b/node-utils/nightly-nightly-emoji-mood-tracker-5/src/index.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const DEFAULT_FILE = path.join(os.homedir(), '.emoji_mood_log.json');
+
+const MOOD_EMOJI = {
+  happy: '😊',
+  sad: '😢',
+  angry: '😠',
+  excited: '🤩',
+  neutral: '😐'
+};
+
+function loadLog(filePath = DEFAULT_FILE) {
+  try {
+    const data = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(data);
+  } catch (e) {
+    return [];
+  }
+}
+
+function saveLog(log, filePath = DEFAULT_FILE) {
+  fs.writeFileSync(filePath, JSON.stringify(log, null, 2), 'utf8');
+}
+
+function addMood(mood, filePath = DEFAULT_FILE) {
+  if (!MOOD_EMOJI[mood]) {
+    throw new Error(`Unsupported mood: ${mood}`);
+  }
+  const log = loadLog(filePath);
+  const entry = {
+    timestamp: new Date().toISOString(),
+    mood,
+    emoji: MOOD_EMOJI[mood]
+  };
+  log.push(entry);
+  saveLog(log, filePath);
+  return entry;
+}
+
+function getStats(filePath = DEFAULT_FILE) {
+  const log = loadLog(filePath);
+  const stats = {};
+  for (const entry of log) {
+    stats[entry.mood] = (stats[entry.mood] || 0) + 1;
+  }
+  return stats;
+}
+
+// CLI handling
+if (require.main === module) {
+  const [,, cmd, arg] = process.argv;
+  if (cmd === 'add' && arg) {
+    try {
+      const entry = addMood(arg);
+      console.log(`Logged ${entry.mood} ${entry.emoji} at ${entry.timestamp}`);
+    } catch (e) {
+      console.error(e.message);
+      process.exit(1);
+    }
+  } else if (cmd === 'stats') {
+    const stats = getStats();
+    console.log('Mood statistics:');
+    for (const [mood, count] of Object.entries(stats)) {
+      console.log(`${mood} (${MOOD_EMOJI[mood] || ''}): ${count}`);
+    }
+  } else {
+    console.log('Usage: node src/index.js <add <mood>|stats>');
+    process.exit(1);
+  }
+}
+
+// Export for testing
+module.exports = { addMood, getStats, MOOD_EMOJI };

--- a/node-utils/nightly-nightly-emoji-mood-tracker-5/tests/test_index.js
+++ b/node-utils/nightly-nightly-emoji-mood-tracker-5/tests/test_index.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { addMood, getStats, MOOD_EMOJI } = require('../src/index');
+
+// Create a temporary directory for isolated storage
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mood-test-'));
+const tempFile = path.join(tempDir, 'log.json');
+
+// Test adding a supported mood
+addMood('happy', tempFile);
+let log = JSON.parse(fs.readFileSync(tempFile, 'utf8'));
+assert.strictEqual(log.length, 1);
+assert.strictEqual(log[0].mood, 'happy');
+assert.strictEqual(log[0].emoji, MOOD_EMOJI['happy']);
+
+// Test stats aggregation
+addMood('sad', tempFile);
+addMood('happy', tempFile);
+const stats = getStats(tempFile);
+assert.deepStrictEqual(stats, { happy: 2, sad: 1 });
+
+// Test unsupported mood throws
+let threw = false;
+try {
+  addMood('confused', tempFile);
+} catch (e) {
+  threw = true;
+}
+assert.strictEqual(threw, true);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-emoji-mood-tracker
- **Provider**: groq
- **Location**: `node-utils/nightly-nightly-emoji-mood-tracker-5`
- **Files Created**: 3
- **Description**: CLI tool to log your mood with an emoji and view simple statistics.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `node-utils/nightly-nightly-emoji-mood-tracker-5`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `node-utils/nightly-nightly-emoji-mood-tracker-5/README.md`
- Run tests located in `node-utils/nightly-nightly-emoji-mood-tracker-5/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.