### PR TITLE
feat(groq): A whimsical CLI that prints post‑apocalyptic themed quotes, optionally filtered by category.

### DIFF
--- a/rust-utils/nightly-nightly-apocalypse-quote-cli/Cargo.toml
+++ b/rust-utils/nightly-nightly-apocalypse-quote-cli/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "nightly-apocalypse-quote-cli"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = "0.8"

--- a/rust-utils/nightly-nightly-apocalypse-quote-cli/README.md
+++ b/rust-utils/nightly-nightly-apocalypse-quote-cli/README.md
@@ -1,0 +1,26 @@
+# Nightly Apocalypse Quote CLI
+
+A whimsical command‑line tool that serves post‑apocalyptic themed quotes to brighten your terminal. Choose a category or let fate decide.
+
+## Installation
+
+```sh
+cargo install --path .
+```
+
+## Usage
+
+```sh
+nightly-apocalypse-quote-cli          # random quote
+nightly-apocalypse-quote-cli --category survival   # quote from survival category
+```
+
+## Categories
+
+- survival
+- wisdom
+- humor
+
+## License
+
+MIT

--- a/rust-utils/nightly-nightly-apocalypse-quote-cli/src/main.rs
+++ b/rust-utils/nightly-nightly-apocalypse-quote-cli/src/main.rs
@@ -1,0 +1,70 @@
+use rand::{Rng, SeedableRng};
+use rand::rngs::StdRng;
+use std::env;
+
+static SURVIVAL_QUOTES: &[&str] = &[
+    "When the world ends, remember to keep your water filter clean.",
+    "A canned bean a day keeps the radiation away.",
+];
+
+static WISDOM_QUOTES: &[&str] = &[
+    "Even in ruins, a sunrise is still a sunrise.",
+    "Hope is the last battery you’ll ever need.",
+];
+
+static HUMOR_QUOTES: &[&str] = &[
+    "Why did the mutant cross the road? To get to the other side‑effect.",
+    "I told my bunker it was time to upgrade – now it’s a smart bunker.",
+];
+
+fn get_quotes(category: &str) -> &'static [&'static str] {
+    match category {
+        "survival" => SURVIVAL_QUOTES,
+        "wisdom" => WISDOM_QUOTES,
+        "humor" => HUMOR_QUOTES,
+        _ => &[
+            "When in doubt, hoard more canned beans.",
+            "The apocalypse is just a really long power outage.",
+        ],
+    }
+}
+
+fn get_random_quote<R: Rng + ?Sized>(category: Option<&str>, rng: &mut R) -> &'static str {
+    let cat = category.unwrap_or("any");
+    let quotes = get_quotes(cat);
+    let idx = rng.gen_range(0..quotes.len());
+    quotes[idx]
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let mut category: Option<&str> = None;
+    if args.len() > 1 && args[1] == "--category" && args.len() > 2 {
+        category = Some(&args[2]);
+    }
+    // Use thread_rng for normal execution
+    let mut rng = rand::thread_rng();
+    let quote = get_random_quote(category, &mut rng);
+    println!("{}", quote);
+}
+
+// Export for tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+
+    #[test]
+    fn test_survival_category_deterministic() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let quote = get_random_quote(Some("survival"), &mut rng);
+        assert_eq!(quote, "When the world ends, remember to keep your water filter clean.");
+    }
+
+    #[test]
+    fn test_unknown_category_fallback() {
+        let mut rng = StdRng::seed_from_u64(1);
+        let quote = get_random_quote(Some("unknown"), &mut rng);
+        assert_eq!(quote, "When in doubt, hoard more canned beans.");
+    }
+}

--- a/rust-utils/nightly-nightly-apocalypse-quote-cli/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-apocalypse-quote-cli/tests/test_main.rs
@@ -1,0 +1,12 @@
+use std::process::Command;
+
+#[test]
+fn cli_runs_without_args() {
+    // The binary path is provided by Cargo during integration tests
+    let output = Command::new(env!("CARGO_BIN_EXE_nightly-apocalypse-quote-cli"))
+        .output()
+        .expect("failed to execute binary");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.trim().is_empty(), "Expected non‑empty quote output");
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-apocalypse-quote-cli
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-apocalypse-quote-cli`
- **Files Created**: 4
- **Description**: A whimsical CLI that prints post‑apocalyptic themed quotes, optionally filtered by category.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-apocalypse-quote-cli`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-apocalypse-quote-cli/README.md`
- Run tests located in `rust-utils/nightly-nightly-apocalypse-quote-cli/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.