### PR TITLE
feat(groq): A tiny Go CLI that computes the remaining amount of a radioactive substance after a given elapsed time using its half‑life.

### DIFF
--- a/go-utils/nightly-nightly-decay-calculator/README.md
+++ b/go-utils/nightly-nightly-decay-calculator/README.md
@@ -1,0 +1,66 @@
+# Nightly Decay Calculator
+
+**Utility name:** `nightly-decay-calculator`
+
+## Overview
+
+`nightly-decay-calculator` is a small, self‑contained Go command‑line tool that calculates how much of a radioactive material remains after a certain amount of time, based on its half‑life. It is useful for anyone who wants a quick, offline estimate of radioactive decay without pulling in heavy scientific libraries.
+
+## Installation
+
+```bash
+# Clone the repository (or copy the utility folder into your project)
+git clone https://github.com/polsala/ApocalypsAI.git
+cd utils/go-utils/nightly-decay-calculator
+
+# Build the binary
+go build -o decaycalc ./src/main.go
+```
+
+The binary `decaycalc` will be created in the current directory.
+
+## Usage
+
+```bash
+./decaycalc -initial <initial_amount> -half-life <half_life> -time <elapsed_time>
+```
+
+- `-initial`   : Initial amount of the substance (any unit, e.g., grams).
+- `-half-life` : Half‑life of the substance in the same time unit you will use for `-time`.
+- `-time`      : Elapsed time since the start of the decay.
+
+### Example
+
+```bash
+# 100 grams of a material with a half‑life of 30 years, after 90 years:
+./decaycalc -initial 100 -half-life 30 -time 90
+```
+
+Output:
+```
+Remaining amount after 90.00 units of time: 12.50 (same unit as initial)
+```
+
+## How it works
+
+The tool uses the classic exponential decay formula:
+
+```
+remaining = initial * 0.5^(time / half_life)
+```
+
+All calculations are performed with `float64` precision.
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+go test ./tests
+```
+
+The test suite covers a few typical scenarios and edge cases.
+
+## License
+
+This utility is released under the MIT License.

--- a/go-utils/nightly-nightly-decay-calculator/go.mod
+++ b/go-utils/nightly-nightly-decay-calculator/go.mod
@@ -1,0 +1,3 @@
+module nightly-decay-calculator
+
+go 1.22

--- a/go-utils/nightly-nightly-decay-calculator/src/main.go
+++ b/go-utils/nightly-nightly-decay-calculator/src/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+    "flag"
+    "fmt"
+    "math"
+)
+
+// computeRemaining calculates the remaining amount of a radioactive substance.
+// It follows the formula: remaining = initial * 0.5^(elapsed/halfLife)
+func computeRemaining(initial, halfLife, elapsed float64) float64 {
+    if halfLife <= 0 {
+        // Avoid division by zero; return 0 as a safe fallback.
+        return 0
+    }
+    exponent := elapsed / halfLife
+    return initial * math.Pow(0.5, exponent)
+}
+
+func main() {
+    // Define command‑line flags.
+    initialPtr := flag.Float64("initial", 0, "Initial amount of the substance (any unit)")
+    halfLifePtr := flag.Float64("half-life", 0, "Half‑life of the substance (same time unit as -time)")
+    timePtr := flag.Float64("time", 0, "Elapsed time since start of decay (same unit as half‑life)")
+
+    flag.Parse()
+
+    // Basic validation.
+    if *initialPtr < 0 || *halfLifePtr <= 0 || *timePtr < 0 {
+        fmt.Println("Error: all inputs must be non‑negative and half‑life must be > 0.")
+        flag.Usage()
+        return
+    }
+
+    remaining := computeRemaining(*initialPtr, *halfLifePtr, *timePtr)
+    fmt.Printf("Remaining amount after %.2f units of time: %.2f (same unit as initial)\n", *timePtr, remaining)
+}

--- a/go-utils/nightly-nightly-decay-calculator/tests/main_test.go
+++ b/go-utils/nightly-nightly-decay-calculator/tests/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+    "math"
+    "testing"
+)
+
+// approxEqual checks if two floats are equal within a small tolerance.
+func approxEqual(a, b, tol float64) bool {
+    return math.Abs(a-b) <= tol
+}
+
+func TestComputeRemaining_Basic(t *testing.T) {
+    // 100 units, half‑life 10, after 10 units -> should be 50.
+    got := computeRemaining(100, 10, 10)
+    want := 50.0
+    if !approxEqual(got, want, 1e-9) {
+        t.Fatalf("expected %.9f, got %.9f", want, got)
+    }
+}
+
+func TestComputeRemaining_MultipleHalfLives(t *testing.T) {
+    // After 3 half‑lives, amount should be initial * (0.5)^3 = initial/8.
+    got := computeRemaining(80, 5, 15) // 3 half‑lives (15/5)
+    want := 10.0
+    if !approxEqual(got, want, 1e-9) {
+        t.Fatalf("expected %.9f, got %.9f", want, got)
+    }
+}
+
+func TestComputeRemaining_ZeroElapsed(t *testing.T) {
+    got := computeRemaining(42, 7, 0)
+    want := 42.0
+    if !approxEqual(got, want, 1e-9) {
+        t.Fatalf("expected %.9f, got %.9f", want, got)
+    }
+}
+
+func TestComputeRemaining_InvalidHalfLife(t *testing.T) {
+    got := computeRemaining(10, 0, 5)
+    want := 0.0 // our implementation returns 0 for non‑positive half‑life.
+    if got != want {
+        t.Fatalf("expected %.9f, got %.9f", want, got)
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-decay-calculator
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-decay-calculator`
- **Files Created**: 4
- **Description**: A tiny Go CLI that computes the remaining amount of a radioactive substance after a given elapsed time using its half‑life.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-decay-calculator`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-decay-calculator/README.md`
- Run tests located in `go-utils/nightly-nightly-decay-calculator/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.