### PR TITLE
feat(groq): An Ansible playbook that drops a random post‑apocalyptic morale quote into a file and makes it appear on user login.

### DIFF
--- a/ansible-playbooks/nightly-nightly-morale-quote-dispens/README.md
+++ b/ansible-playbooks/nightly-nightly-morale-quote-dispens/README.md
@@ -1,0 +1,51 @@
+# nightly‑morale‑quote‑dispenser
+
+## Overview
+
+`nightly-morale-quote-dispenser` is a whimsical yet useful Ansible playbook that:
+
+1. Picks a random morale‑boosting quote from a built‑in list.
+2. Writes the quote to a configurable file (default: `/etc/morale_of_the_day.txt`).
+3. Installs a tiny shell script in `/etc/profile.d/` that prints the quote each time a user opens a new shell session.
+
+The playbook is completely self‑contained – no external APIs or internet access are required – making it safe to run in isolated or offline environments.
+
+## Files
+
+- `src/morale_dispenser.yml` – The main playbook.
+- `src/inventory.ini` – Simple inventory targeting `localhost`.
+- `tests/test_morale_dispenser.yml` – Automated test that validates the playbook creates the quote file and that the content is one of the expected quotes.
+
+## Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `morale_path` | `/etc/morale_of_the_day.txt` | Destination file for the random quote. |
+| `script_path` | `/etc/profile.d/morale.sh` | Path of the shell script that prints the quote on login. |
+| `quotes` | (list of four built‑in quotes) | The pool of possible morale quotes. |
+
+You can override any of these variables on the command line, e.g.:
+
+```bash
+ansible-playbook -i src/inventory.ini src/morale_dispenser.yml \
+  -e "morale_path=/tmp/morale.txt script_path=/tmp/morale.sh"
+```
+
+## Running the Playbook
+
+```bash
+# Install the quote (requires root to write to /etc)
+ansible-playbook -i src/inventory.ini src/morale_dispenser.yml
+```
+
+After a successful run, opening a new terminal will display a random morale quote.
+
+## Testing
+
+The repository includes an offline test suite that can be executed with:
+
+```bash
+ansible-playbook -i src/inventory.ini tests/test_morale_dispenser.yml
+```
+
+The test runs the playbook against a temporary location (`/tmp`) and asserts that the quote file exists and contains one of the expected quotes.

--- a/ansible-playbooks/nightly-nightly-morale-quote-dispens/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-morale-quote-dispens/src/inventory.ini
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-morale-quote-dispens/src/morale_dispenser.yml
+++ b/ansible-playbooks/nightly-nightly-morale-quote-dispens/src/morale_dispenser.yml
@@ -1,0 +1,29 @@
+---
+- name: Deploy post‑apocalyptic morale quote
+  hosts: all
+  become: true
+  vars:
+    # Default destinations – can be overridden via extra_vars
+    morale_path: "/etc/morale_of_the_day.txt"
+    script_path: "/etc/profile.d/morale.sh"
+    quotes:
+      - "Keep calm and hoard supplies."
+      - "Every day is a new scavenger hunt."
+      - "Radiation today, hope tomorrow."
+      - "When in doubt, barter."
+  tasks:
+    - name: Write a random morale quote to file
+      copy:
+        dest: "{{ morale_path }}"
+        content: "{{ quotes | random }}\n"
+        mode: "0644"
+
+    - name: Install login script to display the quote
+      copy:
+        dest: "{{ script_path }}"
+        content: |
+          #!/bin/sh
+          if [ -f "{{ morale_path }}" ]; then
+            cat "{{ morale_path }}"
+          fi
+        mode: "0755"

--- a/ansible-playbooks/nightly-nightly-morale-quote-dispens/tests/test_morale_dispenser.yml
+++ b/ansible-playbooks/nightly-nightly-morale-quote-dispens/tests/test_morale_dispenser.yml
@@ -1,0 +1,52 @@
+---
+- name: Test morale quote dispenser
+  hosts: all
+  become: true
+  vars:
+    # Use temporary paths to avoid requiring privileged writes
+    morale_path: "/tmp/morale_of_the_day.txt"
+    script_path: "/tmp/morale.sh"
+    quotes:
+      - "Keep calm and hoard supplies."
+      - "Every day is a new scavenger hunt."
+      - "Radiation today, hope tomorrow."
+      - "When in doubt, barter."
+  tasks:
+    - name: Run the main playbook with overridden paths
+      import_playbook: "../src/morale_dispenser.yml"
+
+    - name: Verify the morale file exists
+      stat:
+        path: "{{ morale_path }}"
+      register: morale_file
+
+    - name: Assert morale file was created
+      assert:
+        that:
+          - morale_file.stat.exists
+          - morale_file.stat.isreg
+
+    - name: Read the morale file content
+      slurp:
+        src: "{{ morale_path }}"
+      register: morale_content
+
+    - name: Decode content to string
+      set_fact:
+        morale_text: "{{ morale_content.content | b64decode | trim }}"
+
+    - name: Ensure the content is one of the expected quotes
+      assert:
+        that:
+          - "{{ morale_text }} in quotes"
+
+    - name: Verify the login script exists and is executable
+      stat:
+        path: "{{ script_path }}"
+      register: script_file
+
+    - name: Assert script file was created correctly
+      assert:
+        that:
+          - script_file.stat.exists
+          - script_file.stat.mode == '0755'


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-morale-quote-dispenser
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-morale-quote-dispens`
- **Files Created**: 4
- **Description**: An Ansible playbook that drops a random post‑apocalyptic morale quote into a file and makes it appear on user login.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-morale-quote-dispens`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-morale-quote-dispens/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-morale-quote-dispens/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.