### PR TITLE
feat(groq): Generates whimsical, Latin‑styled plant names for world‑building or games.

### DIFF
--- a/rust-utils/nightly-nightly-cryptic-plant-namer-2/rust-utils/nightly-cryptic-plant-namer/Cargo.toml
+++ b/rust-utils/nightly-nightly-cryptic-plant-namer-2/rust-utils/nightly-cryptic-plant-namer/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cryptic-plant-namer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = "0.8"

--- a/rust-utils/nightly-nightly-cryptic-plant-namer-2/rust-utils/nightly-cryptic-plant-namer/README.md
+++ b/rust-utils/nightly-nightly-cryptic-plant-namer-2/rust-utils/nightly-cryptic-plant-namer/README.md
@@ -1,0 +1,32 @@
+# Cryptic Plant Namer
+
+A tiny Rust CLI that conjures whimsical, Latin‑flavored plant names. Perfect for writers, game masters, or anyone who needs a touch of botanical mystery.
+
+## Usage
+
+```sh
+cargo run --quiet
+```
+
+Each execution prints a random plant name, e.g.:
+
+```
+Radiant petalus
+```
+
+You can also use the library directly:
+
+```rust
+use cryptic_plant_namer::generate_name;
+let name = generate_name(0, 2); // "Gleaming petalus"
+```
+
+## How it works
+
+The tool picks an adjective from a short list and combines it with a Latin‑style suffix. The `generate_name` function is deterministic given indices, making it easy to test.
+
+## Testing
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-cryptic-plant-namer-2/rust-utils/nightly-cryptic-plant-namer/src/lib.rs
+++ b/rust-utils/nightly-nightly-cryptic-plant-namer-2/rust-utils/nightly-cryptic-plant-namer/src/lib.rs
@@ -1,0 +1,20 @@
+pub const ADJECTIVES: &[&str] = &["Gleaming", "Mournful", "Silent", "Radiant", "Twisted"];
+pub const SUFFIXES: &[&str] = &["folia", "barkus", "petalus", "rootus", "stemma"];
+
+/// Generate a plant name from explicit indices.
+///
+/// This function is deterministic and used by the test suite.
+pub fn generate_name(adjective_idx: usize, suffix_idx: usize) -> String {
+    let adj = ADJECTIVES.get(adjective_idx % ADJECTIVES.len()).unwrap_or(&"Mystic");
+    let suf = SUFFIXES.get(suffix_idx % SUFFIXES.len()).unwrap_or(&"flora");
+    format!("{} {}", adj, suf)
+}
+
+/// Generate a random plant name using the `rand` crate.
+pub fn random_name() -> String {
+    use rand::Rng;
+    let mut rng = rand::thread_rng();
+    let adj_idx = rng.gen_range(0..ADJECTIVES.len());
+    let suf_idx = rng.gen_range(0..SUFFIXES.len());
+    generate_name(adj_idx, suf_idx)
+}

--- a/rust-utils/nightly-nightly-cryptic-plant-namer-2/rust-utils/nightly-cryptic-plant-namer/src/main.rs
+++ b/rust-utils/nightly-nightly-cryptic-plant-namer-2/rust-utils/nightly-cryptic-plant-namer/src/main.rs
@@ -1,0 +1,5 @@
+use cryptic_plant_namer::random_name;
+
+fn main() {
+    println!("{}", random_name());
+}

--- a/rust-utils/nightly-nightly-cryptic-plant-namer-2/rust-utils/nightly-cryptic-plant-namer/tests/test_generate.rs
+++ b/rust-utils/nightly-nightly-cryptic-plant-namer-2/rust-utils/nightly-cryptic-plant-namer/tests/test_generate.rs
@@ -1,0 +1,19 @@
+#[cfg(test)]
+mod tests {
+    use cryptic_plant_namer::generate_name;
+
+    #[test]
+    fn test_generate_name_known_indices() {
+        let name = generate_name(0, 0);
+        assert_eq!(name, "Gleaming folia");
+        let name2 = generate_name(3, 4);
+        assert_eq!(name2, "Radiant stemma");
+    }
+
+    #[test]
+    fn test_generate_name_wraparound() {
+        // 10 % 5 = 0, 7 % 5 = 2
+        let name = generate_name(10, 7);
+        assert_eq!(name, "Gleaming petalus");
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-cryptic-plant-namer
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-cryptic-plant-namer-2`
- **Files Created**: 5
- **Description**: Generates whimsical, Latin‑styled plant names for world‑building or games.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-cryptic-plant-namer-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-cryptic-plant-namer-2/README.md`
- Run tests located in `rust-utils/nightly-nightly-cryptic-plant-namer-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.