### PR TITLE
feat(groq): An Ansible playbook that prunes dangling Docker images and optionally stopped containers on target hosts.

### DIFF
--- a/ansible-playbooks/nightly-nightly-ansible-docker-prune/README.md
+++ b/ansible-playbooks/nightly-nightly-ansible-docker-prune/README.md
@@ -1,0 +1,30 @@
+# nightly-ansible-docker-prune
+
+An Ansible playbook that safely prunes dangling Docker images (and optionally stopped containers) on target hosts. Useful for reclaiming disk space on CI runners or development machines.
+
+## Requirements
+
+- Ansible 2.10+
+- `community.docker` collection (`ansible-galaxy collection install community.docker`)
+- Docker daemon running on the target hosts.
+
+## Variables
+
+- `docker_prune_enabled` (bool, default: true) – Set to `false` to skip pruning.
+- `prune_containers` (bool, default: false) – When `true`, also removes stopped containers.
+
+## Usage
+
+```bash
+ansible-playbook -i inventory.ini src/prune.yml -e "docker_prune_enabled=true prune_containers=true"
+```
+
+## Testing
+
+Run the included test playbook to verify skip logic without needing Docker:
+
+```bash
+ansible-playbook -i inventory.ini tests/test_prune.yml
+```
+
+The test ensures that when `docker_prune_enabled` is set to `false`, the playbook reports the skip correctly.

--- a/ansible-playbooks/nightly-nightly-ansible-docker-prune/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-ansible-docker-prune/inventory.ini
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-ansible-docker-prune/src/prune.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-docker-prune/src/prune.yml
@@ -1,0 +1,27 @@
+- name: Docker prune playbook
+  hosts: all
+  gather_facts: false
+  vars:
+    docker_prune_enabled: true   # can be overridden via -e
+    prune_containers: false      # can be overridden via -e
+  tasks:
+    - name: Set prune_skipped fact when pruning is disabled
+      set_fact:
+        prune_skipped: true
+      when: not docker_prune_enabled
+
+    - name: Debug message when pruning is disabled
+      debug:
+        msg: "Docker prune disabled by variable docker_prune_enabled=false"
+      when: not docker_prune_enabled
+
+    - name: Prune Docker images and optionally containers
+      community.docker.docker_prune:
+        images: true
+        containers: "{{ prune_containers }}"
+      when: docker_prune_enabled
+
+    - name: Ensure prune_skipped is false when pruning runs
+      set_fact:
+        prune_skipped: false
+      when: docker_prune_enabled

--- a/ansible-playbooks/nightly-nightly-ansible-docker-prune/tests/test_prune.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-docker-prune/tests/test_prune.yml
@@ -1,0 +1,15 @@
+- name: Test Docker prune skip logic
+  hosts: localhost
+  gather_facts: false
+  vars:
+    docker_prune_enabled: false   # Force skip for test
+  tasks:
+    - name: Include the main prune playbook
+      import_playbook: ../src/prune.yml
+
+    - name: Verify that pruning was skipped
+      assert:
+        that:
+          - prune_skipped | bool
+        fail_msg: "Prune was expected to be skipped but it was not."
+        success_msg: "Prune skip logic works as expected."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansible-docker-prune
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-ansible-docker-prune`
- **Files Created**: 4
- **Description**: An Ansible playbook that prunes dangling Docker images and optionally stopped containers on target hosts.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-ansible-docker-prune`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-ansible-docker-prune/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-ansible-docker-prune/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.