### PR TITLE
feat(groq): An Ansible playbook that configures a persistent reverse SSH tunnel via a systemd service for remote access to machines behind NAT.

### DIFF
--- a/ansible-playbooks/nightly-nightly-ansible-ssh-tunnel-s/README.md
+++ b/ansible-playbooks/nightly-nightly-ansible-ssh-tunnel-s/README.md
@@ -1,0 +1,27 @@
+# Nightly Ansible SSH Tunnel Setup
+
+## Overview
+This playbook creates a systemd service that maintains a reverse SSH tunnel from the target host back to a central server, enabling remote access to machines behind NAT or firewalls.
+
+## Requirements
+- Ansible 2.9+
+- SSH key pair pre‑shared between target and central server
+- sudo privileges on target
+
+## Usage
+```bash
+ansible-playbook -i inventory.ini src/setup_tunnel.yml -e "remote_user=ubuntu tunnel_user=ssh_tunnel remote_host=central.example.com remote_port=2222"
+```
+
+## Variables
+- `tunnel_user` (default: `ssh_tunnel`) – user under which the service runs.
+- `remote_user` – user on the central server to connect as.
+- `remote_host` – hostname or IP of the central server.
+- `remote_port` (default: `2222`) – port on the central server to forward to.
+- `local_port` (default: `22`) – local port to expose.
+
+## How it works
+The playbook creates a systemd unit file `/etc/systemd/system/ssh-reverse-tunnel.service` that runs `ssh -N -R ${remote_port}:localhost:${local_port} ${remote_user}@${remote_host}` (via `autossh` for resilience) and ensures the service is enabled and started.
+
+## License
+MIT

--- a/ansible-playbooks/nightly-nightly-ansible-ssh-tunnel-s/src/setup_tunnel.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-ssh-tunnel-s/src/setup_tunnel.yml
@@ -1,0 +1,59 @@
+---
+- name: Configure reverse SSH tunnel service
+  hosts: all
+  become: true
+  vars:
+    tunnel_user: "{{ tunnel_user | default('ssh_tunnel') }}"
+    remote_user: "{{ remote_user | default('root') }}"
+    remote_host: "{{ remote_host }}"
+    remote_port: "{{ remote_port | default('2222') }}"
+    local_port: "{{ local_port | default('22') }}"
+    service_path: /etc/systemd/system/ssh-reverse-tunnel.service
+
+  tasks:
+    - name: Ensure tunnel user exists
+      user:
+        name: "{{ tunnel_user }}"
+        system: true
+        shell: /usr/sbin/nologin
+        create_home: false
+
+    - name: Install autossh package
+      package:
+        name: autossh
+        state: present
+
+    - name: Create systemd service file
+      copy:
+        dest: "{{ service_path }}"
+        owner: root
+        mode: '0644'
+        content: |
+          [Unit]
+          Description=Persistent reverse SSH tunnel
+          After=network.target
+
+          [Service]
+          User={{ tunnel_user }}
+          ExecStart=/usr/bin/autossh -M 0 -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -R {{ remote_port }}:localhost:{{ local_port }} {{ remote_user }}@{{ remote_host }}
+          Restart=always
+          RestartSec=10
+
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Reload systemd daemon
+      command: systemctl daemon-reload
+      notify: Restart tunnel service
+
+    - name: Enable and start tunnel service
+      systemd:
+        name: ssh-reverse-tunnel.service
+        enabled: true
+        state: started
+
+  handlers:
+    - name: Restart tunnel service
+      systemd:
+        name: ssh-reverse-tunnel.service
+        state: restarted

--- a/ansible-playbooks/nightly-nightly-ansible-ssh-tunnel-s/tests/test_setup_tunnel.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-ssh-tunnel-s/tests/test_setup_tunnel.yml
@@ -1,0 +1,18 @@
+---
+- name: Test reverse SSH tunnel playbook
+  hosts: localhost
+  gather_facts: false
+  vars:
+    remote_host: example.com
+    remote_user: testuser
+
+  tasks:
+    - name: Run the tunnel setup playbook in check mode
+      command: ansible-playbook -i localhost, ../../src/setup_tunnel.yml -e "remote_host={{ remote_host }} remote_user={{ remote_user }}" --check
+      register: result
+      # Mock rationale: simulate successful execution without real SSH connections
+
+    - name: Assert playbook ran without failures
+      assert:
+        that:
+          - result.rc == 0


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansible-ssh-tunnel-setup
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-ansible-ssh-tunnel-s`
- **Files Created**: 3
- **Description**: An Ansible playbook that configures a persistent reverse SSH tunnel via a systemd service for remote access to machines behind NAT.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-ansible-ssh-tunnel-s`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-ansible-ssh-tunnel-s/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-ansible-ssh-tunnel-s/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.