### PR TITLE
feat(groq): Schedules nightly apt upgrades via cron and adds a random motivational quote to the system MOTD.

### DIFF
--- a/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/ansible-playbooks/nightly-ansible-apt-upgrade-scheduler/README.md
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/ansible-playbooks/nightly-ansible-apt-upgrade-scheduler/README.md
@@ -1,0 +1,24 @@
+# Nightly Apt Upgrade Scheduler
+
+## Overview
+This Ansible playbook configures a nightly `apt` upgrade on Debian/Ubuntu systems and sprinkles a random motivational quote onto `/etc/motd` after each upgrade. It ensures the `unattended-upgrades` package is present, creates a cron job that runs at 02:00 AM, and updates the MOTD with a whimsical line.
+
+## Requirements
+- Ansible 2.9+ installed on the control machine
+- Sudo/root privileges on the target host (the playbook uses `become: true`)
+- Target hosts must be Debian‑based (apt package manager)
+
+## Usage
+```bash
+# From the repository root
+ansible-playbook -i ansible-playbooks/nightly-ansible-apt-upgrade-scheduler/src/inventory.ini \
+               ansible-playbooks/nightly-ansible-apt-upgrade-scheduler/src/apt_upgrade.yml
+```
+
+## Files
+- `src/apt_upgrade.yml` – The main playbook
+- `src/inventory.ini` – Simple inventory targeting the local machine
+- `tests/test_apt_upgrade.yml` – Automated test that validates the playbook syntax
+
+## License
+MIT – see the repository LICENSE file.

--- a/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/ansible-playbooks/nightly-ansible-apt-upgrade-scheduler/src/apt_upgrade.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/ansible-playbooks/nightly-ansible-apt-upgrade-scheduler/src/apt_upgrade.yml
@@ -1,0 +1,28 @@
+---
+- name: Configure nightly apt upgrades
+  hosts: all
+  become: true
+  vars:
+    quotes:
+      - "Rise and shine, packages!"
+      - "Another day, another upgrade."
+      - "Keep calm and let apt upgrade."
+  tasks:
+    - name: Ensure unattended-upgrades is installed
+      apt:
+        name: unattended-upgrades
+        state: present
+        update_cache: yes
+
+    - name: Create cron job for nightly upgrade
+      cron:
+        name: "Nightly apt upgrade"
+        minute: "0"
+        hour: "2"
+        job: "/usr/bin/apt-get update && /usr/bin/apt-get -y upgrade"
+
+    - name: Add motivational quote to MOTD
+      lineinfile:
+        path: /etc/motd
+        line: "{{ quotes | random }}"
+        create: yes

--- a/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/ansible-playbooks/nightly-ansible-apt-upgrade-scheduler/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/ansible-playbooks/nightly-ansible-apt-upgrade-scheduler/src/inventory.ini
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/ansible-playbooks/nightly-ansible-apt-upgrade-scheduler/tests/test_apt_upgrade.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/ansible-playbooks/nightly-ansible-apt-upgrade-scheduler/tests/test_apt_upgrade.yml
@@ -1,0 +1,17 @@
+---
+- name: Verify playbook syntax
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Run syntax check
+      command: ansible-playbook -i src/inventory.ini src/apt_upgrade.yml --syntax-check
+      args:
+        chdir: "{{ playbook_dir | dirname }}/.."
+      register: syntax_result
+      changed_when: false
+      failed_when: syntax_result.rc != 0
+
+    - name: Assert syntax succeeded
+      assert:
+        that:
+          - syntax_result.rc == 0


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansible-apt-upgrade-scheduler
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-ansible-apt-upgrade`
- **Files Created**: 4
- **Description**: Schedules nightly apt upgrades via cron and adds a random motivational quote to the system MOTD.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-ansible-apt-upgrade`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-ansible-apt-upgrade/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-ansible-apt-upgrade/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.