### PR TITLE
feat(groq): A whimsical CLI tool that translates a sequence of emojis into a readable phrase using a built‑in dictionary.

### DIFF
--- a/rust-utils/nightly-nightly-cryptic-emoji-decode/Cargo.toml
+++ b/rust-utils/nightly-nightly-cryptic-emoji-decode/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "emoji-decoder"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.4", features = ["derive"] }

--- a/rust-utils/nightly-nightly-cryptic-emoji-decode/README.md
+++ b/rust-utils/nightly-nightly-cryptic-emoji-decode/README.md
@@ -1,0 +1,33 @@
+# nightly-cryptic-emoji-decoder
+
+A whimsical CLI tool that translates a sequence of emojis into a readable phrase using a built‑in dictionary. Useful for quick fun decoding or generating secret messages.
+
+## Installation
+
+```sh
+cargo install --path .
+```
+
+## Usage
+
+```sh
+emoji-decoder "🚀 🌕"
+# => launch moon
+```
+
+Supported emojis:
+
+- 🚀 → launch
+- 🌕 → moon
+- 🔥 → fire
+- 💧 → water
+- ⚡ → electric
+- 🧊 → ice
+- 🌟 → star
+- 🪐 → planet
+- 👽 → alien
+- 🤖 → robot
+
+## License
+
+MIT

--- a/rust-utils/nightly-nightly-cryptic-emoji-decode/src/main.rs
+++ b/rust-utils/nightly-nightly-cryptic-emoji-decode/src/main.rs
@@ -1,0 +1,45 @@
+use clap::Parser;
+use std::collections::HashMap;
+
+/// Simple emoji to word decoder
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Emoji sequence (e.g., "🚀 🌕")
+    input: String,
+}
+
+fn build_dict() -> HashMap<&'static str, &'static str> {
+    let mut m = HashMap::new();
+    m.insert("🚀", "launch");
+    m.insert("🌕", "moon");
+    m.insert("🔥", "fire");
+    m.insert("💧", "water");
+    m.insert("⚡", "electric");
+    m.insert("🧊", "ice");
+    m.insert("🌟", "star");
+    m.insert("🪐", "planet");
+    m.insert("👽", "alien");
+    m.insert("🤖", "robot");
+    m
+}
+
+fn decode(input: &str, dict: &HashMap<&str, &str>) -> String {
+    let tokens: Vec<&str> = input.split_whitespace().collect();
+    let mut words = Vec::new();
+    for token in tokens {
+        if let Some(&w) = dict.get(token) {
+            words.push(w);
+        } else {
+            words.push("[unknown]");
+        }
+    }
+    words.join(" ")
+}
+
+fn main() {
+    let args = Args::parse();
+    let dict = build_dict();
+    let result = decode(&args.input, &dict);
+    println!("{}", result);
+}

--- a/rust-utils/nightly-nightly-cryptic-emoji-decode/tests/integration_test.rs
+++ b/rust-utils/nightly-nightly-cryptic-emoji-decode/tests/integration_test.rs
@@ -1,0 +1,21 @@
+#[test]
+fn test_decode_known() {
+    // Run the binary with a known emoji sequence
+    let output = std::process::Command::new("cargo")
+        .args(&["run", "--quiet", "--", "🚀 🌕"])
+        .output()
+        .expect("failed to execute cargo run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "launch moon");
+}
+
+#[test]
+fn test_decode_unknown() {
+    // Run the binary with an emoji that is not in the dictionary
+    let output = std::process::Command::new("cargo")
+        .args(&["run", "--quiet", "--", "🦄"])
+        .output()
+        .expect("failed to execute cargo run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "[unknown]");
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-cryptic-emoji-decoder
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-cryptic-emoji-decode`
- **Files Created**: 4
- **Description**: A whimsical CLI tool that translates a sequence of emojis into a readable phrase using a built‑in dictionary.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-cryptic-emoji-decode`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-cryptic-emoji-decode/README.md`
- Run tests located in `rust-utils/nightly-nightly-cryptic-emoji-decode/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.