### PR TITLE
feat(groq): CLI tool that estimates the maximum safe exposure time to radiation given a constant radiation level and a dose limit.

### DIFF
--- a/rust-utils/nightly-nightly-radiation-exposure-c/README.md
+++ b/rust-utils/nightly-nightly-radiation-exposure-c/README.md
@@ -1,0 +1,38 @@
+# nightly-radiation-exposure-calculator
+
+Estimate the maximum safe exposure time to radiation given a constant radiation level and a dose limit.
+
+## Usage
+
+```sh
+cargo run --quiet -- <radiation_uSv_per_h> <dose_limit_mSv>
+```
+
+Example:
+
+```sh
+cargo run --quiet -- 250 0.5
+```
+
+Outputs:
+
+```
+2.00
+```
+
+## Building without Cargo
+
+If you prefer to compile directly with `rustc`:
+
+```sh
+rustc src/main.rs -o radiation_calc
+./radiation_calc 250 0.5
+```
+
+## Testing
+
+```sh
+cargo test
+```
+
+The test suite verifies the core calculation logic and the CLI output.

--- a/rust-utils/nightly-nightly-radiation-exposure-c/src/lib.rs
+++ b/rust-utils/nightly-nightly-radiation-exposure-c/src/lib.rs
@@ -1,0 +1,6 @@
+pub fn max_exposure_hours(radiation_uSv_per_h: f64, dose_limit_mSv: f64) -> f64 {
+    if radiation_uSv_per_h <= 0.0 {
+        return f64::INFINITY;
+    }
+    dose_limit_mSv * 1000.0 / radiation_uSv_per_h
+}

--- a/rust-utils/nightly-nightly-radiation-exposure-c/src/main.rs
+++ b/rust-utils/nightly-nightly-radiation-exposure-c/src/main.rs
@@ -1,0 +1,40 @@
+mod lib;
+use lib::max_exposure_hours;
+use std::env;
+use std::process;
+
+fn print_usage() {
+    eprintln!("Usage: <radiation_uSv_per_h> <dose_limit_mSv>");
+}
+
+fn parse_arg(arg: &str) -> Result<f64, std::num::ParseFloatError> {
+    arg.parse::<f64>()
+}
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+    if args.len() != 2 {
+        print_usage();
+        process::exit(1);
+    }
+    let radiation = match parse_arg(&args[0]) {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("Invalid radiation value");
+            process::exit(1);
+        }
+    };
+    let dose = match parse_arg(&args[1]) {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("Invalid dose limit value");
+            process::exit(1);
+        }
+    };
+    let hours = max_exposure_hours(radiation, dose);
+    if hours.is_infinite() {
+        println!("Infinity (radiation level is zero)");
+    } else {
+        println!("{:.2}", hours);
+    }
+}

--- a/rust-utils/nightly-nightly-radiation-exposure-c/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-radiation-exposure-c/tests/test_main.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+
+#[test]
+fn test_cli_output() {
+    // Mock rationale: compile the CLI tool locally for a deterministic test
+    let compile = Command::new("rustc")
+        .args(&["src/main.rs", "-o", "radcalc"])
+        .output()
+        .expect("Failed to compile the utility");
+    assert!(compile.status.success(), "Compilation failed: {}", String::from_utf8_lossy(&compile.stderr));
+
+    // Run the compiled binary with known inputs
+    let run = Command::new("./radcalc")
+        .args(&["250", "0.5"])
+        .output()
+        .expect("Failed to execute the utility");
+    assert!(run.status.success(), "Execution failed: {}", String::from_utf8_lossy(&run.stderr));
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(stdout.trim(), "2.00");
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-radiation-exposure-calculator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-radiation-exposure-c`
- **Files Created**: 4
- **Description**: CLI tool that estimates the maximum safe exposure time to radiation given a constant radiation level and a dose limit.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-radiation-exposure-c`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-radiation-exposure-c/README.md`
- Run tests located in `rust-utils/nightly-nightly-radiation-exposure-c/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.