### PR TITLE
feat(gemini): A Go-based server for broadcasting ephemeral, one-way "whispers" to multiple connected clients, ideal for low-latency, non-persistent communication.

### DIFF
--- a/go-utils/nightly-nightly-void-whispers-broadc/README.md
+++ b/go-utils/nightly-nightly-void-whispers-broadc/README.md
@@ -1,0 +1,111 @@
+# Nightly Void Whispers Broadcast
+
+## Summary
+
+The `nightly-void-whispers-broadcast` is a whimsical-yet-useful Go-based server designed to broadcast ephemeral, one-way "whispers" to multiple connected clients. It simulates a low-latency, non-persistent communication channel, perfect for quick status updates, event notifications, or simply sending fleeting messages across a distributed network without the overhead of a full message queue.
+
+Think of it as a digital megaphone for the void, where messages are heard by all who listen, but never linger.
+
+## Features
+
+*   **Concurrent Client Handling**: Efficiently manages multiple client connections using Go's goroutines.
+*   **One-Way Broadcast**: Messages sent to the server are immediately fanned out to all active listeners.
+*   **Ephemeral**: Messages are not stored or persisted; they are broadcast and then gone.
+*   **Simple TCP Protocol**: Clients connect via a standard TCP socket and receive newline-delimited messages.
+*   **Self-Contained**: A single Go binary for the server, with a simple client example.
+
+## How to Use
+
+### 1. Build the Server and Client
+
+Navigate to the `src` directory and build the Go binaries:
+
+```bash
+cd go-utils/nightly-void-whispers-broadcast/src
+go build -o void-whispers-server server.go
+go build -o void-whispers-client client_example.go
+```
+
+### 2. Run the Server
+
+Start the server on a desired port (e.g., `8080`):
+
+```bash
+./void-whispers-server
+```
+
+The server will output:
+`Void Whispers Broadcast Server listening on port 8080...`
+
+### 3. Connect Clients
+
+Open one or more new terminal windows and run the client, specifying the server address and port:
+
+```bash
+./void-whispers-client localhost:8080
+```
+
+Each client will output:
+`Connected to Void Whispers Broadcast Server at localhost:8080. Listening for whispers...`
+
+### 4. Send Whispers (from the server's perspective)
+
+Currently, the `server.go` example runs indefinitely. To send messages, you would integrate the `Broadcast` method into another application or modify `main` function of `server.go` to accept input or trigger broadcasts. For demonstration, you can modify `server.go`'s `main` function temporarily:
+
+```go
+// Inside server.go's main function, after go server.Start("8080")
+
+// Example: Broadcast a message every 3 seconds
+// go func() {
+// 	for i := 0; ; i++ {
+// 		message := fmt.Sprintf("Whisper %d from the void at %s", i, time.Now().Format(time.RFC3339))
+// 		server.Broadcast(message)
+// 		log.Printf("Sent: %s", message)
+// 		time.Sleep(3 * time.Second)
+// 	}
+// }()
+
+// Or, to send a single message after a delay:
+// time.AfterFunc(5 * time.Second, func() {
+// 	server.Broadcast("A single, profound whisper.")
+// })
+
+// Block forever, or until Ctrl+C
+fmt.Println("Server running. Press Ctrl+C to stop.")
+select {} // Block forever
+```
+
+After modifying and rebuilding `server.go`, run it again. Your connected clients will start receiving the broadcasted messages.
+
+## Development
+
+### Project Structure
+
+```
+nightly-void-whispers-broadcast/
+├── README.md
+├── src/
+│   ├── server.go          # The main broadcast server logic
+│   └── client_example.go  # A simple client to demonstrate connection and message reception
+└── tests/
+    └── server_test.go     # Unit and integration tests for the server
+```
+
+### Running Tests
+
+Navigate to the `tests` directory and run the Go tests:
+
+```bash
+cd go-utils/nightly-void-whispers-broadcast/tests
+go test -v
+```
+
+Tests use `localhost` network connections to simulate client-server interactions in a deterministic and offline manner. They verify client connection, message broadcasting, client disconnection handling, and server shutdown.
+
+## Use Cases
+
+*   **Apocalyptic Alert System**: Broadcast urgent, short-lived warnings to all connected survivor outposts.
+*   **Distributed Health Checks**: Send periodic "heartbeat" whispers from a central monitor to various services.
+*   **Event Notification**: Notify all interested parties about a transient event (e.g., "Resource cache found at Sector 7!").
+*   **Game State Updates**: Push real-time, non-critical game state changes to multiple clients in a simple game.
+*   **Ephemeral Chat**: A very basic, non-persistent chat system where messages are only seen by current listeners.

--- a/go-utils/nightly-nightly-void-whispers-broadc/src/client_example.go
+++ b/go-utils/nightly-nightly-void-whispers-broadc/src/client_example.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run client_example.go <server_address:port>")
+		os.Exit(1)
+	}
+	serverAddr := os.Args[1]
+
+	conn, err := net.Dial("tcp", serverAddr)
+	if err != nil {
+		log.Fatalf("Failed to connect to server %s: %v", serverAddr, err)
+	}
+	defer conn.Close()
+	fmt.Printf("Connected to Void Whispers Broadcast Server at %s. Listening for whispers...\n", serverAddr)
+
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		fmt.Printf("Whisper received: %s\n", scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Printf("Error reading from server: %v", err)
+	}
+	fmt.Println("Disconnected from server.")
+}

--- a/go-utils/nightly-nightly-void-whispers-broadc/src/server.go
+++ b/go-utils/nightly-nightly-void-whispers-broadc/src/server.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// BroadcastServer manages client connections and broadcasts messages.
+type BroadcastServer struct {
+	listeners    map[net.Conn]bool
+	messages     chan string
+	addClient    chan net.Conn
+	removeClient chan net.Conn
+	quit         chan struct{}
+	wg           sync.WaitGroup
+	mu           sync.Mutex // Protects listeners map
+}
+
+// NewBroadcastServer creates and initializes a new BroadcastServer.
+func NewBroadcastServer() *BroadcastServer {
+	return &BroadcastServer{
+		listeners:    make(map[net.Conn]bool),
+		messages:     make(chan string, 100), // Buffered channel for messages
+		addClient:    make(chan net.Conn),
+		removeClient: make(chan net.Conn),
+		quit:         make(chan struct{}),
+	}
+}
+
+// Start begins the server's main loop, handling client connections and message broadcasting.
+func (s *BroadcastServer) Start(port string) {
+	listener, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		log.Fatalf("Failed to listen on port %s: %v", port, err)
+	}
+	defer listener.Close()
+	log.Printf("Void Whispers Broadcast Server listening on port %s...", port)
+
+	s.wg.Add(1)
+	go s.manageClientsAndBroadcast()
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				select {
+				case <-s.quit:
+					return // Server is shutting down
+				default:
+					// If the listener is closed by Stop(), Accept() will return an error.
+					// We check if the quit channel is closed to distinguish graceful shutdown.
+					if !isClosed(s.quit) {
+						log.Printf("Error accepting connection: %v", err)
+					}
+					return // Exit the accept loop on error or quit
+				}
+			}
+			log.Printf("New listener connected: %s", conn.RemoteAddr())
+			s.addClient <- conn
+		}
+	}()
+
+	// Wait for quit signal to stop accepting new connections
+	<-s.quit
+	log.Println("Shutting down server...")
+	// Close the listener to prevent new connections
+	listener.Close() // This will cause the Accept() loop to error out and exit
+	close(s.addClient)
+	close(s.removeClient)
+	close(s.messages)
+	s.wg.Wait() // Wait for all goroutines to finish
+	log.Println("Server shut down.")
+}
+
+// Stop sends a signal to shut down the server.
+func (s *BroadcastServer) Stop() {
+	select {
+	case <-s.quit:
+		// Already closed
+	default:
+		close(s.quit)
+	}
+}
+
+// isClosed checks if a channel is closed without blocking.
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+// Broadcast sends a message to all connected listeners.
+func (s *BroadcastServer) Broadcast(message string) {
+	select {
+	case s.messages <- message:
+		// Message sent successfully
+	case <-s.quit:
+		// Server is shutting down, cannot broadcast
+		log.Println("Server is shutting down, cannot broadcast message.")
+	default:
+		// Channel is full, drop message (ephemeral nature)
+		log.Println("Message channel full, dropping whisper.")
+	}
+}
+
+// manageClientsAndBroadcast is the core loop for managing clients and distributing messages.
+func (s *BroadcastServer) manageClientsAndBroadcast() {
+	defer s.wg.Done()
+	for {
+		select {
+		case conn := <-s.addClient:
+			s.mu.Lock()
+			s.listeners[conn] = true
+			s.mu.Unlock()
+			s.wg.Add(1)
+			go s.handleClient(conn)
+		case conn := <-s.removeClient:
+			s.mu.Lock()
+			delete(s.listeners, conn)
+			s.mu.Unlock()
+			log.Printf("Listener disconnected: %s", conn.RemoteAddr())
+			conn.Close()
+		case msg := <-s.messages:
+			s.mu.Lock()
+			// Create a slice of connections to avoid iterating over a map that might change
+			// if a client disconnects during the broadcast loop.
+			connsToSend := make([]net.Conn, 0, len(s.listeners))
+			for conn := range s.listeners {
+				connsToSend = append(connsToSend, conn)
+			}
+			s.mu.Unlock()
+
+			for _, conn := range connsToSend {
+				// Send message in a non-blocking way or with a timeout
+				// For simplicity, we'll block here, but in a real app, for high fan-out,
+				// you might use a goroutine per send or a buffered channel per client.
+				_, err := conn.Write([]byte(msg + "\n"))
+				if err != nil {
+					log.Printf("Error sending to %s: %v", conn.RemoteAddr(), err)
+					s.removeClient <- conn // Mark for removal
+				}
+			}
+		case <-s.quit:
+			// Close all client connections
+			s.mu.Lock()
+			for conn := range s.listeners {
+				conn.Close()
+			}
+			s.listeners = make(map[net.Conn]bool) // Clear map
+			s.mu.Unlock()
+			return
+		}
+	}
+}
+
+// handleClient manages a single client connection.
+// For this broadcast-only server, it primarily listens for client disconnections.
+func (s *BroadcastServer) handleClient(conn net.Conn) {
+	defer s.wg.Done()
+	// We don't expect clients to send messages to the server in this model,
+	// but we need to read to detect disconnects (e.g., client closes connection).
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		// Client sent something, ignore it for this one-way broadcast model
+		// Or log it if you want to see unexpected client input
+		log.Printf("Client %s sent: %s (ignored)", conn.RemoteAddr(), scanner.Text())
+	}
+	// If scanner.Err() is io.EOF, it means the client closed the connection gracefully.
+	// Other errors indicate network issues.
+	// We always remove the client if the loop finishes.
+	s.removeClient <- conn // Client disconnected or error occurred
+}
+
+func main() {
+	server := NewBroadcastServer()
+	port := "8080"
+
+	go server.Start(port) // Start server in a goroutine
+
+	// Set up a channel to listen for OS signals
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+	// Block until a signal is received
+	<-c
+	log.Println("Received shutdown signal, stopping server...")
+	server.Stop()
+
+	// Give some time for graceful shutdown (optional, as wg.Wait() handles it)
+	time.Sleep(500 * time.Millisecond)
+	log.Println("Server application exited.")
+}

--- a/go-utils/nightly-nightly-void-whispers-broadc/tests/server_test.go
+++ b/go-utils/nightly-nightly-void-whispers-broadc/tests/server_test.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Helper to find an available port for testing
+func getFreePort() (string, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return "", err
+	}
+	listener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return "", err
+	}
+	defer listener.Close()
+	return strings.Split(listener.Addr().String(), ":")[1], nil
+}
+
+func TestBroadcastServer_SingleClient(t *testing.T) {
+	port, err := getFreePort()
+	if err != nil {
+		t.Fatalf("Failed to get free port: %v", err)
+	}
+
+	server := NewBroadcastServer()
+
+	var serverWg sync.WaitGroup
+	serverWg.Add(1)
+	go func() {
+		defer serverWg.Done()
+		server.Start(port)
+	}()
+
+	// Give server a moment to start listening
+	time.Sleep(100 * time.Millisecond)
+
+	// Connect a client
+	clientConn, err := net.Dial("tcp", "localhost:"+port)
+	if err != nil {
+		t.Fatalf("Failed to connect client: %v", err)
+	}
+	defer clientConn.Close()
+
+	// Give server a moment to register client
+	time.Sleep(100 * time.Millisecond)
+
+	testMessage := "Hello, void!"
+	server.Broadcast(testMessage)
+
+	// Read from client connection
+	reader := bufio.NewReader(clientConn)
+	clientMsg, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("Client failed to read message: %v", err)
+	}
+
+	expectedMsg := testMessage + "\n"
+	if clientMsg != expectedMsg {
+		t.Errorf("Expected message %q, got %q", expectedMsg, clientMsg)
+	}
+
+	server.Stop()
+	serverWg.Wait() // Wait for server to fully shut down
+}
+
+func TestBroadcastServer_MultipleClients(t *testing.T) {
+	port, err := getFreePort()
+	if err != nil {
+		t.Fatalf("Failed to get free port: %v", err)
+	}
+
+	server := NewBroadcastServer()
+
+	var serverWg sync.WaitGroup
+	serverWg.Add(1)
+	go func() {
+		defer serverWg.Done()
+		server.Start(port)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	numClients := 3
+	clientConns := make([]net.Conn, numClients)
+	clientReaders := make([]*bufio.Reader, numClients)
+	for i := 0; i < numClients; i++ {
+		conn, err := net.Dial("tcp", "localhost:"+port)
+		if err != nil {
+			t.Fatalf("Failed to connect client %d: %v", i, err)
+		}
+		clientConns[i] = conn
+		clientReaders[i] = bufio.NewReader(conn)
+	}
+	defer func() {
+		for _, conn := range clientConns {
+			conn.Close()
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond) // Give server time to register clients
+
+	testMessage := "Whisper to all!"
+	server.Broadcast(testMessage)
+
+	expectedMsg := testMessage + "\n"
+	for i, reader := range clientReaders {
+		clientMsg, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("Client %d failed to read message: %v", i, err)
+		}
+		if clientMsg != expectedMsg {
+			t.Errorf("Client %d: Expected message %q, got %q", i, expectedMsg, clientMsg)
+		}
+	}
+
+	server.Stop()
+	serverWg.Wait()
+}
+
+func TestBroadcastServer_ClientDisconnect(t *testing.T) {
+	port, err := getFreePort()
+	if err != nil {
+		t.Fatalf("Failed to get free port: %v", err)
+	}
+
+	server := NewBroadcastServer()
+
+	var serverWg sync.WaitGroup
+	serverWg.Add(1)
+	go func() {
+		defer serverWg.Done()
+		server.Start(port)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	client1, err := net.Dial("tcp", "localhost:"+port)
+	if err != nil {
+		t.Fatalf("Failed to connect client 1: %v", err)
+	}
+	client2, err := net.Dial("tcp", "localhost:"+port)
+	if err != nil {
+		t.Fatalf("Failed to connect client 2: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond) // Give server time to register clients
+
+	// Client 1 disconnects
+	client1.Close()
+	time.Sleep(200 * time.Millisecond) // Give server time to process disconnect
+
+	// Broadcast a message
+	testMessage := "After disconnect"
+	server.Broadcast(testMessage)
+
+	// Only client 2 should receive the message
+	reader2 := bufio.NewReader(client2)
+	client2Msg, err := reader2.ReadString('\n')
+	if err != nil {
+		t.Fatalf("Client 2 failed to read message: %v", err)
+	}
+	expectedMsg := testMessage + "\n"
+	if client2Msg != expectedMsg {
+		t.Errorf("Client 2: Expected message %q, got %q", expectedMsg, client2Msg)
+	}
+
+	// Try to read from client 1 (should fail or block)
+	// # Mock rationale: In a real scenario, ReadString would block or return EOF/closed connection error.
+	// For deterministic testing, we assert the expected error for a closed connection.
+	client1Reader := bufio.NewReader(client1)
+	_, err = client1Reader.ReadString('\n')
+	if err == nil || (!strings.Contains(err.Error(), "use of closed network connection") && err != io.EOF) {
+		t.Errorf("Expected error for closed connection or EOF, got %v", err)
+	}
+
+	client2.Close()
+	server.Stop()
+	serverWg.Wait()
+}
+
+func TestBroadcastServer_NoClients(t *testing.T) {
+	port, err := getFreePort()
+	if err != nil {
+		t.Fatalf("Failed to get free port: %v", err)
+	}
+
+	server := NewBroadcastServer()
+
+	var serverWg sync.WaitGroup
+	serverWg.Add(1)
+	go func() {
+		defer serverWg.Done()
+		server.Start(port)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// Broadcast a message with no clients connected
+	testMessage := "No one is listening"
+	server.Broadcast(testMessage)
+
+	// No errors should occur, and the server should remain stable.
+	// This test primarily checks for panics or deadlocks.
+	time.Sleep(100 * time.Millisecond)
+
+	server.Stop()
+	serverWg.Wait()
+}
+
+func TestBroadcastServer_Stop(t *testing.T) {
+	port, err := getFreePort()
+	if err != nil {
+		t.Fatalf("Failed to get free port: %v", err)
+	}
+
+	server := NewBroadcastServer()
+
+	var serverWg sync.WaitGroup
+	serverWg.Add(1)
+	go func() {
+		defer serverWg.Done()
+		server.Start(port)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// Connect a client
+	clientConn, err := net.Dial("tcp", "localhost:"+port)
+	if err != nil {
+		t.Fatalf("Failed to connect client: %v", err)
+	}
+	// defer clientConn.Close() // Client will be closed by server.Stop()
+
+	time.Sleep(100 * time.Millisecond) // Give server time to register client
+
+	server.Stop()
+	serverWg.Wait() // Wait for server to shut down
+
+	// Verify client connection is closed
+	// # Mock rationale: Attempting to read from a server-closed connection should result in EOF or a closed network error.
+	reader := bufio.NewReader(clientConn)
+	_, err = reader.ReadString('\n')
+	if err == nil || (err != io.EOF && !strings.Contains(err.Error(), "use of closed network connection")) {
+		t.Errorf("Expected EOF or closed connection error after server stop, got %v", err)
+	}
+	clientConn.Close() // Ensure client is closed even if test fails early
+}
+
+func TestBroadcastServer_BroadcastWhileStopping(t *testing.T) {
+	port, err := getFreePort()
+	if err != nil {
+		t.Fatalf("Failed to get free port: %v", err)
+	}
+
+	server := NewBroadcastServer()
+
+	var serverWg sync.WaitGroup
+	serverWg.Add(1)
+	go func() {
+		defer serverWg.Done()
+		server.Start(port)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// Start shutdown
+	server.Stop()
+
+	// Attempt to broadcast a message immediately after stopping
+	server.Broadcast("This whisper should be dropped")
+
+	// Ensure no panic and server eventually shuts down
+	serverWg.Wait()
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-void-whispers-broadcast
- **Provider**: gemini
- **Location**: `go-utils/nightly-nightly-void-whispers-broadc`
- **Files Created**: 4
- **Description**: A Go-based server for broadcasting ephemeral, one-way "whispers" to multiple connected clients, ideal for low-latency, non-persistent communication.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-void-whispers-broadc`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-void-whispers-broadc/README.md`
- Run tests located in `go-utils/nightly-nightly-void-whispers-broadc/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.