### PR TITLE
feat(groq): An Ansible playbook that updates and upgrades apt packages on Debian/Ubuntu hosts and sends a whimsical apocalypse‑themed notification email.

### DIFF
--- a/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/README.md
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/README.md
@@ -1,0 +1,24 @@
+# nightly-ansible-apt-upgrade-scheduler
+
+Utility that runs an `apt update && apt upgrade` on Debian/Ubuntu hosts and sends a whimsical apocalypse‑themed notification email.
+
+## Usage
+
+```bash
+ansible-playbook -i inventory.ini src/apt_upgrade.yml
+```
+
+## Variables
+
+- `notification_email` (default: `root@localhost`)
+- `apocalypse_quote` (optional) – custom quote to include in the email body.
+
+## What it does
+
+1. Updates the apt cache.
+2. Performs a full distribution upgrade (including autoremove).
+3. Sends an email with a fun quote so you know the world may be ending, but your packages are up‑to‑date.
+
+## License
+
+MIT

--- a/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/src/apt_upgrade.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/src/apt_upgrade.yml
@@ -1,0 +1,28 @@
+---
+- name: Apt Upgrade Scheduler
+  hosts: all
+  become: true
+  vars:
+    notification_email: "{{ notification_email | default('root@localhost') }}"
+    apocalypse_quote: "{{ apocalypse_quote | default('The world ends, but your packages stay updated!') }}"
+  tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+        cache_valid_time: 3600
+
+    - name: Upgrade all packages
+      apt:
+        upgrade: dist
+        autoremove: yes
+
+    - name: Send whimsical notification
+      mail:
+        host: localhost
+        port: 25
+        to: "{{ notification_email }}"
+        subject: "🧟‍♂️ Apt Upgrade Complete"
+        body: |
+          {{ apocalypse_quote }}
+
+          - ApocalypsAI Nightly Integrator

--- a/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/tests/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/tests/inventory.ini
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/tests/test_apt_upgrade.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-apt-upgrade/tests/test_apt_upgrade.yml
@@ -1,0 +1,14 @@
+---
+- name: Syntax check apt upgrade playbook
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Run syntax check
+      command: ansible-playbook -i inventory.ini ../src/apt_upgrade.yml --syntax-check
+      register: result
+      changed_when: false
+
+    - name: Ensure exit code 0
+      assert:
+        that:
+          - result.rc == 0


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansible-apt-upgrade-scheduler
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-ansible-apt-upgrade`
- **Files Created**: 4
- **Description**: An Ansible playbook that updates and upgrades apt packages on Debian/Ubuntu hosts and sends a whimsical apocalypse‑themed notification email.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-ansible-apt-upgrade`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-ansible-apt-upgrade/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-ansible-apt-upgrade/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.