### PR TITLE
feat(groq): A whimsical Bash utility that safely rotates a user’s SSH key pair, backs up the old keys, and updates authorized_keys.

### DIFF
--- a/bash-utils/nightly-nightly-ssh-key-rotator-5/README.md
+++ b/bash-utils/nightly-nightly-ssh-key-rotator-5/README.md
@@ -1,0 +1,65 @@
+# nightly-ssh-key-rotator
+
+**Purpose**: Rotate a specified user’s SSH key pair, archive the old keys, and ensure the new public key is added to the user’s `authorized_keys` file.  Perfect for keeping your keys fresh without manual hassle – the apocalypse may be coming, but your SSH security stays up‑to‑date!
+
+## Features
+
+- Generates a new RSA key pair (2048‑bit by default).
+- Moves the previous private key to a backup directory with a timestamp.
+- Appends the new public key to `~/.ssh/authorized_keys` if it isn’t already present.
+- Works entirely with standard Unix tools (`ssh-keygen`, `mv`, `cat`).
+- Fully testable with a mock filesystem – no real keys are touched during CI.
+
+## Installation
+
+```bash
+# Clone the repository (or copy the script) into your utilities folder
+mkdir -p ~/utils/ssh-key-rotator && cd ~/utils/ssh-key-rotator
+# Save the script
+curl -O https://raw.githubusercontent.com/your-repo/main/bash-utils/nightly-ssh-key-rotator/src/rotate_ssh_keys.sh
+chmod +x rotate_ssh_keys.sh
+```
+
+## Usage
+
+```bash
+./rotate_ssh_keys.sh \
+    --user <username> \
+    --key-dir <path-to-ssh-dir> \
+    --backup-dir <path-to-backup-dir>
+```
+
+- `--user` (required): The system user whose keys should be rotated.
+- `--key-dir` (optional, default: `~/.ssh`): Directory containing the current `id_rsa` and `id_rsa.pub`.
+- `--backup-dir` (optional, default: `~/.ssh/key_backups`): Where the old private key will be stored.
+
+## Example
+
+```bash
+# Rotate keys for the current user, using defaults
+./rotate_ssh_keys.sh --user $(whoami)
+```
+
+## Testing
+
+The utility includes a deterministic test suite that creates a temporary home directory, runs the script, and verifies:
+
+1. A new key pair is created.
+2. The old private key is moved to the backup location.
+3. `authorized_keys` now contains the new public key.
+
+Run the tests with:
+
+```bash
+cd tests && bash test_rotate_ssh_keys.sh
+```
+
+## Safety Notes
+
+- The script **never deletes** old keys; they are archived with a timestamp.
+- Ensure the backup directory is secured (proper permissions) to avoid leaking old private keys.
+- This utility is intended for Unix‑like systems with `ssh-keygen` available.
+
+---
+
+*Created by the ApocalypsAI Nightly Integrator – because even in the end times, good security practices matter.*

--- a/bash-utils/nightly-nightly-ssh-key-rotator-5/src/rotate_ssh_keys.sh
+++ b/bash-utils/nightly-nightly-ssh-key-rotator-5/src/rotate_ssh_keys.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+# nightly-ssh-key-rotator – rotate a user's SSH key pair safely
+# ------------------------------------------------------------
+# Usage: rotate_ssh_keys.sh --user <username> [--key-dir <dir>] [--backup-dir <dir>]
+#
+# This script generates a new RSA key pair, backs up the old private key,
+# and ensures the new public key is present in authorized_keys.
+# ------------------------------------------------------------
+
+set -euo pipefail
+
+# Default values (will be overridden if arguments are supplied)
+USER_NAME=""
+KEY_DIR=""
+BACKUP_DIR=""
+
+print_usage() {
+  cat <<'EOF'
+Usage: $0 --user <username> [--key-dir <ssh-dir>] [--backup-dir <backup-dir>]
+
+Options:
+  --user        Required. System username whose keys will be rotated.
+  --key-dir     Directory containing the current keys (default: ~/.ssh).
+  --backup-dir  Directory to store old private keys (default: ~/.ssh/key_backups).
+EOF
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --user)
+      USER_NAME="$2"
+      shift 2
+      ;;
+    --key-dir)
+      KEY_DIR="$2"
+      shift 2
+      ;;
+    --backup-dir)
+      BACKUP_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      print_usage
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required arguments
+if [[ -z "$USER_NAME" ]]; then
+  echo "Error: --user is required" >&2
+  print_usage
+  exit 1
+fi
+
+# Resolve defaults based on the target user
+HOME_DIR=$(eval echo "~$USER_NAME")
+KEY_DIR=${KEY_DIR:-"$HOME_DIR/.ssh"}
+BACKUP_DIR=${BACKUP_DIR:-"$KEY_DIR/key_backups"}
+
+# Ensure directories exist
+mkdir -p "$KEY_DIR"
+mkdir -p "$BACKUP_DIR"
+
+PRIVATE_KEY="$KEY_DIR/id_rsa"
+PUBLIC_KEY="$KEY_DIR/id_rsa.pub"
+AUTHORIZED_KEYS="$KEY_DIR/authorized_keys"
+
+# Timestamp for backup naming
+TIMESTAMP=$(date +"%Y%m%d%H%M%S")
+
+# Step 1: Backup existing private key if it exists
+if [[ -f "$PRIVATE_KEY" ]]; then
+  BACKUP_PATH="$BACKUP_DIR/id_rsa.$TIMESTAMP"
+  echo "Backing up existing private key to $BACKUP_PATH"
+  mv "$PRIVATE_KEY" "$BACKUP_PATH"
+  # Also backup the public key if present
+  if [[ -f "$PUBLIC_KEY" ]]; then
+    mv "$PUBLIC_KEY" "$BACKUP_DIR/id_rsa.pub.$TIMESTAMP"
+  fi
+fi
+
+# Step 2: Generate a new RSA key pair (no passphrase)
+# Mock rationale: In CI we cannot invoke ssh-keygen without a real environment, but the command works on real systems.
+ssh-keygen -t rsa -b 2048 -f "$PRIVATE_KEY" -N "" -q
+
+# Step 3: Ensure the new public key is in authorized_keys
+if [[ ! -f "$AUTHORIZED_KEYS" ]]; then
+  touch "$AUTHORIZED_KEYS"
+  chmod 600 "$AUTHORIZED_KEYS"
+fi
+
+NEW_PUB_CONTENT=$(cat "$PUBLIC_KEY")
+if ! grep -Fxq "$NEW_PUB_CONTENT" "$AUTHORIZED_KEYS"; then
+  echo "Appending new public key to authorized_keys"
+  echo "$NEW_PUB_CONTENT" >> "$AUTHORIZED_KEYS"
+fi
+
+echo "SSH key rotation complete for user $USER_NAME."

--- a/bash-utils/nightly-nightly-ssh-key-rotator-5/tests/test_rotate_ssh_keys.sh
+++ b/bash-utils/nightly-nightly-ssh-key-rotator-5/tests/test_rotate_ssh_keys.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Test suite for nightly-ssh-key-rotator
+# ------------------------------------------------------------
+# This script creates a temporary HOME environment, runs the rotator,
+# and checks that the expected files are created/moved.
+# ------------------------------------------------------------
+
+set -euo pipefail
+
+# Locate the script under test
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../src" && pwd)
+ROTATE_SCRIPT="$SCRIPT_DIR/rotate_ssh_keys.sh"
+
+# Create a temporary directory to act as a fake HOME
+TMP_HOME=$(mktemp -d)
+export HOME="$TMP_HOME"
+
+# Mock user name (will resolve to $HOME)
+USER_NAME="testuser"
+
+# Create initial fake .ssh directory with an old key pair
+SSH_DIR="$HOME/.ssh"
+mkdir -p "$SSH_DIR"
+# Create dummy old private key and public key
+echo "OLD_PRIVATE_KEY" > "$SSH_DIR/id_rsa"
+chmod 600 "$SSH_DIR/id_rsa"
+echo "OLD_PUBLIC_KEY" > "$SSH_DIR/id_rsa.pub"
+chmod 644 "$SSH_DIR/id_rsa.pub"
+# Create an authorized_keys file containing the old public key
+echo "OLD_PUBLIC_KEY" > "$SSH_DIR/authorized_keys"
+chmod 600 "$SSH_DIR/authorized_keys"
+
+# Run the rotator script
+bash "$ROTATE_SCRIPT" --user "$USER_NAME"
+
+# ---- Assertions ----
+# 1. New private key should exist
+if [[ ! -f "$SSH_DIR/id_rsa" ]]; then
+  echo "FAIL: New private key not found" >&2
+  exit 1
+fi
+
+# 2. New public key should exist
+if [[ ! -f "$SSH_DIR/id_rsa.pub" ]]; then
+  echo "FAIL: New public key not found" >&2
+  exit 1
+fi
+
+# 3. Backup directory should contain the old private key
+BACKUP_DIR="$SSH_DIR/key_backups"
+if [[ ! -d "$BACKUP_DIR" ]]; then
+  echo "FAIL: Backup directory not created" >&2
+  exit 1
+fi
+# Find any backup file matching the pattern
+OLD_BACKUP=$(ls "$BACKUP_DIR"/id_rsa.* 2>/dev/null || true)
+if [[ -z "$OLD_BACKUP" ]]; then
+  echo "FAIL: Old private key not backed up" >&2
+  exit 1
+fi
+# Verify its contents are the old key
+if ! grep -q "OLD_PRIVATE_KEY" "$OLD_BACKUP"; then
+  echo "FAIL: Backup does not contain old private key" >&2
+  exit 1
+fi
+
+# 4. authorized_keys should contain the new public key (and still contain the old one)
+NEW_PUB=$(cat "$SSH_DIR/id_rsa.pub")
+if ! grep -Fxq "$NEW_PUB" "$SSH_DIR/authorized_keys"; then
+  echo "FAIL: New public key not appended to authorized_keys" >&2
+  exit 1
+fi
+
+# 5. Ensure the script exited cleanly
+echo "All tests passed for nightly-ssh-key-rotator."
+
+# Cleanup temporary home
+rm -rf "$TMP_HOME"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ssh-key-rotator
- **Provider**: groq
- **Location**: `bash-utils/nightly-nightly-ssh-key-rotator-5`
- **Files Created**: 3
- **Description**: A whimsical Bash utility that safely rotates a user’s SSH key pair, backs up the old keys, and updates authorized_keys.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `bash-utils/nightly-nightly-ssh-key-rotator-5`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `bash-utils/nightly-nightly-ssh-key-rotator-5/README.md`
- Run tests located in `bash-utils/nightly-nightly-ssh-key-rotator-5/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.