### PR TITLE
feat(groq): An Ansible playbook that installs a rotating post‑apocalyptic Message of the Day with random quotes.

### DIFF
--- a/ansible-playbooks/nightly-nightly-apocalypse-motd/README.md
+++ b/ansible-playbooks/nightly-nightly-apocalypse-motd/README.md
@@ -1,0 +1,23 @@
+# Apocalypse MOTD
+
+A whimsical Ansible playbook that installs a rotating "Apocalypse of the Day" message of the day (MOTD) with random post‑apocalyptic quotes. Useful for adding a bit of flavor to servers.
+
+## Usage
+
+```bash
+ansible-playbook -i src/inventory.ini src/playbook.yml -e "motd_path=/etc/motd"
+```
+
+To test locally without sudo, specify a writable path:
+
+```bash
+ansible-playbook -i src/inventory.ini src/playbook.yml -e "motd_path=./test_motd.txt"
+```
+
+The playbook installs a template that selects a random quote from a predefined list.
+
+## Files
+
+- `src/playbook.yml` – entry point.
+- `src/roles/apocalypse_motd/` – role with tasks, vars, and template.
+- `tests/run_test.sh` – simple CI test.

--- a/ansible-playbooks/nightly-nightly-apocalypse-motd/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-apocalypse-motd/src/inventory.ini
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-apocalypse-motd/src/playbook.yml
+++ b/ansible-playbooks/nightly-nightly-apocalypse-motd/src/playbook.yml
@@ -1,0 +1,6 @@
+- hosts: all
+  become: true
+  vars:
+    motd_path: "{{ motd_path | default('/etc/motd') }}"
+  roles:
+    - apocalypse_motd

--- a/ansible-playbooks/nightly-nightly-apocalypse-motd/src/roles/apocalypse_motd/tasks/main.yml
+++ b/ansible-playbooks/nightly-nightly-apocalypse-motd/src/roles/apocalypse_motd/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: Ensure MOTD directory exists
+  file:
+    path: "{{ motd_path | dirname }}"
+    state: directory
+    mode: '0755'
+  when: motd_path != '/etc/motd'
+
+- name: Deploy MOTD file
+  template:
+    src: motd.j2
+    dest: "{{ motd_path }}"
+    mode: '0644'

--- a/ansible-playbooks/nightly-nightly-apocalypse-motd/src/roles/apocalypse_motd/templates/motd.j2
+++ b/ansible-playbooks/nightly-nightly-apocalypse-motd/src/roles/apocalypse_motd/templates/motd.j2
@@ -1,0 +1,1 @@
+{{ motd_quotes | random }}

--- a/ansible-playbooks/nightly-nightly-apocalypse-motd/src/roles/apocalypse_motd/vars/main.yml
+++ b/ansible-playbooks/nightly-nightly-apocalypse-motd/src/roles/apocalypse_motd/vars/main.yml
@@ -1,0 +1,4 @@
+motd_quotes:
+  - "The end is nigh, but coffee remains."
+  - "Remember: every sunrise is a second chance."
+  - "In the wasteland, laughter is the best armor."

--- a/ansible-playbooks/nightly-nightly-apocalypse-motd/tests/run_test.sh
+++ b/ansible-playbooks/nightly-nightly-apocalypse-motd/tests/run_test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Mock rationale: Simulate running the playbook and checking file creation without affecting system files.
+
+set -e
+PLAYBOOK_DIR=$(dirname "$0")/..
+TMP_MOTD="./test_motd.txt"
+# Run the playbook against localhost using a local connection.
+ansible-playbook -i "$PLAYBOOK_DIR/src/inventory.ini" "$PLAYBOOK_DIR/src/playbook.yml" -e "motd_path=$TMP_MOTD" --connection=local --become=false
+if [ -f "$TMP_MOTD" ]; then
+  echo "MOTD file created successfully."
+  # Clean up after test
+  rm -f "$TMP_MOTD"
+  exit 0
+else
+  echo "MOTD file was not created."
+  exit 1
+fi


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-apocalypse-motd
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-apocalypse-motd`
- **Files Created**: 7
- **Description**: An Ansible playbook that installs a rotating post‑apocalyptic Message of the Day with random quotes.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-apocalypse-motd`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-apocalypse-motd/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-apocalypse-motd/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.