### PR TITLE
feat(groq): Terraform module that provisions a versioned S3 bucket with apocalypse‑ready lifecycle rules and a starter supply object.

### DIFF
--- a/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
@@ -1,0 +1,53 @@
+# nightly‑safehouse‑s3
+
+A whimsical yet practical Terraform module that creates an **S3 Safehouse** – a version‑enabled bucket with lifecycle rules to archive old data to Glacier and a pre‑seeded "starter supply" object.
+
+## Features
+
+- Configurable bucket name prefix
+- Versioning enabled (so you never lose a crucial file)
+- Lifecycle rule: move objects to Glacier after 30 days, delete after 365 days
+- Optional starter supply object (e.g., "Emergency rations.txt")
+- Outputs for bucket ID, ARN, and starter‑supply URL
+
+## Usage
+
+```hcl
+module "safehouse" {
+  source               = "./utils/terraform-modules/nightly-safehouse-s3"
+  bucket_name_prefix   = "my‑post‑apoc"
+  region               = "us-west-2"
+  supply_content       = "Emergency rations: water, beans, and hope."
+}
+
+output "safehouse_bucket" {
+  value = module.safehouse.bucket_id
+}
+```
+
+## Variables
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `bucket_name_prefix` | Prefix for the bucket name (final name will be `${prefix}-${random_id}`) | `string` | `"safehouse"` |
+| `region` | AWS region for the bucket | `string` | `"us-east-1"` |
+| `supply_content` | Content of the starter‑supply object | `string` | `"Emergency rations"` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `bucket_id` | The ID of the created bucket |
+| `bucket_arn` | The ARN of the created bucket |
+| `supply_url` | HTTPS URL of the starter‑supply object |
+
+## Testing
+
+Run the bundled test script:
+
+```bash
+cd utils/terraform-modules/nightly-safehouse-s3/tests
+bash test_module.sh
+```
+
+The script validates the configuration and checks that the expected resources are defined.

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/src/main.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/src/main.tf
@@ -1,0 +1,55 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "random_id" "bucket_suffix" {
+  byte_length = 4
+}
+
+resource "aws_s3_bucket" "safehouse" {
+  bucket = "${var.bucket_name_prefix}-${random_id.bucket_suffix.hex}"
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    id      = "archive-and-delete"
+    enabled = true
+
+    transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "safehouse_block" {
+  bucket = aws_s3_bucket.safehouse.id
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls  = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_object" "starter_supply" {
+  bucket  = aws_s3_bucket.safehouse.id
+  key     = "starter-supply.txt"
+  content = var.supply_content
+  acl     = "private"
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/src/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_id" {
+  description = "The ID of the created S3 bucket"
+  value       = aws_s3_bucket.safehouse.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the created S3 bucket"
+  value       = aws_s3_bucket.safehouse.arn
+}
+
+output "supply_url" {
+  description = "HTTPS URL of the starter‑supply object"
+  value       = "https://s3-${var.region}.amazonaws.com/${aws_s3_bucket.safehouse.id}/starter-supply.txt"
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/src/variables.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/src/variables.tf
@@ -1,0 +1,17 @@
+variable "bucket_name_prefix" {
+  description = "Prefix for the S3 bucket name"
+  type        = string
+  default     = "safehouse"
+}
+
+variable "region" {
+  description = "AWS region where the bucket will be created"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "supply_content" {
+  description = "Content of the starter‑supply object"
+  type        = string
+  default     = "Emergency rations"
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/tests/test_module.sh
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/tests/test_module.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# test_module.sh – deterministic offline test for nightly‑safehouse‑s3
+# Mock rationale: we avoid real AWS calls; we only verify that the generated
+# Terraform files contain the expected resource blocks and variables.
+
+set -euo pipefail
+
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# 1. Ensure required files exist
+for f in main.tf variables.tf outputs.tf; do
+  if [[ ! -f "${MODULE_DIR}/src/${f}" ]]; then
+    echo "Missing ${f} in src/"
+    exit 1
+  fi
+done
+
+# 2. Simple content checks
+if ! grep -q "resource \"aws_s3_bucket\" \"safehouse\"" "${MODULE_DIR}/src/main.tf"; then
+  echo "aws_s3_bucket \"safehouse\" not defined"
+  exit 1
+fi
+
+if ! grep -q "variable \"bucket_name_prefix\"" "${MODULE_DIR}/src/variables.tf"; then
+  echo "bucket_name_prefix variable missing"
+  exit 1
+fi
+
+if ! grep -q "output \"supply_url\"" "${MODULE_DIR}/src/outputs.tf"; then
+  echo "supply_url output missing"
+  exit 1
+fi
+
+# 3. Run terraform validate (offline – no provider download)
+pushd "${MODULE_DIR}/src" > /dev/null
+terraform init -backend=false -get=false > /dev/null 2>&1 || true
+# The init may attempt to download the AWS provider; we suppress errors because we are offline.
+# Validate will succeed as long as the syntax is correct.
+terraform validate -no-color || {
+  echo "terraform validate failed"
+  exit 1
+}
+popd > /dev/null
+
+echo "All checks passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-safehouse-s3
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-safehouse-s3-8`
- **Files Created**: 5
- **Description**: Terraform module that provisions a versioned S3 bucket with apocalypse‑ready lifecycle rules and a starter supply object.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-safehouse-s3-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-safehouse-s3-8/README.md`
- Run tests located in `terraform-modules/nightly-nightly-safehouse-s3-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.