### PR TITLE
feat(groq): A tiny Dockerized Go HTTP server that returns a random whimsical quote on each request.

### DIFF
--- a/docker-tools/nightly-nightly-docker-quote-server-4/Dockerfile
+++ b/docker-tools/nightly-nightly-docker-quote-server-4/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o server .
+
+FROM alpine:latest
+COPY --from=builder /app/server /server
+EXPOSE 8080
+ENTRYPOINT ["/server"]

--- a/docker-tools/nightly-nightly-docker-quote-server-4/README.md
+++ b/docker-tools/nightly-nightly-docker-quote-server-4/README.md
@@ -1,0 +1,26 @@
+# Nightly Docker Quote Server
+
+A whimsical Dockerized Go HTTP service that returns a random quote.
+
+## Usage
+
+```sh
+docker build -t nightly-quote-server .
+docker run -p 8080:8080 nightly-quote-server
+```
+
+Then request a quote:
+
+```sh
+curl http://localhost:8080/quote
+```
+
+Typical response:
+
+```json
+{"quote":"The early bird gets the worm, but the second mouse gets the cheese."}
+```
+
+## How it works
+
+The server picks a random quote from an embedded list each time `/quote` is requested. No external dependencies, perfect for quick morale boosts in CI pipelines or local dev sessions.

--- a/docker-tools/nightly-nightly-docker-quote-server-4/src/main.go
+++ b/docker-tools/nightly-nightly-docker-quote-server-4/src/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+    "encoding/json"
+    "log"
+    "math/rand"
+    "net/http"
+    "time"
+)
+
+var quotes = []string{
+    "The early bird gets the worm, but the second mouse gets the cheese.",
+    "When life gives you lemons, make lemonade… and then find someone whose life gave them vodka.",
+    "I’m not lazy, I’m on energy‑saving mode.",
+    "If at first you don’t succeed, skydiving is not for you.",
+    "Adventure is out there… unless you left it at home.",
+}
+
+type QuoteResponse struct {
+    Quote string `json:"quote"`
+}
+
+func quoteHandler(w http.ResponseWriter, r *http.Request) {
+    rand.Seed(time.Now().UnixNano())
+    q := quotes[rand.Intn(len(quotes))]
+    resp := QuoteResponse{Quote: q}
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(resp)
+}
+
+func main() {
+    http.HandleFunc("/quote", quoteHandler)
+    log.Println("Starting server on :8080")
+    if err := http.ListenAndServe(":8080", nil); err != nil {
+        log.Fatalf("Server failed: %v", err)
+    }
+}

--- a/docker-tools/nightly-nightly-docker-quote-server-4/tests/main_test.go
+++ b/docker-tools/nightly-nightly-docker-quote-server-4/tests/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+func TestQuoteHandler(t *testing.T) {
+    req := httptest.NewRequest(http.MethodGet, "/quote", nil)
+    w := httptest.NewRecorder()
+    quoteHandler(w, req)
+
+    resp := w.Result()
+    if resp.StatusCode != http.StatusOK {
+        t.Fatalf("expected status 200, got %d", resp.StatusCode)
+    }
+    var qr QuoteResponse
+    if err := json.NewDecoder(resp.Body).Decode(&qr); err != nil {
+        t.Fatalf("failed to decode json: %v", err)
+    }
+    // Verify the quote is one of the known quotes
+    found := false
+    for _, q := range quotes {
+        if q == qr.Quote {
+            found = true
+            break
+        }
+    }
+    if !found {
+        t.Fatalf("unexpected quote: %s", qr.Quote)
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-docker-quote-server
- **Provider**: groq
- **Location**: `docker-tools/nightly-nightly-docker-quote-server-4`
- **Files Created**: 4
- **Description**: A tiny Dockerized Go HTTP server that returns a random whimsical quote on each request.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `docker-tools/nightly-nightly-docker-quote-server-4`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `docker-tools/nightly-nightly-docker-quote-server-4/README.md`
- Run tests located in `docker-tools/nightly-nightly-docker-quote-server-4/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.