### PR TITLE
feat(groq): CLI tool that sums radiation doses from a CSV and warns if a threshold is exceeded

### DIFF
--- a/rust-utils/nightly-nightly-radiation-exposure-t/README.md
+++ b/rust-utils/nightly-nightly-radiation-exposure-t/README.md
@@ -1,0 +1,11 @@
+Nightly Radiation Exposure Tracker
+A tiny CLI tool that reads a CSV of radiation exposure events and reports the total dose. Optionally warns if a threshold is exceeded.
+
+Usage:
+  nightly-radiation-exposure-tracker <file> [threshold]
+
+The CSV should have two columns: timestamp,dose (dose in mSv). Example:
+2023-01-01T12:00:00Z,0.5
+2023-01-02T08:30:00Z,1.2
+
+If a threshold is provided, the tool prints a warning when total dose > threshold.

--- a/rust-utils/nightly-nightly-radiation-exposure-t/src/lib.rs
+++ b/rust-utils/nightly-nightly-radiation-exposure-t/src/lib.rs
@@ -1,0 +1,29 @@
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+
+/// Parses a CSV file at `path` and returns the sum of the dose column.
+///
+/// The CSV must have exactly two columns per line: `<timestamp>,<dose>`.
+/// Empty lines are ignored. Returns an error string on any problem.
+pub fn parse_and_compute(path: &str) -> Result<f64, String> {
+    let file = File::open(path).map_err(|e| format!("Failed to open file: {}", e))?;
+    let reader = BufReader::new(file);
+    let mut total = 0.0_f64;
+    for (idx, line_res) in reader.lines().enumerate() {
+        let line = line_res.map_err(|e| format!("Error reading line {}: {}", idx + 1, e))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = trimmed.split(',').collect();
+        if parts.len() != 2 {
+            return Err(format!("Invalid format on line {}: {}", idx + 1, trimmed));
+        }
+        let dose_str = parts[1].trim();
+        let dose: f64 = dose_str
+            .parse()
+            .map_err(|_| format!("Invalid dose on line {}: {}", idx + 1, dose_str))?;
+        total += dose;
+    }
+    Ok(total)
+}

--- a/rust-utils/nightly-nightly-radiation-exposure-t/src/main.rs
+++ b/rust-utils/nightly-nightly-radiation-exposure-t/src/main.rs
@@ -1,0 +1,35 @@
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <file> [threshold]", args[0]);
+        std::process::exit(1);
+    }
+    let file_path = &args[1];
+    let threshold: Option<f64> = if args.len() >= 3 {
+        match args[2].parse() {
+            Ok(v) => Some(v),
+            Err(_) => {
+                eprintln!("Invalid threshold value: {}", args[2]);
+                std::process::exit(1);
+            }
+        }
+    } else {
+        None
+    };
+    match nightly_radiation_exposure_tracker::parse_and_compute(file_path) {
+        Ok(total) => {
+            println!("Total dose: {:.3} mSv", total);
+            if let Some(th) = threshold {
+                if total > th {
+                    println!("Warning: total dose exceeds threshold of {:.3} mSv!", th);
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/rust-utils/nightly-nightly-radiation-exposure-t/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-radiation-exposure-t/tests/test_main.rs
@@ -1,0 +1,29 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::env;
+
+#[test]
+fn test_parse_and_compute_valid() {
+    // Mock rationale: create a temporary CSV file with known dose values.
+    let mut tmp_path = env::temp_dir();
+    tmp_path.push("test_exposure_valid.csv");
+    let mut file = File::create(&tmp_path).expect("create temp file");
+    writeln!(file, "2023-01-01T12:00:00Z,0.5").unwrap();
+    writeln!(file, "2023-01-02T08:30:00Z,1.2").unwrap();
+    let result = nightly_radiation_exposure_tracker::parse_and_compute(tmp_path.to_str().unwrap());
+    assert_eq!(result.unwrap(), 1.7);
+    std::fs::remove_file(tmp_path).unwrap();
+}
+
+#[test]
+fn test_parse_and_compute_invalid_format() {
+    // Mock rationale: create a temporary CSV with a malformed line.
+    let mut tmp_path = env::temp_dir();
+    tmp_path.push("test_exposure_invalid.csv");
+    let mut file = File::create(&tmp_path).expect("create temp file");
+    writeln!(file, "bad_line_without_comma").unwrap();
+    let result = nightly_radiation_exposure_tracker::parse_and_compute(tmp_path.to_str().unwrap());
+    assert!(result.is_err());
+    std::fs::remove_file(tmp_path).unwrap();
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-radiation-exposure-tracker
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-radiation-exposure-t`
- **Files Created**: 4
- **Description**: CLI tool that sums radiation doses from a CSV and warns if a threshold is exceeded

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-radiation-exposure-t`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-radiation-exposure-t/README.md`
- Run tests located in `rust-utils/nightly-nightly-radiation-exposure-t/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.