### PR TITLE
feat(groq): A whimsical CLI tool that estimates remaining battery life in hours based on capacity, draw, and efficiency.

### DIFF
--- a/rust-utils/nightly-nightly-battery-life-estimat/Cargo.toml
+++ b/rust-utils/nightly-nightly-battery-life-estimat/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "battery-life-estimator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-battery-life-estimat/README.md
+++ b/rust-utils/nightly-nightly-battery-life-estimat/README.md
@@ -1,0 +1,32 @@
+# Battery Life Estimator
+
+A whimsical CLI tool to estimate remaining battery life in hours based on current capacity, average draw, and an optional efficiency factor.
+
+## Build
+
+```sh
+cargo build --release
+```
+
+## Usage
+
+```sh
+battery-life-estimator <capacity_mAh> <draw_mA> [efficiency]
+```
+
+- `capacity_mAh`: current battery capacity in mAh.
+- `draw_mA`: average power draw in mA.
+- `efficiency` (optional): efficiency factor (0.0‑1.0), default **0.9**.
+
+### Example
+
+```sh
+$ battery-life-estimator 3000 500
+Estimated battery life: 5.40 hours
+```
+
+## Testing
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-battery-life-estimat/src/lib.rs
+++ b/rust-utils/nightly-nightly-battery-life-estimat/src/lib.rs
@@ -1,0 +1,13 @@
+/// Computes the estimated battery life in hours.
+///
+/// * `capacity` – current battery capacity in mAh.
+/// * `draw` – average power draw in mA.
+/// * `efficiency` – efficiency factor (0.0‑1.0). Typical default is 0.9.
+///
+/// Returns `f64::INFINITY` when `draw` is zero.
+pub fn compute_estimated_hours(capacity: f64, draw: f64, efficiency: f64) -> f64 {
+    if draw == 0.0 {
+        return f64::INFINITY;
+    }
+    capacity * efficiency / draw
+}

--- a/rust-utils/nightly-nightly-battery-life-estimat/src/main.rs
+++ b/rust-utils/nightly-nightly-battery-life-estimat/src/main.rs
@@ -1,0 +1,48 @@
+use std::env;
+use battery_life_estimator::compute_estimated_hours;
+
+fn print_usage() {
+    eprintln!("Usage: battery-life-estimator <capacity_mAh> <draw_mA> [efficiency]");
+    eprintln!("  capacity_mAh: current battery capacity in mAh");
+    eprintln!("  draw_mA: average power draw in mA");
+    eprintln!("  efficiency (optional): efficiency factor (0.0-1.0), default 0.9");
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 || args.len() > 4 {
+        print_usage();
+        std::process::exit(1);
+    }
+    let capacity: f64 = match args[1].parse() {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("Invalid capacity value");
+            std::process::exit(1);
+        }
+    };
+    let draw: f64 = match args[2].parse() {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("Invalid draw value");
+            std::process::exit(1);
+        }
+    };
+    let efficiency: f64 = if args.len() == 4 {
+        match args[3].parse() {
+            Ok(v) => v,
+            Err(_) => {
+                eprintln!("Invalid efficiency value");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        0.9
+    };
+    let hours = compute_estimated_hours(capacity, draw, efficiency);
+    if hours.is_infinite() {
+        println!("Estimated battery life: infinite (draw is zero)");
+    } else {
+        println!("Estimated battery life: {:.2} hours", hours);
+    }
+}

--- a/rust-utils/nightly-nightly-battery-life-estimat/tests/estimate.rs
+++ b/rust-utils/nightly-nightly-battery-life-estimat/tests/estimate.rs
@@ -1,0 +1,22 @@
+#[cfg(test)]
+mod tests {
+    use battery_life_estimator::compute_estimated_hours;
+
+    #[test]
+    fn typical_case() {
+        let hours = compute_estimated_hours(3000.0, 500.0, 0.9);
+        assert!((hours - 5.4).abs() < 1e-6);
+    }
+
+    #[test]
+    fn zero_draw() {
+        let hours = compute_estimated_hours(3000.0, 0.0, 0.9);
+        assert!(hours.is_infinite());
+    }
+
+    #[test]
+    fn custom_efficiency() {
+        let hours = compute_estimated_hours(2000.0, 400.0, 0.8);
+        assert!((hours - 4.0).abs() < 1e-6);
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-battery-life-estimator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-battery-life-estimat`
- **Files Created**: 5
- **Description**: A whimsical CLI tool that estimates remaining battery life in hours based on capacity, draw, and efficiency.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-battery-life-estimat`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-battery-life-estimat/README.md`
- Run tests located in `rust-utils/nightly-nightly-battery-life-estimat/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.