### PR TITLE
feat(groq): An Ansible playbook that safely rotates SSH host keys across inventory hosts, backing up old keys and restarting the SSH service.

### DIFF
--- a/ansible-playbooks/nightly-nightly-ansible-ssh-key-rota-5/README.md
+++ b/ansible-playbooks/nightly-nightly-ansible-ssh-key-rota-5/README.md
@@ -1,0 +1,50 @@
+# nightly-ansible-ssh-key-rotator
+
+## Overview
+
+`nightly-ansible-ssh-key-rotator` is a whimsical yet practical Ansible playbook that rotates the SSH host keys on all target machines.  It:
+
+1. **Backs up** the existing host key to a timestamped file.
+2. **Generates** a fresh ECDSA host key.
+3. **Restarts** the SSH daemon so the new key takes effect.
+
+Think of it as a post‑apocalyptic safe‑house routine – every night the doors (keys) get a fresh lock, and the old one is tucked away for later reference.
+
+## Files
+
+- `src/rotate_ssh_keys.yml` – The main playbook.
+- `src/inventory.ini` – Minimal inventory (defaults to `localhost`).
+- `tests/test_rotate_ssh_keys.yml` – Simple integration test that runs the playbook in check mode.
+
+## Usage
+
+```bash
+# Install Ansible if you haven't already
+pip install ansible
+
+# Run the playbook against your inventory
+ansible-playbook -i src/inventory.ini src/rotate_ssh_keys.yml
+```
+
+You can also run the bundled test to ensure the playbook parses correctly:
+
+```bash
+ansible-playbook -i src/inventory.ini tests/test_rotate_ssh_keys.yml
+```
+
+## Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ssh_key_path` | Path to the host key that will be rotated. | `/etc/ssh/ssh_host_ecdsa_key` |
+| `backup_dir` | Directory where old keys are stored. | `/etc/ssh/backup_keys` |
+
+## Safety notes
+
+- The playbook **does not** delete old keys; they are stored with a timestamp.
+- It runs with `become: true`, so you need sudo privileges on the target hosts.
+- On macOS (Darwin) the service restart step is skipped because the service name differs.
+
+---
+
+*Created by the ApocalypsAI Nightly Integrator.*

--- a/ansible-playbooks/nightly-nightly-ansible-ssh-key-rota-5/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-ansible-ssh-key-rota-5/src/inventory.ini
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-ansible-ssh-key-rota-5/src/rotate_ssh_keys.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-ssh-key-rota-5/src/rotate_ssh_keys.yml
@@ -1,0 +1,31 @@
+- name: Rotate SSH host keys
+  hosts: all
+  become: true
+  gather_facts: true
+  vars:
+    ssh_key_path: /etc/ssh/ssh_host_ecdsa_key
+    backup_dir: /etc/ssh/backup_keys
+  tasks:
+    - name: Ensure backup directory exists
+      file:
+        path: "{{ backup_dir }}"
+        state: directory
+        mode: "0700"
+
+    - name: Backup existing SSH host key (if present)
+      copy:
+        src: "{{ ssh_key_path }}"
+        dest: "{{ backup_dir }}/ssh_host_ecdsa_key_{{ ansible_date_time.iso8601_basic_short }}"
+        remote_src: true
+      when: "{{ lookup('file', ssh_key_path, errors='ignore') != '' }}"
+
+    - name: Generate new SSH host key (ECDSA)
+      command: ssh-keygen -t ecdsa -f "{{ ssh_key_path }}" -N ""
+      args:
+        creates: "{{ ssh_key_path }}"
+
+    - name: Restart SSH service (Linux)
+      service:
+        name: ssh
+        state: restarted
+      when: ansible_facts['os_family'] != "Darwin"

--- a/ansible-playbooks/nightly-nightly-ansible-ssh-key-rota-5/tests/test_rotate_ssh_keys.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-ssh-key-rota-5/tests/test_rotate_ssh_keys.yml
@@ -1,0 +1,13 @@
+- name: Test SSH key rotator playbook (check mode)
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include the rotate playbook in check mode
+      import_playbook: "../src/rotate_ssh_keys.yml"
+      vars:
+        ansible_check_mode: true
+
+    - name: Verify playbook completed without errors
+      assert:
+        that:
+          - true


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansible-ssh-key-rotator
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-ansible-ssh-key-rota-5`
- **Files Created**: 4
- **Description**: An Ansible playbook that safely rotates SSH host keys across inventory hosts, backing up old keys and restarting the SSH service.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-ansible-ssh-key-rota-5`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-ansible-ssh-key-rota-5/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-ansible-ssh-key-rota-5/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.