### PR TITLE
feat(groq): A whimsical Terraform module that provisions a mock post‑apocalyptic shelter as an AWS S3 bucket with a random name.

### DIFF
--- a/terraform-modules/nightly-nightly-shelter-terraform-mo/README.md
+++ b/terraform-modules/nightly-nightly-shelter-terraform-mo/README.md
@@ -1,0 +1,47 @@
+# Nightly Shelter Terraform Module
+
+## Overview
+
+This Terraform module creates a **mock post‑apocalyptic shelter** represented by an AWS S3 bucket. The bucket name is generated from a random pet name combined with a user‑provided prefix, giving each shelter a unique, whimsical identity.
+
+## Features
+
+- Generates a random, human‑readable name using `random_pet`.
+- Allows a custom prefix (e.g., `shelter-`) via the `bucket_name_prefix` variable.
+- Outputs the final bucket name for downstream use.
+
+## Usage
+
+```hcl
+module "shelter" {
+  source            = "./utils/nightly-shelter-terraform-module"
+  bucket_name_prefix = "shelter-"
+}
+
+output "shelter_bucket" {
+  value = module.shelter.bucket_name
+}
+```
+
+## Variables
+
+| Name                | Type   | Description                                 | Default |
+|---------------------|--------|---------------------------------------------|---------|
+| `bucket_name_prefix`| string | Prefix for the generated bucket name.       | `"shelter-"` |
+
+## Outputs
+
+| Name        | Description                              |
+|-------------|------------------------------------------|
+| `bucket_name`| The full name of the created S3 bucket. |
+
+## Testing
+
+A simple Bash test suite lives under `tests/`. Run it with:
+
+```bash
+cd utils/nightly-shelter-terraform-module
+bash tests/test_module.sh
+```
+
+The test checks that the Terraform files contain the expected resources and variables.

--- a/terraform-modules/nightly-nightly-shelter-terraform-mo/src/main.tf
+++ b/terraform-modules/nightly-nightly-shelter-terraform-mo/src/main.tf
@@ -1,0 +1,8 @@
+resource "random_pet" "shelter_name" {
+  length = 2
+}
+
+resource "aws_s3_bucket" "shelter_bucket" {
+  bucket = "${var.bucket_name_prefix}${random_pet.shelter_name.id}"
+  acl    = "private"
+}

--- a/terraform-modules/nightly-nightly-shelter-terraform-mo/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-shelter-terraform-mo/src/outputs.tf
@@ -1,0 +1,4 @@
+output "bucket_name" {
+  description = "The full name of the created S3 bucket."
+  value       = aws_s3_bucket.shelter_bucket.id
+}

--- a/terraform-modules/nightly-nightly-shelter-terraform-mo/src/variables.tf
+++ b/terraform-modules/nightly-nightly-shelter-terraform-mo/src/variables.tf
@@ -1,0 +1,5 @@
+variable "bucket_name_prefix" {
+  description = "Prefix for the generated bucket name."
+  type        = string
+  default     = "shelter-"
+}

--- a/terraform-modules/nightly-nightly-shelter-terraform-mo/tests/test_module.sh
+++ b/terraform-modules/nightly-nightly-shelter-terraform-mo/tests/test_module.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+# Mock rationale: Verify that the Terraform files contain the expected resources and variables.
+# This avoids network calls and keeps the test deterministic.
+
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Helper to assert a pattern exists in a file
+assert_grep() {
+  local pattern="$1"
+  local file="$2"
+  if ! grep -qE "$pattern" "$file"; then
+    echo "FAIL: Expected pattern '$pattern' not found in $file"
+    exit 1
+  fi
+}
+
+# Check that main.tf defines the random_pet and aws_s3_bucket resources
+assert_grep "resource \"random_pet\" \"shelter_name\"" "$MODULE_DIR/src/main.tf"
+assert_grep "resource \"aws_s3_bucket\" \"shelter_bucket\"" "$MODULE_DIR/src/main.tf"
+
+# Check that variables.tf defines bucket_name_prefix variable
+assert_grep "variable \"bucket_name_prefix\"" "$MODULE_DIR/src/variables.tf"
+
+# Check that outputs.tf defines bucket_name output
+assert_grep "output \"bucket_name\"" "$MODULE_DIR/src/outputs.tf"
+
+echo "All checks passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-shelter-terraform-module
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-shelter-terraform-mo`
- **Files Created**: 5
- **Description**: A whimsical Terraform module that provisions a mock post‑apocalyptic shelter as an AWS S3 bucket with a random name.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-shelter-terraform-mo`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-shelter-terraform-mo/README.md`
- Run tests located in `terraform-modules/nightly-nightly-shelter-terraform-mo/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.