### PR TITLE
feat(groq): A whimsical Dockerized utility that prints a randomly generated cryptid description each time it runs.

### DIFF
--- a/docker-tools/nightly-nightly-cryptic-cryptid-gene/Dockerfile
+++ b/docker-tools/nightly-nightly-cryptic-cryptid-gene/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-alpine
+WORKDIR /app
+COPY src/cryptid_generator.py .
+ENTRYPOINT ["python", "-c", "import cryptid_generator, sys; sys.stdout.write(cryptid_generator.generate() + '\\n')"]

--- a/docker-tools/nightly-nightly-cryptic-cryptid-gene/README.md
+++ b/docker-tools/nightly-nightly-cryptic-cryptid-gene/README.md
@@ -1,0 +1,24 @@
+# Cryptic Cryptid Generator
+
+A whimsical Dockerized utility that prints a randomly generated cryptid description each time it runs. Perfect for adding a touch of mystery to your terminal.
+
+## Usage
+
+```sh
+docker build -t cryptid-generator .
+docker run --rm cryptid-generator
+```
+
+Example output:
+
+```
+The Neon-Scaled Skywhale, a mysterious creature that dwells in the moonlit marshes and sings lullabies to wandering travelers.
+```
+
+## How it works
+
+The container runs a tiny Python script that assembles a cryptid name and description from predefined parts.
+
+## License
+
+MIT

--- a/docker-tools/nightly-nightly-cryptic-cryptid-gene/src/cryptid_generator.py
+++ b/docker-tools/nightly-nightly-cryptic-cryptid-gene/src/cryptid_generator.py
@@ -1,0 +1,37 @@
+import random
+
+_ADJECTIVES = [
+    "Neon-Scaled", "Shadowy", "Gigantic", "Miniature", "Ethereal",
+    "Flaming", "Glacial", "Thunderous", "Invisible", "Radiant"
+]
+
+_CREATURES = [
+    "Skywhale", "Mirewolf", "Stonebeetle", "Luminox", "Abyssal Serpent",
+    "Crystaline Owl", "Molten Tortoise", "Silk Spider", "Obsidian Panther", "Celestial Fox"
+]
+
+_HABITATS = [
+    "the moonlit marshes", "the volcanic canyons", "the crystal caves",
+    "the endless deserts", "the misty forests", "the stormy seas",
+    "the floating islands", "the underground rivers", "the ancient ruins", "the aurora-lit tundra"
+]
+
+_BEHAVIORS = [
+    "sings lullabies to wandering travelers",
+    "guards hidden treasure",
+    "weaves dreams into reality",
+    "collects lost memories",
+    "illuminates the night with bioluminescent breath",
+    "creates mirages to confuse predators",
+    "dances with the wind",
+    "writes poetry in the sand",
+    "plays chess with the stars",
+    "whispers secrets of the cosmos"
+]
+
+def generate() -> str:
+    """Return a whimsical cryptid description."""
+    name = f"The {random.choice(_ADJECTIVES)} {random.choice(_CREATURES)}"
+    habitat = random.choice(_HABITATS)
+    behavior = random.choice(_BEHAVIORS)
+    return f"{name}, a mysterious creature that dwells in {habitat} and {behavior}."

--- a/docker-tools/nightly-nightly-cryptic-cryptid-gene/tests/test_cryptid_generator.py
+++ b/docker-tools/nightly-nightly-cryptic-cryptid-gene/tests/test_cryptid_generator.py
@@ -1,0 +1,20 @@
+import unittest
+import random
+import sys
+import os
+
+# Add the src directory to the import path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import cryptid_generator
+
+class TestCryptidGenerator(unittest.TestCase):
+    def test_generate_deterministic(self):
+        # Mock rationale: fixing the random seed ensures deterministic output for testing.
+        random.seed(0)
+        result = cryptid_generator.generate()
+        expected = "The Radiant Luminox, a mysterious creature that dwells in the misty forests and illuminates the night with bioluminescent breath."
+        self.assertEqual(result, expected)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-cryptic-cryptid-generator
- **Provider**: groq
- **Location**: `docker-tools/nightly-nightly-cryptic-cryptid-gene`
- **Files Created**: 4
- **Description**: A whimsical Dockerized utility that prints a randomly generated cryptid description each time it runs.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `docker-tools/nightly-nightly-cryptic-cryptid-gene`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `docker-tools/nightly-nightly-cryptic-cryptid-gene/README.md`
- Run tests located in `docker-tools/nightly-nightly-cryptic-cryptid-gene/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.