### PR TITLE
feat(groq): Suggests GitHub issue labels based on the issue title using a simple keyword‑to‑label map.

### DIFF
--- a/node-utils/nightly-nightly-issue-label-suggeste/README.md
+++ b/node-utils/nightly-nightly-issue-label-suggeste/README.md
@@ -1,0 +1,27 @@
+# nightly-issue-label-suggester
+
+A tiny Node.js utility that suggests GitHub issue labels based on the issue title. It uses a simple keyword‑to‑label mapping and works offline.
+
+## Installation
+
+```sh
+npm install -g nightly-issue-label-suggester
+```
+
+## Usage
+
+```sh
+node src/main.js "Add dark mode to settings page"
+# => ["enhancement"]
+```
+
+Or as a module:
+
+```js
+const { suggestLabels } = require('./src/main');
+console.log(suggestLabels("Crash on startup"));
+```
+
+## How it works
+
+The utility lower‑cases the title, tokenises it, and matches known keywords to a set of predefined labels. If no keywords match, it returns `["question"]`.

--- a/node-utils/nightly-nightly-issue-label-suggeste/src/main.js
+++ b/node-utils/nightly-nightly-issue-label-suggeste/src/main.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * nightly-issue-label-suggester
+ * Suggests GitHub issue labels based on title keywords.
+ */
+
+function suggestLabels(title) {
+  if (typeof title !== 'string') return [];
+  const map = {
+    bug: ['bug'],
+    error: ['bug'],
+    fail: ['bug'],
+    crash: ['bug'],
+    broken: ['bug'],
+    feature: ['enhancement'],
+    add: ['enhancement'],
+    implement: ['enhancement'],
+    improve: ['enhancement'],
+    upgrade: ['enhancement'],
+    doc: ['documentation'],
+    docs: ['documentation'],
+    readme: ['documentation'],
+    documentation: ['documentation'],
+    test: ['testing'],
+    ci: ['ci'],
+    build: ['ci'],
+    refactor: ['refactor'],
+    performance: ['performance'],
+    security: ['security'],
+    deps: ['dependencies'],
+    dependency: ['dependencies'],
+    chore: ['chore']
+  };
+  const lower = title.toLowerCase();
+  const words = lower.split(/\\s+/);
+  const labels = new Set();
+  for (const word of words) {
+    if (map[word]) {
+      map[word].forEach(l => labels.add(l));
+    }
+  }
+  if (labels.size === 0) {
+    labels.add('question');
+  }
+  return Array.from(labels);
+}
+
+// CLI mode
+if (require.main === module) {
+  const title = process.argv[2] || '';
+  const result = suggestLabels(title);
+  console.log(JSON.stringify(result));
+}
+
+module.exports = { suggestLabels };

--- a/node-utils/nightly-nightly-issue-label-suggeste/tests/test_main.js
+++ b/node-utils/nightly-nightly-issue-label-suggeste/tests/test_main.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { suggestLabels } = require('../src/main');
+
+// Mock rationale: deterministic keyword mapping ensures repeatable results
+
+function testCase(title, expected) {
+  const result = suggestLabels(title);
+  assert.deepStrictEqual(result.sort(), expected.sort(), `Failed for "${title}"`);
+}
+
+// Test known mappings
+testCase('Crash on startup', ['bug']);
+testCase('Add dark mode feature', ['enhancement']);
+testCase('Update README documentation', ['documentation']);
+testCase('Refactor authentication flow', ['refactor']);
+testCase('Random unrelated title', ['question']);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-issue-label-suggester
- **Provider**: groq
- **Location**: `node-utils/nightly-nightly-issue-label-suggeste`
- **Files Created**: 3
- **Description**: Suggests GitHub issue labels based on the issue title using a simple keyword‑to‑label map.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `node-utils/nightly-nightly-issue-label-suggeste`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `node-utils/nightly-nightly-issue-label-suggeste/README.md`
- Run tests located in `node-utils/nightly-nightly-issue-label-suggeste/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.