### PR TITLE
feat(groq): Estimates remaining radioactivity of a given isotope after a time period using built‑in half‑life data.

### DIFF
--- a/node-utils/nightly-nightly-radiation-decay-esti/README.md
+++ b/node-utils/nightly-nightly-radiation-decay-esti/README.md
@@ -1,0 +1,32 @@
+# Nightly Radiation Decay Estimator
+
+A whimsical CLI utility that estimates remaining radioactivity of a given isotope after a certain time, using built‑in half‑life data. Perfect for post‑apocalyptic scavengers who need to know if a glowing barrel is still dangerous.
+
+## Installation
+
+```sh
+npm install -g .
+```
+
+## Usage
+
+```sh
+node src/index.js <isotope> <initial_activity_Bq> <years_elapsed>
+```
+
+Example:
+
+```sh
+node src/index.js Cs-137 1000 30.17
+# => Remaining activity: 500.00 Bq
+```
+
+## Supported isotopes
+
+- I-131 (8 days)
+- Cs-137 (30.17 years)
+- U-235 (7.04e8 years)
+
+## License
+
+MIT

--- a/node-utils/nightly-nightly-radiation-decay-esti/src/index.js
+++ b/node-utils/nightly-nightly-radiation-decay-esti/src/index.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+const fs = require('fs');
+
+const halfLives = {
+  'I-131': 8 / 365, // days to years
+  'Cs-137': 30.17,
+  'U-235': 7.04e8,
+};
+
+function computeDecay(isotope, initialActivity, years) {
+  const hl = halfLives[isotope];
+  if (hl === undefined) {
+    throw new Error(`Unknown isotope: ${isotope}`);
+  }
+  const remaining = initialActivity * Math.pow(0.5, years / hl);
+  return remaining;
+}
+
+// CLI handling
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.length !== 3) {
+    console.error('Usage: node src/index.js <isotope> <initial_Bq> <years>');
+    process.exit(1);
+  }
+  const [iso, initStr, yearsStr] = args;
+  const init = parseFloat(initStr);
+  const years = parseFloat(yearsStr);
+  if (isNaN(init) || isNaN(years)) {
+    console.error('Initial activity and years must be numbers.');
+    process.exit(1);
+  }
+  try {
+    const remaining = computeDecay(iso, init, years);
+    console.log(`Remaining activity: ${remaining.toFixed(2)} Bq`);
+  } catch (e) {
+    console.error(e.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { computeDecay, halfLives };

--- a/node-utils/nightly-nightly-radiation-decay-esti/tests/test.js
+++ b/node-utils/nightly-nightly-radiation-decay-esti/tests/test.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+const { computeDecay, halfLives } = require('../src/index.js');
+
+// Helper for approximate equality
+function approxEqual(a, b, epsilon = 1e-6) {
+  return Math.abs(a - b) < epsilon;
+}
+
+// Test known half-life: Cs-137 should halve activity after its half‑life
+(function testCs137HalfLife() {
+  const result = computeDecay('Cs-137', 1000, halfLives['Cs-137']);
+  assert(approxEqual(result, 500), `Cs-137 half‑life test failed: ${result}`);
+})();
+
+// Test I-131 with its ~0.0219‑year half‑life
+(function testI131() {
+  const result = computeDecay('I-131', 200, 0.0219);
+  // After one half‑life, activity should be ~100 Bq
+  assert(approxEqual(result, 100, 0.1), `I-131 test failed: ${result}`);
+})();
+
+// Test that an unknown isotope throws an error
+(function testUnknownIsotope() {
+  let threw = false;
+  try {
+    computeDecay('X-999', 100, 1);
+  } catch (e) {
+    threw = true;
+  }
+  assert(threw, 'Expected error for unknown isotope');
+})();
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-radiation-decay-estimator
- **Provider**: groq
- **Location**: `node-utils/nightly-nightly-radiation-decay-esti`
- **Files Created**: 3
- **Description**: Estimates remaining radioactivity of a given isotope after a time period using built‑in half‑life data.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `node-utils/nightly-nightly-radiation-decay-esti`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `node-utils/nightly-nightly-radiation-decay-esti/README.md`
- Run tests located in `node-utils/nightly-nightly-radiation-decay-esti/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.