### PR TITLE
feat(groq): Prints a visual swatch of all 256 ANSI background colors for terminal use

### DIFF
--- a/go-utils/nightly-nightly-ansi-color-swatch/README.md
+++ b/go-utils/nightly-nightly-ansi-color-swatch/README.md
@@ -1,0 +1,26 @@
+# nightly-ansi-color-swatch
+
+Utility that prints a visual swatch of all 256 ANSI background colors in your terminal. Helpful for developers to pick colors for terminal applications.
+
+## Usage
+
+```sh
+go run src/main.go
+```
+
+Or build and run:
+
+```sh
+go build -o ansi-swatch src/main.go
+./ansi-swatch
+```
+
+The output displays each color code with a colored block.
+
+## How it works
+
+The program iterates over color codes 0‑255 and prints each code with its background set using the ANSI escape sequence `\x1b[48;5;<code>m`. After each line, it resets formatting.
+
+## License
+
+MIT

--- a/go-utils/nightly-nightly-ansi-color-swatch/src/main.go
+++ b/go-utils/nightly-nightly-ansi-color-swatch/src/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+    "fmt"
+    "strings"
+)
+
+func generateSwatch() string {
+    var sb strings.Builder
+    for i := 0; i < 256; i++ {
+        // Print color block with code
+        sb.WriteString(fmt.Sprintf("\x1b[48;5;%dm %3d \x1b[0m", i, i))
+        // Newline every 8 colors for readability
+        if (i+1)%8 == 0 {
+            sb.WriteString("\n")
+        } else {
+            sb.WriteString(" ")
+        }
+    }
+    return sb.String()
+}
+
+func main() {
+    fmt.Print(generateSwatch())
+}

--- a/go-utils/nightly-nightly-ansi-color-swatch/tests/test_main.go
+++ b/go-utils/nightly-nightly-ansi-color-swatch/tests/test_main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+    "strings"
+    "testing"
+)
+
+func TestGenerateSwatchContainsKnownColors(t *testing.T) {
+    output := generateSwatch()
+    // Check that reset code is present
+    if !strings.Contains(output, "\x1b[0m") {
+        t.Fatalf("output missing reset escape sequence")
+    }
+    // Check a few specific color codes
+    expected := []string{
+        "\x1b[48;5;0m   0 \x1b[0m",
+        "\x1b[48;5;255m 255 \x1b[0m",
+    }
+    for _, exp := range expected {
+        if !strings.Contains(output, exp) {
+            t.Fatalf("output missing expected segment: %q", exp)
+        }
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansi-color-swatch
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-ansi-color-swatch`
- **Files Created**: 3
- **Description**: Prints a visual swatch of all 256 ANSI background colors for terminal use

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-ansi-color-swatch`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-ansi-color-swatch/README.md`
- Run tests located in `go-utils/nightly-nightly-ansi-color-swatch/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.