### PR TITLE
feat(groq): Estimates Docker image size from a Dockerfile using built‑in heuristics.

### DIFF
--- a/docker-tools/nightly-nightly-docker-size-estimato-2/Dockerfile
+++ b/docker-tools/nightly-nightly-docker-size-estimato-2/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.18
+WORKDIR /app
+COPY src/estimate_size.sh /estimate_size.sh
+RUN chmod +x /estimate_size.sh
+ENTRYPOINT ["/estimate_size.sh"]

--- a/docker-tools/nightly-nightly-docker-size-estimato-2/README.md
+++ b/docker-tools/nightly-nightly-docker-size-estimato-2/README.md
@@ -1,0 +1,38 @@
+# nightly-docker-size-estimator
+
+Estimates the size of a Docker image from a Dockerfile using a tiny heuristic lookup. Useful for quick sanity checks before building large images.
+
+## Usage
+
+```sh
+docker run --rm -v $(pwd)/Dockerfile:/Dockerfile \
+    nightly-docker-size-estimator /Dockerfile
+```
+
+The tool prints the estimated size in MB.
+
+## How it works
+
+- Looks up the base image size from a built‑in table.
+- Adds 10 MB for each `RUN` instruction.
+- Adds 1 MB for each `COPY` or `ADD` instruction.
+- Returns the sum.
+
+## Example
+
+Given a Dockerfile:
+
+```Dockerfile
+FROM alpine:3.18
+RUN apk add --no-cache curl
+COPY . /app
+RUN echo "done"
+```
+
+The estimator outputs `26 MB`.
+
+## Building the estimator image
+
+```sh
+docker build -t nightly-docker-size-estimator .
+```

--- a/docker-tools/nightly-nightly-docker-size-estimato-2/src/estimate_size.sh
+++ b/docker-tools/nightly-nightly-docker-size-estimato-2/src/estimate_size.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+# Simple Docker image size estimator
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <Dockerfile>"
+  exit 1
+fi
+
+DOCKERFILE="$1"
+
+# Base image size table (in MB)
+BASE_SIZES='\nalpine:3.18=5\nubuntu:22.04=70\ndebian:stable-slim=30\n'
+
+# Extract the base image name from the first FROM line
+BASE=$(awk '/^FROM /{print $2}' "$DOCKERFILE" | head -n1)
+BASE_SIZE=0
+for entry in $BASE_SIZES; do
+  name=$(echo "$entry" | cut -d= -f1)
+  size=$(echo "$entry" | cut -d= -f2)
+  if [ "$name" = "$BASE" ]; then
+    BASE_SIZE=$size
+    break
+  fi
+done
+
+# Count relevant Dockerfile instructions
+RUN_COUNT=$(grep -i '^RUN ' "$DOCKERFILE" | wc -l | tr -d ' ')
+COPY_COUNT=$(grep -iE '^(COPY|ADD) ' "$DOCKERFILE" | wc -l | tr -d ' ')
+
+# Apply heuristics (10 MB per RUN, 1 MB per COPY/ADD)
+RUN_SIZE=$((RUN_COUNT * 10))
+COPY_SIZE=$((COPY_COUNT * 1))
+TOTAL=$((BASE_SIZE + RUN_SIZE + COPY_SIZE))
+
+echo "${TOTAL} MB"

--- a/docker-tools/nightly-nightly-docker-size-estimato-2/tests/test_estimate.sh
+++ b/docker-tools/nightly-nightly-docker-size-estimato-2/tests/test_estimate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -e
+
+# Create a temporary Dockerfile for testing
+cat > /tmp/Dockerfile.test <<'EOF'
+FROM alpine:3.18
+RUN apk add --no-cache curl
+COPY . /app
+RUN echo "done"
+EOF
+
+EXPECTED="26 MB"
+OUTPUT=$(./src/estimate_size.sh /tmp/Dockerfile.test)
+
+if [ "$OUTPUT" = "$EXPECTED" ]; then
+  echo "PASS"
+  exit 0
+else
+  echo "FAIL: expected $EXPECTED but got $OUTPUT"
+  exit 1
+fi


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-docker-size-estimator
- **Provider**: groq
- **Location**: `docker-tools/nightly-nightly-docker-size-estimato-2`
- **Files Created**: 4
- **Description**: Estimates Docker image size from a Dockerfile using built‑in heuristics.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `docker-tools/nightly-nightly-docker-size-estimato-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `docker-tools/nightly-nightly-docker-size-estimato-2/README.md`
- Run tests located in `docker-tools/nightly-nightly-docker-size-estimato-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.