### PR TITLE
feat(groq): A whimsical Bash utility that safely rotates SSH host keys, backing up old keys and creating fresh placeholders.

### DIFF
--- a/bash-utils/nightly-nightly-ssh-key-rotator-5/README.md
+++ b/bash-utils/nightly-nightly-ssh-key-rotator-5/README.md
@@ -1,0 +1,46 @@
+# nightly-ssh-key-rotator
+
+**Purpose**: Quickly rotate SSH host keys on a server (or in a test directory) while preserving the old keys in a backup location.  This is handy for security drills, CI environments, or just for fun.
+
+## Features
+- Backs up existing `ssh_host_*` key files with a timestamp.
+- Creates new empty placeholder key files (you can replace the placeholder generation with `ssh-keygen` if desired).
+- Supports custom key directory and backup directory.
+- Dry‑run mode to see what would happen without touching the filesystem.
+
+## Installation
+```bash
+# Clone the repository (or copy the utility folder) and make the script executable
+chmod +x src/rotate_ssh_keys.sh
+```
+
+## Usage
+```bash
+# Rotate keys in the default /etc/ssh directory (requires sudo)
+sudo src/rotate_ssh_keys.sh
+
+# Rotate keys in a custom directory (useful for testing)
+src/rotate_ssh_keys.sh --key-dir /tmp/ssh_test --backup-dir /tmp/ssh_backup
+
+# Dry‑run – show actions without making changes
+src/rotate_ssh_keys.sh --dry-run
+```
+
+## Options
+- `--key-dir PATH`   : Directory containing the `ssh_host_*` key files (default: `/etc/ssh`).
+- `--backup-dir PATH`: Directory where old keys will be stored (default: `<key-dir>/backup`).
+- `--dry-run`        : Print actions without performing them.
+- `-h, --help`       : Show help message.
+
+## Testing
+Run the bundled test suite:
+```bash
+bash tests/test_rotate_ssh_keys.sh
+```
+The test creates a temporary key directory, runs the rotator, and verifies that:
+1. Old keys are moved to the backup location.
+2. New placeholder key files exist.
+3. No errors are reported.
+
+## License
+MIT © ApocalypsAI community

--- a/bash-utils/nightly-nightly-ssh-key-rotator-5/src/rotate_ssh_keys.sh
+++ b/bash-utils/nightly-nightly-ssh-key-rotator-5/src/rotate_ssh_keys.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# nightly-ssh-key-rotator
+# Rotates SSH host keys, backing up old ones and creating new placeholders.
+# ---------------------------------------------------------------
+
+set -euo pipefail
+
+# Default values
+KEY_DIR="/etc/ssh"
+BACKUP_DIR=""
+DRY_RUN=false
+
+print_help() {
+  cat <<'EOF'
+Usage: rotate_ssh_keys.sh [options]
+
+Options:
+  --key-dir PATH     Directory containing ssh_host_* key files (default: /etc/ssh)
+  --backup-dir PATH  Directory to store backups (default: <key-dir>/backup)
+  --dry-run          Show actions without making changes
+  -h, --help         Show this help message
+EOF
+}
+
+# Parse arguments
+while (( "$#" )); do
+  case "$1" in
+    --key-dir)
+      KEY_DIR="$2"; shift 2;;
+    --backup-dir)
+      BACKUP_DIR="$2"; shift 2;;
+    --dry-run)
+      DRY_RUN=true; shift;;
+    -h|--help)
+      print_help; exit 0;;
+    *)
+      echo "Error: Unknown argument: $1" >&2; print_help; exit 1;;
+  esac
+done
+
+# Validate key directory
+if [[ ! -d "$KEY_DIR" ]]; then
+  echo "Error: Key directory '$KEY_DIR' does not exist." >&2
+  exit 1
+fi
+
+# Determine backup directory if not supplied
+if [[ -z "$BACKUP_DIR" ]]; then
+  BACKUP_DIR="$KEY_DIR/backup"
+fi
+
+timestamp=$(date +"%Y%m%d%H%M%S")
+
+# Function to perform an action (or echo in dry‑run mode)
+run() {
+  if $DRY_RUN; then
+    echo "[dry‑run] $*"
+  else
+    eval "$@"
+  fi
+}
+
+# Ensure backup directory exists
+run "mkdir -p \"$BACKUP_DIR\""
+
+# List of typical host key files (private and public)
+key_files=(
+  ssh_host_rsa_key
+  ssh_host_rsa_key.pub
+  ssh_host_ecdsa_key
+  ssh_host_ecdsa_key.pub
+  ssh_host_ed25519_key
+  ssh_host_ed25519_key.pub
+)
+
+# Rotate each key if it exists
+for key in "${key_files[@]}"; do
+  src="$KEY_DIR/$key"
+  if [[ -e "$src" ]]; then
+    backup_name="${key}.${timestamp}.bak"
+    run "mv \"$src\" \"$BACKUP_DIR/$backup_name\""
+    # Create a new placeholder (empty) key file
+    run "touch \"$src\""
+    echo "Rotated $key -> $BACKUP_DIR/$backup_name (new placeholder created)"
+  else
+    echo "Skipping $key (not found)"
+  fi
+done
+
+# Optional: restart sshd (only if not dry‑run and running as root)
+if ! $DRY_RUN && [[ $EUID -eq 0 ]]; then
+  if command -v systemctl >/dev/null 2>&1; then
+    echo "Restarting sshd via systemctl..."
+    run "systemctl restart sshd"
+  elif command -v service >/dev/null 2>&1; then
+    echo "Restarting sshd via service..."
+    run "service ssh restart"
+  else
+    echo "Warning: Could not determine how to restart sshd. Please restart manually."
+  fi
+fi
+
+exit 0

--- a/bash-utils/nightly-nightly-ssh-key-rotator-5/tests/test_rotate_ssh_keys.sh
+++ b/bash-utils/nightly-nightly-ssh-key-rotator-5/tests/test_rotate_ssh_keys.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Test suite for nightly-ssh-key-rotator
+# ---------------------------------------------------------------
+
+set -euo pipefail
+
+# Helper: create a temporary directory and clean up on exit
+TMP_ROOT=$(mktemp -d)
+cleanup() { rm -rf "$TMP_ROOT"; }
+trap cleanup EXIT
+
+KEY_DIR="$TMP_ROOT/ssh_keys"
+BACKUP_DIR="$TMP_ROOT/backup"
+
+mkdir -p "$KEY_DIR"
+
+# Create dummy key files (content is irrelevant)
+for key in ssh_host_rsa_key ssh_host_rsa_key.pub ssh_host_ecdsa_key ssh_host_ecdsa_key.pub; do
+  echo "old-$key" > "$KEY_DIR/$key"
+done
+
+# Path to the script under test
+SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")/../src/rotate_ssh_keys.sh"
+
+# Run the rotator (non‑dry‑run) with custom directories
+bash "$SCRIPT_PATH" --key-dir "$KEY_DIR" --backup-dir "$BACKUP_DIR"
+
+# ---- Assertions ----
+# 1. Backup directory should exist and contain renamed files
+if [[ ! -d "$BACKUP_DIR" ]]; then
+  echo "FAIL: Backup directory was not created" >&2
+  exit 1
+fi
+
+backup_count=$(ls -1 "$BACKUP_DIR" | wc -l)
+if (( backup_count != 4 )); then
+  echo "FAIL: Expected 4 backup files, found $backup_count" >&2
+  exit 1
+fi
+
+# 2. New placeholder files should exist and be empty
+for key in ssh_host_rsa_key ssh_host_rsa_key.pub ssh_host_ecdsa_key ssh_host_ecdsa_key.pub; do
+  if [[ ! -f "$KEY_DIR/$key" ]]; then
+    echo "FAIL: New placeholder $key missing" >&2
+    exit 1
+  fi
+  if [[ -s "$KEY_DIR/$key" ]]; then
+    echo "FAIL: Placeholder $key is not empty" >&2
+    exit 1
+  fi
+done
+
+# 3. Files that were not present originally should be untouched (e.g., ed25519)
+if [[ -e "$KEY_DIR/ssh_host_ed25519_key" ]]; then
+  echo "FAIL: Unexpected ed25519 key file created" >&2
+  exit 1
+fi
+
+echo "All tests passed."
+exit 0


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ssh-key-rotator
- **Provider**: groq
- **Location**: `bash-utils/nightly-nightly-ssh-key-rotator-5`
- **Files Created**: 3
- **Description**: A whimsical Bash utility that safely rotates SSH host keys, backing up old keys and creating fresh placeholders.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `bash-utils/nightly-nightly-ssh-key-rotator-5`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `bash-utils/nightly-nightly-ssh-key-rotator-5/README.md`
- Run tests located in `bash-utils/nightly-nightly-ssh-key-rotator-5/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.