### PR TITLE
feat(groq): Terraform module that provisions a secure, versioned S3 bucket for post-apocalyptic supplies with encryption and lifecycle rules.

### DIFF
--- a/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
@@ -1,0 +1,39 @@
+# Safehouse S3 Terraform Module
+
+## Overview
+
+Creates an S3 bucket configured for post‑apocalyptic supply storage:
+
+- Versioning enabled
+- Server‑side encryption (AES‑256)
+- Lifecycle rule to delete objects older than 30 days
+- Optional tags
+
+## Usage
+
+```hcl
+module "safehouse" {
+  source      = "git::https://github.com/yourorg/apocalypsai.git//terraform-modules/nightly-safehouse-s3"
+  bucket_name = "my-apocalypse-supplies"
+  tags = {
+    Environment = "production"
+    Project     = "Safehouse"
+  }
+}
+```
+
+Run `terraform init` and `terraform apply`.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| bucket_name | Name of the S3 bucket | string | n/a | yes |
+| tags | Map of tags to assign | map(string) | {} | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| bucket_id | ID of the bucket |
+| bucket_arn | ARN of the bucket |

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/main.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "safehouse" {
+  bucket = var.bucket_name
+  tags   = var.tags
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "expire-old-supplies"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+
+    noncurrent_version_expiration {
+      days = 30
+    }
+  }
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/outputs.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_id" {
+  description = "ID of the bucket"
+  value       = aws_s3_bucket.safehouse.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the bucket"
+  value       = aws_s3_bucket.safehouse.arn
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/tests/validate.sh
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/tests/validate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Initialize Terraform without remote backend
+terraform init -backend=false > /dev/null
+
+# Validate configuration syntax
+terraform validate
+
+# Generate a plan (no‑op) and capture output
+plan_output=$(terraform plan -no-color -input=false 2>/dev/null || true)
+
+# Check that versioning is set to enabled in the plan
+if echo "$plan_output" | grep -q "versioning.*enabled = true"; then
+  echo "PASS: Versioning is enabled"
+else
+  echo "FAIL: Versioning not found"
+  exit 1
+fi
+
+echo "All checks passed."

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/variables.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/variables.tf
@@ -1,0 +1,10 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to the bucket"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-safehouse-s3
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-safehouse-s3-8`
- **Files Created**: 5
- **Description**: Terraform module that provisions a secure, versioned S3 bucket for post-apocalyptic supplies with encryption and lifecycle rules.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-safehouse-s3-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-safehouse-s3-8/README.md`
- Run tests located in `terraform-modules/nightly-nightly-safehouse-s3-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.