### PR TITLE
feat(groq): GitHub Action that enforces a minimum pull request title length to keep PRs descriptive.

### DIFF
--- a/github-actions/nightly-nightly-pr-title-guard/README.md
+++ b/github-actions/nightly-nightly-pr-title-guard/README.md
@@ -1,0 +1,30 @@
+# PR Title Guard
+
+A lightweight GitHub Action that ensures pull request titles meet a configurable minimum length. Prevents vague or empty titles, encouraging clearer communication.
+
+## Usage
+
+```yaml
+name: PR Title Guard
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  title-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check PR title length
+        uses: ./  # assuming the action lives at the repository root
+        with:
+          min_length: 15
+```
+
+## Inputs
+
+- `min_length` (default: `10`): Minimum number of characters required for the PR title.
+
+## How it works
+
+The action reads the event payload from `GITHUB_EVENT_PATH`, extracts the PR title, and fails the job if the title is shorter than `min_length`.

--- a/github-actions/nightly-nightly-pr-title-guard/src/action.yml
+++ b/github-actions/nightly-nightly-pr-title-guard/src/action.yml
@@ -1,0 +1,17 @@
+name: "PR Title Guard"
+description: "Fail if PR title is shorter than a configurable minimum length."
+author: "ApocalypsAI"
+
+inputs:
+  min_length:
+    description: "Minimum title length"
+    required: false
+    default: "10"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check PR title
+      shell: bash
+      run: |
+        "${{ github.action_path }}/check_title.sh" "${{ inputs.min_length }}"

--- a/github-actions/nightly-nightly-pr-title-guard/src/check_title.sh
+++ b/github-actions/nightly-nightly-pr-title-guard/src/check_title.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MIN_LENGTH="${1}"
+EVENT_PATH="${GITHUB_EVENT_PATH:-}"
+
+if [[ -z "${EVENT_PATH}" ]]; then
+  echo "::error::GITHUB_EVENT_PATH is not set."
+  exit 1
+fi
+
+# Extract title using jq (assume jq is available)
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::error::jq is required but not installed."
+  exit 1
+fi
+
+TITLE=$(jq -r .pull_request.title "${EVENT_PATH}")
+
+if [[ -z "${TITLE}" ]]; then
+  echo "::error::Could not find pull request title in event payload."
+  exit 1
+fi
+
+TITLE_LENGTH=${#TITLE}
+
+if (( TITLE_LENGTH < MIN_LENGTH )); then
+  echo "::error::PR title is too short (${TITLE_LENGTH} < ${MIN_LENGTH})."
+  exit 1
+else
+  echo "PR title length (${TITLE_LENGTH}) meets minimum (${MIN_LENGTH})."
+fi

--- a/github-actions/nightly-nightly-pr-title-guard/tests/test_check_title.sh
+++ b/github-actions/nightly-nightly-pr-title-guard/tests/test_check_title.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../src" && pwd)"
+CHECK_SCRIPT="${SCRIPT_DIR}/check_title.sh"
+
+# Helper to run a test case
+run_test() {
+  local name="$1"
+  local json_content="$2"
+  local min_len="$3"
+  local expect_success="$4"
+
+  tmpfile=$(mktemp)
+  echo "${json_content}" > "${tmpfile}"
+  export GITHUB_EVENT_PATH="${tmpfile}"
+
+  if "${CHECK_SCRIPT}" "${min_len}"; then
+    result=0
+  else
+    result=1
+  fi
+
+  if [[ "${result}" -eq 0 && "${expect_success}" == "true" ]] || [[ "${result}" -ne 0 && "${expect_success}" == "false" ]]; then
+    echo "PASS: ${name}"
+  else
+    echo "FAIL: ${name}"
+    exit 1
+  fi
+
+  rm -f "${tmpfile}"
+}
+
+# Test 1: sufficient length
+run_test "sufficient-length" '{"pull_request":{"title":"Add comprehensive documentation for the new API"}}' 10 true
+
+# Test 2: too short
+run_test "too-short" '{"pull_request":{"title":"Fix"}}' 10 false
+
+echo "All tests passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-pr-title-guard
- **Provider**: groq
- **Location**: `github-actions/nightly-nightly-pr-title-guard`
- **Files Created**: 4
- **Description**: GitHub Action that enforces a minimum pull request title length to keep PRs descriptive.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `github-actions/nightly-nightly-pr-title-guard`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `github-actions/nightly-nightly-pr-title-guard/README.md`
- Run tests located in `github-actions/nightly-nightly-pr-title-guard/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.