### PR TITLE
feat(groq): A whimsical Terraform module that creates a mock secret vault with a randomly‑named pet, useful for demo environments and teaching Terraform basics.

### DIFF
--- a/terraform-modules/nightly-nightly-terraform-cryptic-ke/README.md
+++ b/terraform-modules/nightly-nightly-terraform-cryptic-ke/README.md
@@ -1,0 +1,47 @@
+# nightly-terraform-cryptic-keeper
+
+## Overview
+
+`nightly-terraform-cryptic-keeper` is a tiny Terraform module that pretends to provision a secret vault.  It generates a whimsical name using the `random_pet` provider and outputs that name so you can reference it in other resources.
+
+The module is deliberately simple – perfect for:
+
+* Demo environments where you need a placeholder resource.
+* Teaching Terraform basics without touching real cloud APIs.
+* Adding a dash of fun to CI pipelines.
+
+## Usage
+
+```hcl
+module "cryptic_vault" {
+  source = "./nightly-terraform-cryptic-keeper"
+  prefix = "demo"
+}
+
+output "vault_name" {
+  value = module.cryptic_vault.vault_name
+}
+```
+
+## Variables
+
+| Name   | Description                     | Type   | Default |
+|--------|---------------------------------|--------|---------|
+| prefix | Optional prefix for the vault. | string | ""      |
+
+## Outputs
+
+| Name       | Description                                 |
+|------------|---------------------------------------------|
+| vault_name | The generated, whimsical vault name string. |
+
+## Testing
+
+A lightweight Bash test lives under `tests/`. Run it with:
+
+```bash
+cd nightly-terraform-cryptic-keeper
+bash tests/test_module.sh
+```
+
+The test simply validates that the module files contain the expected Terraform blocks.

--- a/terraform-modules/nightly-nightly-terraform-cryptic-ke/main.tf
+++ b/terraform-modules/nightly-nightly-terraform-cryptic-ke/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+  }
+}
+
+resource "random_pet" "vault_name" {
+  length = 2
+}
+
+resource "null_resource" "vault_placeholder" {
+  triggers = {
+    name = var.prefix != "" ? "${var.prefix}-${random_pet.vault_name.id}" : random_pet.vault_name.id
+  }
+  provisioner "local-exec" {
+    command = "echo 'Vault \"${self.triggers.name}\" created (mock)'
+  }
+}

--- a/terraform-modules/nightly-nightly-terraform-cryptic-ke/outputs.tf
+++ b/terraform-modules/nightly-nightly-terraform-cryptic-ke/outputs.tf
@@ -1,0 +1,4 @@
+output "vault_name" {
+  description = "The generated, whimsical vault name"
+  value       = var.prefix != "" ? "${var.prefix}-${random_pet.vault_name.id}" : random_pet.vault_name.id
+}

--- a/terraform-modules/nightly-nightly-terraform-cryptic-ke/tests/test_module.sh
+++ b/terraform-modules/nightly-nightly-terraform-cryptic-ke/tests/test_module.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# test_module.sh – verifies that the Terraform module contains the required blocks.
+# Mock rationale: we avoid invoking the real Terraform binary to keep the test offline and deterministic.
+
+set -euo pipefail
+
+# Helper to assert a pattern exists in a file.
+assert_grep() {
+  local pattern="$1"
+  local file="$2"
+  if ! grep -qE "$pattern" "$file"; then
+    echo "FAIL: Expected pattern '$pattern' not found in $file"
+    exit 1
+  fi
+}
+
+# Check that the required provider block is present.
+assert_grep "required_providers" "main.tf"
+assert_grep "random" "main.tf"
+
+# Check that the random_pet resource is defined.
+assert_grep "resource \"random_pet\"" "main.tf"
+
+# Check that the output is declared.
+assert_grep "output \"vault_name\"" "outputs.tf"
+
+echo "PASS: All required Terraform blocks are present."

--- a/terraform-modules/nightly-nightly-terraform-cryptic-ke/variables.tf
+++ b/terraform-modules/nightly-nightly-terraform-cryptic-ke/variables.tf
@@ -1,0 +1,5 @@
+variable "prefix" {
+  description = "Optional prefix for the vault name"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-terraform-cryptic-keeper
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-terraform-cryptic-ke`
- **Files Created**: 5
- **Description**: A whimsical Terraform module that creates a mock secret vault with a randomly‑named pet, useful for demo environments and teaching Terraform basics.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-terraform-cryptic-ke`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-terraform-cryptic-ke/README.md`
- Run tests located in `terraform-modules/nightly-nightly-terraform-cryptic-ke/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.