### PR TITLE
feat(groq): An Ansible playbook that sets up an apt-mirror for offline package caching and optional sync to client hosts, perfect for post‑apocalyptic environments.

### DIFF
--- a/ansible-playbooks/nightly-nightly-ansible-apt-mirror-s/README.md
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-mirror-s/README.md
@@ -1,0 +1,22 @@
+# nightly-ansible-apt-mirror-sync
+
+Utility to set up an apt-mirror on a host and optionally sync it to other hosts, enabling offline package installation in a post‑apocalyptic environment.
+
+## Usage
+
+```bash
+ansible-playbook -i inventory.ini src/playbook.yml
+```
+
+## Variables
+
+- `mirror_url`: URL of the upstream mirror (default: `http://archive.ubuntu.com/ubuntu`)
+- `target_dir`: directory where the mirror is stored (default: `/var/spool/apt-mirror`)
+
+## Inventory
+
+Create an `inventory.ini` file (see `src/inventory.ini`) with a `[mirror]` group for the host that will host the mirror and an optional `[clients]` group for hosts that should receive a synced copy.
+
+## License
+
+MIT

--- a/ansible-playbooks/nightly-nightly-ansible-apt-mirror-s/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-mirror-s/src/inventory.ini
@@ -1,0 +1,6 @@
+[mirror]
+mirror-host ansible_host=127.0.0.1 ansible_user=root
+
+[clients]
+# Add client hosts here, e.g.,
+# client1 ansible_host=192.168.1.10 ansible_user=root

--- a/ansible-playbooks/nightly-nightly-ansible-apt-mirror-s/src/playbook.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-mirror-s/src/playbook.yml
@@ -1,0 +1,42 @@
+---
+- name: Setup apt-mirror for offline package cache
+  hosts: mirror
+  become: true
+  vars:
+    mirror_url: "{{ mirror_url | default('http://archive.ubuntu.com/ubuntu') }}"
+    target_dir: "{{ target_dir | default('/var/spool/apt-mirror') }}"
+  tasks:
+    - name: Ensure apt-mirror package is installed
+      apt:
+        name: apt-mirror
+        state: present
+        update_cache: yes
+
+    - name: Create mirror configuration
+      copy:
+        dest: /etc/apt/mirror.list
+        content: |
+          set base_path {{ target_dir }}
+          set defaultarch amd64
+          set nthreads 20
+          set _tilde 0
+          deb {{ mirror_url }} focal main restricted universe multiverse
+          deb {{ mirror_url }} focal-updates main restricted universe multiverse
+          deb {{ mirror_url }} focal-security main restricted universe multiverse
+        mode: '0644'
+
+    - name: Run apt-mirror to download packages
+      command: apt-mirror
+      args:
+        creates: "{{ target_dir }}/var"
+
+    - name: Ensure rsync is installed for optional sync
+      apt:
+        name: rsync
+        state: present
+
+    - name: Sync mirror to secondary hosts (optional)
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups['clients'] | default([]) }}"
+      command: rsync -a --delete {{ target_dir }}/ {{ item }}:{{ target_dir }}/
+      when: groups['clients'] is defined and groups['clients'] | length > 0

--- a/ansible-playbooks/nightly-nightly-ansible-apt-mirror-s/tests/test_playbook.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-mirror-s/tests/test_playbook.yml
@@ -1,0 +1,9 @@
+- name: Verify apt-mirror playbook syntax
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Run syntax check
+      command: ansible-playbook -i ../src/inventory.ini ../src/playbook.yml --syntax-check
+      register: result
+      changed_when: false
+      failed_when: result.rc != 0


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansible-apt-mirror-sync
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-ansible-apt-mirror-s`
- **Files Created**: 4
- **Description**: An Ansible playbook that sets up an apt-mirror for offline package caching and optional sync to client hosts, perfect for post‑apocalyptic environments.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-ansible-apt-mirror-s`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-ansible-apt-mirror-s/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-ansible-apt-mirror-s/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.