### PR TITLE
feat(groq): A tiny Go HTTP service that converts timestamps to a target timezone and adds post‑apocalyptic flavor text.

### DIFF
--- a/go-utils/nightly-nightly-wasteland-timezone-t/README.md
+++ b/go-utils/nightly-nightly-wasteland-timezone-t/README.md
@@ -1,0 +1,37 @@
+# Wasteland Timezone Teleporter
+
+A tiny Go HTTP service that converts a given timestamp to a target timezone and adds a post‑apocalyptic flavor text.
+
+## Usage
+
+```sh
+go run src/main.go
+```
+
+The server listens on `localhost:8080`. Make a request like:
+
+```
+GET /teleport?time=2023-01-01T15:04:05Z&tz=America/New_York
+```
+
+### Response
+
+```json
+{
+  "original": "2023-01-01T15:04:05Z",
+  "target": "2023-01-01T10:04:05-05:00",
+  "message": "The sun rises over the rusted ruins."
+}
+```
+
+## Build
+
+```sh
+go build -o teleporter src/main.go
+```
+
+## Tests
+
+```sh
+go test ./...
+```

--- a/go-utils/nightly-nightly-wasteland-timezone-t/src/main.go
+++ b/go-utils/nightly-nightly-wasteland-timezone-t/src/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "log"
+    "net/http"
+    "time"
+    "hash/crc32"
+)
+
+type response struct {
+    Original string `json:"original"`
+    Target   string `json:"target"`
+    Message  string `json:"message"`
+}
+
+var messages = []string{
+    "The sun rises over the rusted ruins.",
+    "Radiation whispers through the broken glass.",
+    "Dust devils dance on the cracked asphalt.",
+    "A lone crow caws over the silent city.",
+    "The wind carries the scent of ozone.",
+}
+
+func getMessage(tz string) string {
+    idx := int(crc32.ChecksumIEEE([]byte(tz))) % len(messages)
+    return messages[idx]
+}
+
+func teleportHandler(w http.ResponseWriter, r *http.Request) {
+    timeStr := r.URL.Query().Get("time")
+    tzStr := r.URL.Query().Get("tz")
+    if timeStr == "" || tzStr == "" {
+        http.Error(w, "missing time or tz parameter", http.StatusBadRequest)
+        return
+    }
+    t, err := time.Parse(time.RFC3339, timeStr)
+    if err != nil {
+        http.Error(w, "invalid time format", http.StatusBadRequest)
+        return
+    }
+    loc, err := time.LoadLocation(tzStr)
+    if err != nil {
+        http.Error(w, "invalid timezone", http.StatusBadRequest)
+        return
+    }
+    target := t.In(loc)
+    resp := response{
+        Original: t.Format(time.RFC3339),
+        Target:   target.Format(time.RFC3339),
+        Message:  getMessage(tzStr),
+    }
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(resp)
+}
+
+func main() {
+    http.HandleFunc("/teleport", teleportHandler)
+    fmt.Println("Listening on :8080")
+    log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/go-utils/nightly-nightly-wasteland-timezone-t/tests/main_test.go
+++ b/go-utils/nightly-nightly-wasteland-timezone-t/tests/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+func TestTeleportHandler(t *testing.T) {
+    req := httptest.NewRequest("GET", "/teleport?time=2023-01-01T15:04:05Z&tz=UTC", nil)
+    w := httptest.NewRecorder()
+    teleportHandler(w, req)
+
+    if w.Code != http.StatusOK {
+        t.Fatalf("expected status 200, got %d", w.Code)
+    }
+
+    var resp response
+    err := json.NewDecoder(w.Body).Decode(&resp)
+    if err != nil {
+        t.Fatalf("failed to decode response: %v", err)
+    }
+
+    expectedOriginal := "2023-01-01T15:04:05Z"
+    if resp.Original != expectedOriginal {
+        t.Errorf("original mismatch: got %s, want %s", resp.Original, expectedOriginal)
+    }
+
+    expectedTarget := "2023-01-01T15:04:05Z"
+    if resp.Target != expectedTarget {
+        t.Errorf("target mismatch: got %s, want %s", resp.Target, expectedTarget)
+    }
+
+    // Deterministic message based on tz "UTC"
+    expectedMessage := getMessage("UTC")
+    if resp.Message != expectedMessage {
+        t.Errorf("message mismatch: got %s, want %s", resp.Message, expectedMessage)
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-wasteland-timezone-teleporter
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-wasteland-timezone-t`
- **Files Created**: 3
- **Description**: A tiny Go HTTP service that converts timestamps to a target timezone and adds post‑apocalyptic flavor text.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-wasteland-timezone-t`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-wasteland-timezone-t/README.md`
- Run tests located in `go-utils/nightly-nightly-wasteland-timezone-t/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.