### PR TITLE
feat(groq): A whimsical CLI tool that converts a given string into an ASCII (Unicode block) QR code printable in any terminal.

### DIFF
--- a/rust-utils/nightly-nightly-cryptic-qr-encoder-3/Cargo.toml
+++ b/rust-utils/nightly-nightly-cryptic-qr-encoder-3/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "nightly-cryptic-qr-encoder"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+qrcode = "0.7"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.0"

--- a/rust-utils/nightly-nightly-cryptic-qr-encoder-3/README.md
+++ b/rust-utils/nightly-nightly-cryptic-qr-encoder-3/README.md
@@ -1,0 +1,29 @@
+# nightly-cryptic-qr-encoder
+
+A whimsical CLI tool that converts a given string into an ASCII (Unicode block) QR code, printable in any terminal.
+
+## Usage
+
+```sh
+cargo run -- <text>
+```
+
+Example:
+
+```sh
+cargo run -- "Hello, world!"
+```
+
+Outputs a QR code made of █ and space characters.
+
+## Building
+
+```sh
+cargo build --release
+```
+
+## Testing
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-cryptic-qr-encoder-3/src/lib.rs
+++ b/rust-utils/nightly-nightly-cryptic-qr-encoder-3/src/lib.rs
@@ -1,0 +1,13 @@
+use qrcode::QrCode;
+use qrcode::render::unicode;
+
+/// Encode the given text into an ASCII QR code using Unicode dense blocks.
+///
+/// Returns a `String` containing the rendered QR code where the dark modules are
+/// represented by the `█` character and light modules by a space. Newlines separate rows.
+pub fn encode_to_ascii(text: &str) -> String {
+    let code = QrCode::new(text.as_bytes()).expect("Failed to create QR code");
+    code.render::<unicode::Dense1x2>()
+        .quiet_zone(false)
+        .build()
+}

--- a/rust-utils/nightly-nightly-cryptic-qr-encoder-3/src/main.rs
+++ b/rust-utils/nightly-nightly-cryptic-qr-encoder-3/src/main.rs
@@ -1,0 +1,12 @@
+use std::env;
+use nightly_cryptic_qr_encoder::encode_to_ascii;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: {} <text>", args[0]);
+        std::process::exit(1);
+    }
+    let output = encode_to_ascii(&args[1]);
+    println!("{}", output);
+}

--- a/rust-utils/nightly-nightly-cryptic-qr-encoder-3/tests/integration_test.rs
+++ b/rust-utils/nightly-nightly-cryptic-qr-encoder-3/tests/integration_test.rs
@@ -1,0 +1,11 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn test_cli_output_non_empty() {
+    let mut cmd = Command::cargo_bin("nightly-cryptic-qr-encoder").unwrap();
+    cmd.arg("test");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::is_match(r"^[█ \n]+$").unwrap());
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-cryptic-qr-encoder
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-cryptic-qr-encoder-3`
- **Files Created**: 5
- **Description**: A whimsical CLI tool that converts a given string into an ASCII (Unicode block) QR code printable in any terminal.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-cryptic-qr-encoder-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-cryptic-qr-encoder-3/README.md`
- Run tests located in `rust-utils/nightly-nightly-cryptic-qr-encoder-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.