### PR TITLE
feat(groq): Terraform module that provisions a versioned, encrypted S3 bucket with a 30‑day lifecycle rule and a read‑only IAM policy for post‑apocalyptic safe‑house storage.

### DIFF
--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/README.md
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/README.md
@@ -1,0 +1,56 @@
+# Nightly Apocalypse Safehouse S3
+
+## Overview
+
+A tiny Terraform module that creates an Amazon S3 bucket suitable for storing post‑apocalyptic resources. The bucket includes:
+
+* **Versioning** – never lose a previous version of a file.
+* **Server‑side encryption** – AES‑256 encryption at rest.
+* **Lifecycle rule** – automatically expire objects older than 30 days.
+* **Read‑only IAM policy** – a policy ARN you can attach to users or roles that only need to read the bucket.
+
+## Usage
+
+```hcl
+module "safehouse" {
+  source      = "./nightly-apocalypse-safehouse-s3"
+  bucket_name = "my‑post‑apoc‑stash"
+  tags = {
+    Environment = "production"
+    Project     = "apocalypse"
+  }
+}
+
+output "bucket_arn" {
+  value = module.safehouse.bucket_arn
+}
+
+output "read_only_policy_arn" {
+  value = module.safehouse.read_only_policy_arn
+}
+```
+
+## Variables
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `bucket_name` | Name of the S3 bucket (must be globally unique) | `string` | n/a |
+| `tags` | Optional tags to apply to the bucket | `map(string)` | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `bucket_arn` | ARN of the created bucket |
+| `read_only_policy_arn` | ARN of the generated read‑only IAM policy |
+
+## Testing
+
+A simple shell script is provided under `tests/validate.sh` that checks the presence of the required resources without contacting AWS. Run it with:
+
+```bash
+cd nightly-apocalypse-safehouse-s3
+tests/validate.sh
+```
+
+If all checks pass you will see `All checks passed.`.

--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/main.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/main.tf
@@ -1,0 +1,63 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "safehouse" {
+  bucket        = var.bucket_name
+  force_destroy = true
+  tags          = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "safehouse" {
+  bucket = aws_s3_bucket.safehouse.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "safehouse" {
+  bucket = aws_s3_bucket.safehouse.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "safehouse" {
+  bucket = aws_s3_bucket.safehouse.id
+
+  rule {
+    id     = "expire-after-30-days"
+    status = "Enabled"
+    filter {}
+    expiration {
+      days = 30
+    }
+  }
+}
+
+resource "aws_iam_policy" "read_only" {
+  name   = "${var.bucket_name}-read-only"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow",
+        Action   = ["s3:GetObject", "s3:ListBucket"],
+        Resource = [
+          aws_s3_bucket.safehouse.arn,
+          "${aws_s3_bucket.safehouse.arn}/*"
+        ]
+      }
+    ]
+  })
+}

--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/outputs.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_arn" {
+  description = "ARN of the created bucket"
+  value       = aws_s3_bucket.safehouse.arn
+}
+
+output "read_only_policy_arn" {
+  description = "ARN of the read‑only IAM policy"
+  value       = aws_iam_policy.read_only.arn
+}

--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/tests/validate.sh
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/tests/validate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Test that the Terraform module contains required resources
+
+set -e
+
+MODULE_DIR=$(dirname "$0")/..
+
+# Check that main.tf defines aws_s3_bucket
+if ! grep -q 'resource "aws_s3_bucket"' "$MODULE_DIR/main.tf"; then
+  echo "Missing aws_s3_bucket resource"
+  exit 1
+fi
+
+# Check versioning block
+if ! grep -q 'aws_s3_bucket_versioning' "$MODULE_DIR/main.tf"; then
+  echo "Missing versioning configuration"
+  exit 1
+fi
+
+# Check encryption block
+if ! grep -q 'aws_s3_bucket_server_side_encryption_configuration' "$MODULE_DIR/main.tf"; then
+  echo "Missing encryption configuration"
+  exit 1
+fi
+
+# Check lifecycle block
+if ! grep -q 'aws_s3_bucket_lifecycle_configuration' "$MODULE_DIR/main.tf"; then
+  echo "Missing lifecycle configuration"
+  exit 1
+fi
+
+# Check IAM policy
+if ! grep -q 'aws_iam_policy' "$MODULE_DIR/main.tf"; then
+  echo "Missing IAM policy"
+  exit 1
+fi
+
+echo "All checks passed."

--- a/terraform-modules/nightly-nightly-apocalypse-safehouse-6/variables.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-safehouse-6/variables.tf
@@ -1,0 +1,10 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to the bucket"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-apocalypse-safehouse-s3
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-apocalypse-safehouse-6`
- **Files Created**: 5
- **Description**: Terraform module that provisions a versioned, encrypted S3 bucket with a 30‑day lifecycle rule and a read‑only IAM policy for post‑apocalyptic safe‑house storage.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-apocalypse-safehouse-6`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-apocalypse-safehouse-6/README.md`
- Run tests located in `terraform-modules/nightly-nightly-apocalypse-safehouse-6/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.