### PR TITLE
feat(gemini): An Ansible playbook to periodically archive specified local directories and transfer them to a remote 'hoard' location, ensuring digital resilience.

### DIFF
--- a/ansible-playbooks/nightly-nightly-ansible-data-hoarder/README.md
+++ b/ansible-playbooks/nightly-nightly-ansible-data-hoarder/README.md
@@ -1,0 +1,64 @@
+# Nightly Ansible Data Hoarder
+
+## Summary
+This Ansible playbook, `nightly-ansible-data-hoarder`, is designed to help you prepare for the digital apocalypse by ensuring your most precious data is regularly archived and safely transferred to a designated 'hoard' location. Think of it as a digital squirrel preparing for winter, meticulously stashing away nuts (your data) in a secure, remote bunker.
+
+## Whimsical Purpose
+In an age where digital bits can vanish faster than a forgotten password, the Data Hoarder ensures your critical files, configurations, and cherished cat memes are preserved. It's your personal digital time capsule, ready to be unearthed when the data streams run dry.
+
+## Usage
+
+1.  **Prerequisites**:
+    *   Ansible installed on your control machine.
+    *   SSH access (with appropriate keys or password) to the target machine(s) where the source data resides and where the remote hoard path is accessible (can be the same machine).
+
+2.  **Configuration**:
+    *   **`src/inventory.ini`**: Define your target hosts. For local execution, `localhost` is sufficient.
+        ```ini
+        [hoard_targets]
+        localhost ansible_connection=local
+        # Or for remote hosts:
+        # my_server_1 ansible_host=192.168.1.100 ansible_user=your_user
+        ```
+    *   **`src/vars/hoarding_config.yml`**: This file specifies which directories to archive and where to send them.
+        ```yaml
+        # src/vars/hoarding_config.yml
+        source_dirs:
+          - /path/to/your/first/precious/data
+          - /path/to/your/second/important/folder
+        
+        remote_hoard_path: /mnt/remote_backup_drive/digital_bunker
+        # Ensure this path exists and is writable by the Ansible user on the target host.
+        ```
+
+3.  **Run the Playbook**:
+    Execute the playbook from the root of this utility's directory:
+    ```bash
+    ansible-playbook -i src/inventory.ini src/hoard_data.yml
+    ```
+
+    *   The playbook will create a timestamped `.tar.gz` archive for each `source_dir`.
+    *   These archives will then be copied to the `remote_hoard_path`.
+
+## How it Works
+
+*   It iterates through the `source_dirs` defined in `hoarding_config.yml`.
+*   For each directory, it generates a unique archive name using the current timestamp.
+*   It uses `ansible.builtin.archive` to compress the directory on the target host.
+*   It then uses `ansible.builtin.copy` to transfer the compressed archive from its temporary location on the target host to the `remote_hoard_path` on the same target host.
+*   The playbook is designed to be idempotent for the creation of the remote hoard path, but will always create a new timestamped archive for each run, ensuring a historical record of your data.
+
+## Testing
+
+To ensure your digital hoarding strategy is sound, run the provided test playbook:
+
+```bash
+ansible-playbook -i src/inventory.ini tests/test_hoard_data.yml
+```
+
+This test playbook will:
+1.  Create dummy source directories and files.
+2.  Define a temporary local directory to act as the 'remote hoard'.
+3.  Execute the `hoard_data.yml` playbook against these dummy paths.
+4.  Verify that the expected timestamped archives are created in the temporary 'remote hoard' directory.
+5.  Clean up all dummy data and directories.

--- a/ansible-playbooks/nightly-nightly-ansible-data-hoarder/src/hoard_data.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-data-hoarder/src/hoard_data.yml
@@ -1,0 +1,41 @@
+---
+- name: Nightly Data Hoarder - Archive and Transfer Precious Data
+  hosts: hoard_targets
+  gather_facts: no
+  vars_files:
+    - vars/hoarding_config.yml
+
+  tasks:
+    - name: Ensure remote hoard path exists
+      ansible.builtin.file:
+        path: "{{ remote_hoard_path }}"
+        state: directory
+        mode: '0755'
+
+    - name: Get current timestamp for archive naming
+      ansible.builtin.set_fact:
+        current_timestamp: "{{ ansible_date_time.iso8601_basic_short }}"
+
+    - name: Loop through source directories and hoard them
+      ansible.builtin.block:
+        - name: Archive source directory '{{ item }}'
+          ansible.builtin.archive:
+            path: "{{ item }}"
+            dest: "/tmp/{{ item | basename }}-{{ current_timestamp }}.tar.gz"
+            format: gz
+          register: archive_result
+          # Mock rationale: The archive module is run against a local path, simulating the creation of an archive file.
+
+        - name: Transfer archived data to remote hoard path
+          ansible.builtin.copy:
+            src: "{{ archive_result.dest }}"
+            dest: "{{ remote_hoard_path }}/{{ archive_result.dest | basename }}"
+            remote_src: yes # Source is on the remote host (which is localhost in our test case)
+          # Mock rationale: The copy module transfers a locally created archive to another local path, simulating a remote transfer.
+
+        - name: Clean up local temporary archive file
+          ansible.builtin.file:
+            path: "{{ archive_result.dest }}"
+            state: absent
+          when: archive_result.dest is defined and archive_result.dest != ''
+      loop: "{{ source_dirs }}"

--- a/ansible-playbooks/nightly-nightly-ansible-data-hoarder/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-ansible-data-hoarder/src/inventory.ini
@@ -1,0 +1,3 @@
+[hoard_targets]
+localhost ansible_connection=local
+# my_server_1 ansible_host=192.168.1.100 ansible_user=your_user

--- a/ansible-playbooks/nightly-nightly-ansible-data-hoarder/src/vars/hoarding_config.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-data-hoarder/src/vars/hoarding_config.yml
@@ -1,0 +1,9 @@
+# src/vars/hoarding_config.yml
+# Define the local directories you want to archive.
+source_dirs:
+  - /tmp/my_precious_data
+  - /tmp/another_vault
+
+# Define the remote path where archives should be stored.
+# This path must exist and be writable on the target host(s).
+remote_hoard_path: /tmp/the_digital_bunker

--- a/ansible-playbooks/nightly-nightly-ansible-data-hoarder/tests/test_hoard_data.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-data-hoarder/tests/test_hoard_data.yml
@@ -1,0 +1,99 @@
+---
+- name: Test Nightly Data Hoarder Playbook
+  hosts: localhost
+  gather_facts: no
+
+  vars:
+    test_source_dir_1: "/tmp/test_hoard_data_1"
+    test_source_dir_2: "/tmp/test_hoard_data_2"
+    test_remote_hoard_path: "/tmp/test_digital_bunker_hoard"
+
+  pre_tasks:
+    - name: Ensure test source directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: '0755'
+      loop:
+        - "{{ test_source_dir_1 }}"
+        - "{{ test_source_dir_2 }}"
+      # Mock rationale: Creates local dummy directories to simulate actual source data paths.
+
+    - name: Create dummy files in test source directories
+      ansible.builtin.copy:
+        content: "This is some test data for {{ item.file }}."
+        dest: "{{ item.path }}/{{ item.file }}"
+      loop:
+        - { path: "{{ test_source_dir_1 }}", file: "file1.txt" }
+        - { path: "{{ test_source_dir_1 }}", file: "file2.log" }
+        - { path: "{{ test_source_dir_2 }}", file: "config.json" }
+      # Mock rationale: Populates dummy directories with files, making them valid targets for archiving.
+
+    - name: Ensure test remote hoard path exists and is empty
+      ansible.builtin.file:
+        path: "{{ test_remote_hoard_path }}"
+        state: absent
+      # Mock rationale: Ensures a clean state for the test destination.
+
+    - name: Re-create test remote hoard path
+      ansible.builtin.file:
+        path: "{{ test_remote_hoard_path }}"
+        state: directory
+        mode: '0755'
+      # Mock rationale: Creates a local dummy directory to simulate the remote hoard location.
+
+  tasks:
+    - name: Get current timestamp for expected archive names
+      ansible.builtin.set_fact:
+        expected_timestamp: "{{ ansible_date_time.iso8601_basic_short }}"
+      # Mock rationale: Captures the timestamp that the main playbook will use for naming archives, enabling deterministic checks.
+
+    - name: Run the main data hoarding playbook
+      ansible.builtin.include_tasks:
+        file: ../src/hoard_data.yml
+      vars:
+        source_dirs:
+          - "{{ test_source_dir_1 }}"
+          - "{{ test_source_dir_2 }}"
+        remote_hoard_path: "{{ test_remote_hoard_path }}"
+      # Mock rationale: Executes the target playbook with test-specific variables, directing its operations to the dummy paths.
+
+    - name: Verify archive 1 was created and transferred
+      ansible.builtin.stat:
+        path: "{{ test_remote_hoard_path }}/{{ test_source_dir_1 | basename }}-{{ expected_timestamp }}.tar.gz"
+      register: stat_archive_1
+      # Mock rationale: Checks for the existence of the expected archive file in the dummy remote hoard path.
+
+    - name: Assert archive 1 exists
+      ansible.builtin.assert:
+        that:
+          - stat_archive_1.stat.exists is true
+        msg: "Archive for {{ test_source_dir_1 }} was not found in {{ test_remote_hoard_path }}"
+
+    - name: Verify archive 2 was created and transferred
+      ansible.builtin.stat:
+        path: "{{ test_remote_hoard_path }}/{{ test_source_dir_2 | basename }}-{{ expected_timestamp }}.tar.gz"
+      register: stat_archive_2
+      # Mock rationale: Checks for the existence of the expected archive file in the dummy remote hoard path.
+
+    - name: Assert archive 2 exists
+      ansible.builtin.assert:
+        that:
+          - stat_archive_2.stat.exists is true
+        msg: "Archive for {{ test_source_dir_2 }} was not found in {{ test_remote_hoard_path }}"
+
+  post_tasks:
+    - name: Clean up test source directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ test_source_dir_1 }}"
+        - "{{ test_source_dir_2 }}"
+      # Mock rationale: Removes the dummy source directories after testing.
+
+    - name: Clean up test remote hoard path
+      ansible.builtin.file:
+        path: "{{ test_remote_hoard_path }}"
+        state: absent
+      # Mock rationale: Removes the dummy remote hoard directory after testing.


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansible-data-hoarder
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-ansible-data-hoarder`
- **Files Created**: 5
- **Description**: An Ansible playbook to periodically archive specified local directories and transfer them to a remote 'hoard' location, ensuring digital resilience.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-ansible-data-hoarder`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-ansible-data-hoarder/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-ansible-data-hoarder/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.