### PR TITLE
feat(gemini): An Ansible playbook to maintain digital garden markdown files by checking tags, links, and archiving old content.

### DIFF
--- a/ansible-playbooks/nightly-nightly-digital-garden-keepe/README.md
+++ b/ansible-playbooks/nightly-nightly-digital-garden-keepe/README.md
@@ -1,0 +1,59 @@
+# Nightly Digital Garden Keeper
+
+This Ansible playbook helps maintain a collection of markdown files, often referred to as a "digital garden" or knowledge base. It automates several common maintenance tasks:
+
+- **Tag Validation**: Identifies markdown files that are missing required YAML front matter tags or have empty tag fields.
+- **Broken Link Detection**: Scans for internal markdown links (`[text](link.md)`) that point to non-existent local files.
+- **Content Archiving**: Moves old markdown files (based on their modification time) into a designated archive directory.
+- **Report Generation**: Creates a summary report of all findings.
+
+## Usage
+
+1.  **Define your inventory**: Ensure you have a `localhost` entry in your `inventory.ini` file, as this playbook runs locally.
+
+    ```ini
+    [localhost]
+    localhost ansible_connection=local
+    ```
+
+2.  **Configure variables**: Adjust the `garden_path`, `archive_path`, `archive_after_days`, `required_tags_field`, and `required_date_field` in `src/vars/main.yml` or pass them as extra variables (`-e`).
+
+    - `garden_path`: The root directory of your digital garden markdown files.
+    - `archive_path`: The directory where old files will be moved.
+    - `archive_after_days`: Files older than this many days will be archived.
+    - `required_tags_field`: The YAML front matter field name expected for tags (e.g., `tags`).
+    - `required_date_field`: The YAML front matter field name expected for the date (e.g., `date`).
+
+3.  **Run the playbook**:
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/garden_keeper.yml
+    ```
+
+    After execution, a `digital_garden_report.md` will be generated in your `garden_path` detailing any issues found and actions taken.
+
+## Example Front Matter
+
+Your markdown files should ideally have YAML front matter like this:
+
+```markdown
+---
+title: My Awesome Note
+tags: [ansible, automation, garden]
+date: 2023-10-27
+---
+
+This is the content of my note.
+
+[Link to another note](another-note.md)
+```
+
+## Testing
+
+To run the tests, navigate to the utility's root directory and execute:
+
+```bash
+ansible-playbook -i tests/inventory.ini tests/test_garden_keeper.yml
+```
+
+This will set up a temporary test environment, run the `garden_keeper.yml` playbook against it, and assert the expected outcomes.

--- a/ansible-playbooks/nightly-nightly-digital-garden-keepe/src/garden_keeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-keepe/src/garden_keeper.yml
@@ -1,0 +1,52 @@
+---
+- name: Digital Garden Keeper Playbook
+  hosts: localhost
+  connection: local
+  gather_facts: no
+
+  vars_files:
+    - vars/main.yml
+
+  tasks:
+    - name: Ensure archive directory exists
+      ansible.builtin.file:
+        path: "{{ archive_path }}"
+        state: directory
+        mode: '0755'
+
+    - name: Find all markdown files
+      ansible.builtin.find:
+        paths: "{{ garden_path }}"
+        patterns: "*.md"
+        recurse: yes
+      register: md_files_found
+
+    - name: Initialize report variables
+      ansible.builtin.set_fact:
+        untagged_files: []
+        old_files_archived: []
+        broken_links_found: []
+        report_summary: {}
+
+    - name: Process each markdown file
+      ansible.builtin.include_tasks: process_file.yml
+      loop: "{{ md_files_found.files }}"
+      loop_control:
+        loop_var: current_file
+
+    - name: Populate report summary
+      ansible.builtin.set_fact:
+        report_summary:
+          total_files_scanned: "{{ md_files_found.files | length }}"
+      # Mock rationale: Uses local variables derived from previous tasks.
+
+    - name: Generate Digital Garden Report
+      ansible.builtin.template:
+        src: "{{ playbook_dir }}/templates/report.j2"
+        dest: "{{ garden_path }}/digital_garden_report.md"
+      vars:
+        report:
+          untagged_files: "{{ untagged_files }}"
+          old_files_archived: "{{ old_files_archived }}"
+          broken_links_found: "{{ broken_links_found }}"
+          summary: "{{ report_summary }}"

--- a/ansible-playbooks/nightly-nightly-digital-garden-keepe/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-digital-garden-keepe/src/inventory.ini
@@ -1,0 +1,2 @@
+[localhost]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-digital-garden-keepe/src/process_file.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-keepe/src/process_file.yml
@@ -1,0 +1,76 @@
+---
+- name: Read file content for {{ current_file.path }}
+  ansible.builtin.slurp:
+    src: "{{ current_file.path }}"
+  register: file_content_slurp
+  # Mock rationale: `slurp` module operates on the local filesystem, which is controlled by the test setup.
+
+- name: Decode file content for {{ current_file.path }}
+  ansible.builtin.set_fact:
+    file_content: "{{ file_content_slurp.content | b64decode }}"
+  # Mock rationale: Decodes local file content, no external calls.
+
+- name: Extract front matter for {{ current_file.path }}
+  ansible.builtin.set_fact:
+    front_matter: "{{ file_content | regex_search('^---\n(.*?)\n---\n', multiline=True, '\\1') | first | from_yaml(default={}) }}"
+  when: file_content | regex_search('^---\n(.*?)\n---\n', multiline=True)
+  # Mock rationale: Uses regex and YAML parsing on local file content, no external calls.
+
+- name: Check for missing or empty '{{ required_tags_field }}' in {{ current_file.path }}
+  ansible.builtin.set_fact:
+    untagged_files: "{{ untagged_files + [current_file.path] }}"
+  when:
+    - front_matter is defined
+    - required_tags_field not in front_matter or
+      (front_matter[required_tags_field] is string and front_matter[required_tags_field] | trim == '') or
+      (front_matter[required_tags_field] is iterable and front_matter[required_tags_field] | length == 0)
+  # Mock rationale: Checks local variable `front_matter` derived from file content.
+
+- name: Find internal markdown links in {{ current_file.path }}
+  ansible.builtin.set_fact:
+    _links_in_file: "{{ file_content | regex_findall('\[[^\]]+\]\\(([^)]+\\.md)\\)') }}"
+  # Mock rationale: Uses regex on local file content.
+
+- name: Validate each internal link in {{ current_file.path }}
+  ansible.builtin.stat:
+    path: "{{ current_file.path | dirname }}/{{ item }}"
+  register: link_stat_result
+  loop: "{{ _links_in_file }}"
+  loop_control:
+    loop_var: link_target
+  when: _links_in_file | length > 0
+  # Mock rationale: `stat` module operates on the local filesystem, which is controlled by the test setup.
+
+- name: Add broken link to list for {{ current_file.path }}
+  ansible.builtin.set_fact:
+    broken_links_found: "{{ broken_links_found + [{ 'source': current_file.path, 'link': link_target, 'target_path': current_file.path | dirname + '/' + link_target }] }}"
+  loop: "{{ _links_in_file }}"
+  loop_control:
+    loop_var: link_target
+    index_var: link_idx
+  when:
+    - link_stat_result.results is defined
+    - not link_stat_result.results[link_idx].stat.exists
+  # Mock rationale: Uses results from previous `stat` task, which is deterministic.
+
+- name: Get file modification time for {{ current_file.path }}
+  ansible.builtin.stat:
+    path: "{{ current_file.path }}"
+  register: file_stat_mtime
+  # Mock rationale: `stat` module operates on the local filesystem, which is controlled by the test setup.
+
+- name: Archive old file {{ current_file.path }} if older than {{ archive_after_days }} days
+  ansible.builtin.command: "mv {{ current_file.path }} {{ archive_path }}/"
+  args:
+    creates: "{{ archive_path }}/{{ current_file.path | basename }}"
+  when:
+    - file_stat_mtime.stat.mtime is defined
+    - (ansible_date_time.epoch | int - file_stat_mtime.stat.mtime) > (archive_after_days * 24 * 60 * 60)
+  register: archive_result
+  # Mock rationale: `command` module operates on the local filesystem. `ansible_date_time.epoch` is a fact, but for testing, we control the `mtime` of test files to simulate age.
+
+- name: Add archived file to list
+  ansible.builtin.set_fact:
+    old_files_archived: "{{ old_files_archived + [current_file.path] }}"
+  when: archive_result.changed
+  # Mock rationale: Uses results from previous `command` task, which is deterministic.

--- a/ansible-playbooks/nightly-nightly-digital-garden-keepe/src/templates/report.j2
+++ b/ansible-playbooks/nightly-nightly-digital-garden-keepe/src/templates/report.j2
@@ -1,0 +1,35 @@
+# Digital Garden Keeper Report - {{ ansible_date_time.date }} {{ ansible_date_time.time }}
+
+## Summary
+- Total files scanned: {{ report.summary.total_files_scanned | default(0) }}
+- Untagged files found: {{ report.untagged_files | length }}
+- Broken links found: {{ report.broken_links_found | length }}
+- Files archived: {{ report.old_files_archived | length }}
+
+## Untagged Files (missing '{{ required_tags_field }}' or empty)
+{% if report.untagged_files %}
+{% for file in report.untagged_files %}
+- {{ file }}
+{% endfor %}
+{% else %}
+_None found._
+{% endif %}
+
+## Broken Internal Links
+{% if report.broken_links_found %}
+{% for link_info in report.broken_links_found %}
+- Source: {{ link_info.source }}
+  Broken Link: `{{ link_info.link }}` (Target: `{{ link_info.target_path }}`)
+{% endfor %}
+{% else %}
+_None found._
+{% endif %}
+
+## Archived Files (older than {{ archive_after_days }} days)
+{% if report.old_files_archived %}
+{% for file in report.old_files_archived %}
+- {{ file }}
+{% endfor %}
+{% else %}
+_None found._
+{% endif %}

--- a/ansible-playbooks/nightly-nightly-digital-garden-keepe/src/vars/main.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-keepe/src/vars/main.yml
@@ -1,0 +1,5 @@
+garden_path: "{{ playbook_dir }}/../garden_content"
+archive_path: "{{ garden_path }}/_archive"
+archive_after_days: 365
+required_tags_field: "tags"
+required_date_field: "date"

--- a/ansible-playbooks/nightly-nightly-digital-garden-keepe/tests/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-digital-garden-keepe/tests/inventory.ini
@@ -1,0 +1,2 @@
+[localhost]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-digital-garden-keepe/tests/test_garden_keeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-keepe/tests/test_garden_keeper.yml
@@ -1,0 +1,121 @@
+---
+- name: Test Digital Garden Keeper Playbook
+  hosts: localhost
+  connection: local
+  gather_facts: no
+
+  vars:
+    test_garden_path: "{{ playbook_dir }}/test_garden_content"
+    test_archive_path: "{{ test_garden_path }}/_archive"
+    test_report_file: "{{ test_garden_path }}/digital_garden_report.md"
+    # Set a very short archive period for testing to ensure files are archived
+    test_archive_after_days: 0.00001 # Effectively archives any file older than a few seconds
+
+  tasks:
+    - name: Clean up previous test environment
+      ansible.builtin.file:
+        path: "{{ test_garden_path }}"
+        state: absent
+      # Mock rationale: Ensures a clean slate for each test run by removing previous test artifacts.
+
+    - name: Create test garden directory
+      ansible.builtin.file:
+        path: "{{ test_garden_path }}"
+        state: directory
+        mode: '0755'
+      # Mock rationale: Sets up the controlled directory structure for testing.
+
+    - name: Create test files
+      ansible.builtin.copy:
+        dest: "{{ test_garden_path }}/{{ item.name }}"
+        content: |
+          ---
+          title: {{ item.title }}
+          {% if item.tags is defined %}tags: {{ item.tags }}{% endif %}
+          date: {{ item.date }}
+          ---
+          This is content for {{ item.name }}.
+          {% if item.link is defined %}[Link to another file]({{ item.link }}){% endif %}
+      loop:
+        - { name: "file_with_tags.md", title: "Tagged File", tags: "[ansible, garden]", date: "2023-01-01" }
+        - { name: "file_no_tags.md", title: "Untagged File", date: "2023-01-01" }
+        - { name: "file_empty_tags.md", title: "Empty Tags File", tags: "[]", date: "2023-01-01" }
+        - { name: "file_with_broken_link.md", title: "Broken Link File", tags: "[test]", date: "2023-01-01", link: "non_existent_file.md" }
+        - { name: "file_with_valid_link.md", title: "Valid Link File", tags: "[test]", date: "2023-01-01", link: "linked_file.md" }
+        - { name: "linked_file.md", title: "Linked File", tags: "[linked]", date: "2023-01-01" }
+        - { name: "old_file.md", title: "Old File", tags: "[old]", date: "2022-01-01" } # This should be archived
+      # Mock rationale: Creates a controlled set of markdown files with specific content and metadata for testing various scenarios.
+
+    - name: Set mtime for old_file.md to ensure archiving
+      ansible.builtin.command: "touch -d '2 days ago' {{ test_garden_path }}/old_file.md"
+      # Mock rationale: Manipulates file system timestamps deterministically to simulate file age for testing the archiving logic.
+
+    - name: Run the Digital Garden Keeper playbook
+      ansible.builtin.include_playbook: "{{ playbook_dir }}/../src/garden_keeper.yml"
+      vars:
+        garden_path: "{{ test_garden_path }}"
+        archive_path: "{{ test_archive_path }}"
+        archive_after_days: "{{ test_archive_after_days }}"
+      # Mock rationale: Executes the target playbook against the controlled test environment.
+
+    - name: Read generated report content
+      ansible.builtin.set_fact:
+        report_content: "{{ lookup('file', test_report_file) }}"
+      # Mock rationale: Reads the generated report file from the controlled test environment for assertion.
+
+    - name: Assert untagged files are reported
+      ansible.builtin.assert:
+        that:
+          - "'{{ test_garden_path }}/file_no_tags.md' in report_content"
+          - "'{{ test_garden_path }}/file_empty_tags.md' in report_content"
+          - "'{{ test_garden_path }}/file_with_tags.md' not in report_content"
+        fail_msg: "Untagged files assertion failed."
+      # Mock rationale: Asserts the content of the locally generated report, which is deterministic.
+
+    - name: Assert broken links are reported
+      ansible.builtin.assert:
+        that:
+          - "'Broken Link: `non_existent_file.md`' in report_content"
+          - "'Broken Link: `linked_file.md`' not in report_content"
+        fail_msg: "Broken links assertion failed."
+      # Mock rationale: Asserts the content of the locally generated report, which is deterministic.
+
+    - name: Stat original old_file.md
+      ansible.builtin.stat:
+        path: "{{ test_garden_path }}/old_file.md"
+      register: stat_old_file
+      # Mock rationale: `stat` module operates on the local filesystem.
+
+    - name: Stat archived old_file.md
+      ansible.builtin.stat:
+        path: "{{ test_archive_path }}/old_file.md"
+      register: stat_archived_file
+      # Mock rationale: `stat` module operates on the local filesystem.
+
+    - name: Assert old file was archived and reported
+      ansible.builtin.assert:
+        that:
+          - "not stat_old_file.stat.exists" # Original file should be gone
+          - "stat_archived_file.stat.exists" # Archived file should exist
+          - "'{{ test_garden_path }}/old_file.md' in report_content" # Should be listed in report
+        fail_msg: "Archived files assertion failed."
+      # Mock rationale: Checks local file system state and report content, both deterministic.
+
+    - name: Assert report file exists
+      ansible.builtin.stat:
+        path: "{{ test_report_file }}"
+      register: report_stat
+      # Mock rationale: `stat` module operates on the local filesystem.
+
+    - name: Assert report file was created
+      ansible.builtin.assert:
+        that:
+          - report_stat.stat.exists
+        fail_msg: "Report file was not created."
+      # Mock rationale: Checks local variable `report_stat` derived from file system.
+
+    - name: Clean up test environment
+      ansible.builtin.file:
+        path: "{{ test_garden_path }}"
+        state: absent
+      # Mock rationale: Cleans up the controlled test environment after tests complete.


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-digital-garden-keeper
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-digital-garden-keepe`
- **Files Created**: 8
- **Description**: An Ansible playbook to maintain digital garden markdown files by checking tags, links, and archiving old content.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-digital-garden-keepe`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-digital-garden-keepe/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-digital-garden-keepe/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.