### PR TITLE
feat(groq): A whimsical Go HTTP server that serves random post‑apocalyptic radio chatter messages for testing and fun.

### DIFF
--- a/go-utils/nightly-nightly-radio-chatter-api/README.md
+++ b/go-utils/nightly-nightly-radio-chatter-api/README.md
@@ -1,0 +1,45 @@
+# nightly-radio-chatter-api
+
+A whimsical Go HTTP server that serves random post‑apocalyptic radio chatter messages. Useful for testing chat‑bot integrations, demos, or just adding a bit of flavor to your projects.
+
+## Usage
+
+```sh
+# Run directly (requires Go 1.18+)
+go run src/main.go
+```
+
+The server listens on `localhost:8080`.
+
+### Endpoints
+
+- `GET /chatter?seed=<int>` – Returns a JSON payload with a deterministic message when a `seed` is supplied, otherwise the seed is derived from the current time.
+
+Example response:
+
+```json
+{
+  "seed": 123,
+  "message": "radio static chant the names of heroes."
+}
+```
+
+## Build
+
+```sh
+go build -o radio-chatter src/main.go
+```
+
+## Test
+
+```sh
+go test ./...
+```
+
+---
+
+### Why this utility?
+
+* **Whimsical** – The messages are crafted from a pool of post‑apocalyptic fragments.
+* **Deterministic** – Supplying a `seed` yields the same message, making it perfect for automated tests.
+* **Concurrent** – The Go HTTP server can handle many simultaneous requests out of the box.

--- a/go-utils/nightly-nightly-radio-chatter-api/src/main.go
+++ b/go-utils/nightly-nightly-radio-chatter-api/src/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+    "encoding/json"
+    "log"
+    "math/rand"
+    "net/http"
+    "strconv"
+    "time"
+)
+
+type Response struct {
+    Seed    int64  `json:"seed"`
+    Message string `json:"message"`
+}
+
+var fragments = []string{
+    "static whispers",
+    "radio static",
+    "muted sirens",
+    "echoes of the old world",
+    "crackling transmissions",
+    "ghostly frequencies",
+    "lost broadcasts",
+    "flickering signals",
+    "hushed warnings",
+    "rumbling alarms",
+}
+
+var actions = []string{
+    "drift across the wasteland",
+    "carry secrets",
+    "warn of incoming storms",
+    "recount forgotten tales",
+    "signal safe havens",
+    "announce the sunrise",
+    "chant the names of heroes",
+    "broadcast hope",
+    "relay the last orders",
+    "sing lullabies of steel",
+}
+
+func generateMessage(r *rand.Rand) string {
+    f := fragments[r.Intn(len(fragments))]
+    a := actions[r.Intn(len(actions))]
+    return f + " " + a + "."
+}
+
+func handler(w http.ResponseWriter, req *http.Request) {
+    var seed int64
+    q := req.URL.Query().Get("seed")
+    if q != "" {
+        if s, err := strconv.ParseInt(q, 10, 64); err == nil {
+            seed = s
+        } else {
+            seed = time.Now().UnixNano()
+        }
+    } else {
+        seed = time.Now().UnixNano()
+    }
+    r := rand.New(rand.NewSource(seed))
+    msg := generateMessage(r)
+    resp := Response{Seed: seed, Message: msg}
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(resp)
+}
+
+func main() {
+    http.HandleFunc("/chatter", handler)
+    log.Println("Starting server on :8080")
+    log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/go-utils/nightly-nightly-radio-chatter-api/tests/main_test.go
+++ b/go-utils/nightly-nightly-radio-chatter-api/tests/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+    "encoding/json"
+    "net/http/httptest"
+    "testing"
+)
+
+func TestHandlerDeterministic(t *testing.T) {
+    seed := int64(12345)
+
+    // First request with the seed
+    req1 := httptest.NewRequest("GET", "/chatter?seed=12345", nil)
+    w1 := httptest.NewRecorder()
+    handler(w1, req1)
+    var r1 Response
+    if err := json.NewDecoder(w1.Result().Body).Decode(&r1); err != nil {
+        t.Fatalf("failed to decode first response: %v", err)
+    }
+
+    // Second request with the same seed
+    req2 := httptest.NewRequest("GET", "/chatter?seed=12345", nil)
+    w2 := httptest.NewRecorder()
+    handler(w2, req2)
+    var r2 Response
+    if err := json.NewDecoder(w2.Result().Body).Decode(&r2); err != nil {
+        t.Fatalf("failed to decode second response: %v", err)
+    }
+
+    // # Mock rationale: With identical seeds the random generator should produce identical messages.
+    if r1.Message != r2.Message {
+        t.Fatalf("messages differ for same seed: %q vs %q", r1.Message, r2.Message)
+    }
+    if r1.Seed != seed || r2.Seed != seed {
+        t.Fatalf("seed mismatch: got %d and %d, expected %d", r1.Seed, r2.Seed, seed)
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-radio-chatter-api
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-radio-chatter-api`
- **Files Created**: 3
- **Description**: A whimsical Go HTTP server that serves random post‑apocalyptic radio chatter messages for testing and fun.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-radio-chatter-api`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-radio-chatter-api/README.md`
- Run tests located in `go-utils/nightly-nightly-radio-chatter-api/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.