### PR TITLE
feat(gemini): A Go-based concurrent TCP server that listens for 'temporal echoes' (messages), processes them with timestamps and unique IDs, and logs them.

### DIFF
--- a/go-utils/nightly-nightly-temporal-echo-listen/README.md
+++ b/go-utils/nightly-nightly-temporal-echo-listen/README.md
@@ -1,0 +1,88 @@
+# Nightly Temporal Echo Listener
+
+"Listen closely, for the whispers of time carry echoes from beyond the veil."
+
+The `nightly-temporal-echo-listen` is a whimsical yet useful Go-based concurrent TCP server designed to simulate listening for "temporal echoes" – simple text messages sent over a network. It processes each incoming message by assigning a unique echo ID, stamping it with the current time, and logging it to the console.
+
+This utility is excellent for:
+- **Testing concurrent systems**: Simulate a message sink that handles multiple incoming connections and messages concurrently.
+- **Network debugging**: A simple TCP server to send arbitrary text data to and observe its processing.
+- **Educational purposes**: Demonstrate Go's concurrency primitives (`goroutines`, `channels`, `sync.WaitGroup`, `sync.Mutex`).
+- **Pure whimsy**: Just because it's fun to imagine listening to temporal echoes!
+
+## Features
+- **Concurrent Handling**: Each client connection is handled in its own goroutine.
+- **Message Processing**: Assigns a unique ID and timestamp to each received message.
+- **Centralized Logging**: Processed echoes are sent to a dedicated logging goroutine via a channel.
+- **Graceful Shutdown**: Responds to `SIGINT` (Ctrl+C) and `SIGTERM` for clean termination.
+
+## How to Run
+
+1.  **Prerequisites**:
+    *   Go (version 1.16 or higher) installed on your system.
+
+2.  **Navigate to the utility directory**:
+    ```bash
+    cd go-utils/nightly-temporal-echo-listen
+    ```
+
+3.  **Build the executable**:
+    ```bash
+    go build -o temporal-echo-listener src/main.go
+    ```
+
+4.  **Run the server**:
+    ```bash
+    ./temporal-echo-listener
+    ```
+    By default, the server will listen on port `8080`. You can specify a different port using the `PORT` environment variable:
+    ```bash
+    PORT=9000 ./temporal-echo-listener
+    ```
+
+5.  **Send echoes (messages) to the server**:
+    You can use `netcat` (nc) or `telnet` to connect to the server.
+
+    *   **Using `netcat` (recommended)**:
+        ```bash
+        echo "Hello from the past!" | nc localhost 8080
+        echo "A ripple in the fabric of time." | nc localhost 8080
+        ```
+        For an interactive session:
+        ```bash
+        nc localhost 8080
+        # Type your messages, press Enter after each
+        # Press Ctrl+D to close the connection
+        ```
+
+    *   **Using `telnet` (if `nc` is not available)**:
+        ```bash
+        telnet localhost 8080
+        # Type your messages, press Enter after each
+        # Press Ctrl+] then type 'quit' and Enter to close
+        ```
+
+    You will see output similar to this on the server's console:
+    ```
+    2023/10/27 10:30:00 Temporal Echo Listener started on :8080
+    2023/10/27 10:30:05 New temporal conduit opened from 127.0.0.1:54321
+    [ECHO 1] 2023-10-27T10:30:05Z from 127.0.0.1:54321: "Hello from the past!"
+    [ECHO 2] 2023-10-27T10:30:06Z from 127.0.0.1:54321: "A ripple in the fabric of time."
+    2023/10/27 10:30:06 Temporal conduit from 127.0.0.1:54321 closed.
+    ```
+
+6.  **Stop the server**:
+    Press `Ctrl+C` in the terminal where the server is running.
+
+## How to Test
+
+1.  **Navigate to the utility directory**:
+    ```bash
+    cd go-utils/nightly-temporal-echo-listen
+    ```
+
+2.  **Run the tests**:
+    ```bash
+    go test ./tests/...
+    ```
+    This will execute all unit and integration tests, including those that simulate network interactions using `net.Pipe()` for offline, deterministic testing, and full end-to-end tests using ephemeral ports.

--- a/go-utils/nightly-nightly-temporal-echo-listen/src/main.go
+++ b/go-utils/nightly-nightly-temporal-echo-listen/src/main.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultPort = 8080
+)
+
+// Echo represents a processed temporal echo
+type Echo struct {
+	ID         int
+	Timestamp  time.Time
+	Message    string
+	ClientAddr string
+}
+
+// EchoProcessor handles incoming messages and transforms them into Echo objects
+type EchoProcessor struct {
+	nextEchoID int
+	mu         sync.Mutex
+}
+
+// NewEchoProcessor creates a new EchoProcessor
+func NewEchoProcessor() *EchoProcessor {
+	return &EchoProcessor{
+		nextEchoID: 1,
+	}
+}
+
+// ProcessMessage takes a raw message and client address, returns a processed Echo
+func (ep *EchoProcessor) ProcessMessage(message, clientAddr string) Echo {
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
+
+	echo := Echo{
+		ID:         ep.nextEchoID,
+		Timestamp:  time.Now(),
+		Message:    message,
+		ClientAddr: clientAddr,
+	}
+	ep.nextEchoID++
+	return echo
+}
+
+// Server holds the server configuration and state
+type Server struct {
+	port        int
+	listener    net.Listener
+	processor   *EchoProcessor
+	echoChannel chan Echo
+	wg          sync.WaitGroup
+	shutdown    chan struct{}
+}
+
+// NewServer creates a new Server instance
+func NewServer(port int) *Server {
+	return &Server{
+		port:        port,
+		processor:   NewEchoProcessor(),
+		echoChannel: make(chan Echo, 100), // Buffered channel for echoes
+		shutdown:    make(chan struct{}),
+	}
+}
+
+// Start begins listening for incoming connections
+func (s *Server) Start() error {
+	addr := fmt.Sprintf(":%d", s.port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", addr, err)
+	}
+	s.listener = listener
+	log.Printf("Temporal Echo Listener started on %s", s.listener.Addr().String())
+
+	// Start echo logger goroutine
+	s.wg.Add(1)
+	go s.logEchoes()
+
+	// Accept connections in a loop
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for {
+			conn, err := s.listener.Accept()
+			if err != nil {
+				select {
+				case <-s.shutdown:
+					log.Println("Server listener shutting down.")
+					return
+				default:
+					// If not a graceful shutdown, log the error
+					log.Printf("Error accepting connection: %v", err)
+					continue
+				}
+			}
+			s.wg.Add(1)
+			go s.handleConnection(conn)
+		}
+	}()
+	return nil
+}
+
+// Stop gracefully shuts down the server
+func (s *Server) Stop() {
+	log.Println("Shutting down Temporal Echo Listener...")
+	close(s.shutdown) // Signal shutdown to listener goroutine
+	if s.listener != nil {
+		s.listener.Close() // Close the listener to unblock Accept()
+	}
+	close(s.echoChannel) // Close the channel to signal logEchoes to exit
+	s.wg.Wait()          // Wait for all goroutines to finish
+	log.Println("Temporal Echo Listener stopped.")
+}
+
+// handleConnection processes a single client connection
+func (s *Server) handleConnection(conn net.Conn) {
+	defer s.wg.Done()
+	defer conn.Close()
+
+	clientAddr := conn.RemoteAddr().String()
+	log.Printf("New temporal conduit opened from %s", clientAddr)
+
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		message := scanner.Text()
+		if message == "" {
+			continue
+		}
+		echo := s.processor.ProcessMessage(message, clientAddr)
+		s.echoChannel <- echo // Send processed echo to the logging channel
+	}
+
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		log.Printf("Error reading from %s: %v", clientAddr, err)
+	}
+	log.Printf("Temporal conduit from %s closed.", clientAddr)
+}
+
+// logEchoes consumes echoes from the channel and logs them
+func (s *Server) logEchoes() {
+	defer s.wg.Done()
+	for echo := range s.echoChannel {
+		fmt.Printf("[ECHO %d] %s from %s: \"%s\"\n", echo.ID, echo.Timestamp.Format(time.RFC3339), echo.ClientAddr, echo.Message)
+	}
+	log.Println("Echo logging goroutine stopped.")
+}
+
+func main() {
+	portStr := os.Getenv("PORT")
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port == 0 {
+		port = defaultPort
+	}
+
+	server := NewServer(port)
+	if err := server.Start(); err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
+
+	// Set up a channel to listen for OS signals
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// Block until a signal is received
+	<-sigChan
+	log.Println("OS signal received, initiating shutdown...")
+	server.Stop()
+}

--- a/go-utils/nightly-nightly-temporal-echo-listen/tests/main_test.go
+++ b/go-utils/nightly-nightly-temporal-echo-listen/tests/main_test.go
@@ -1,0 +1,335 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestEchoProcessor_ProcessMessage ensures messages are processed correctly
+func TestEchoProcessor_ProcessMessage(t *testing.T) {
+	ep := NewEchoProcessor()
+
+	msg1 := "Hello Temporal Void"
+	addr1 := "127.0.0.1:12345"
+	echo1 := ep.ProcessMessage(msg1, addr1)
+
+	if echo1.ID != 1 {
+		t.Errorf("Expected first echo ID to be 1, got %d", echo1.ID)
+	}
+	if echo1.Message != msg1 {
+		t.Errorf("Expected message '%s', got '%s'", msg1, echo1.Message)
+	}
+	if echo1.ClientAddr != addr1 {
+		t.Errorf("Expected client address '%s', got '%s'", addr1, echo1.ClientAddr)
+	}
+	if time.Since(echo1.Timestamp) > time.Second { // Check timestamp is recent
+		t.Errorf("Timestamp is not recent enough: %v", echo1.Timestamp)
+	}
+
+	msg2 := "Another ripple"
+	addr2 := "127.0.0.1:54321"
+	echo2 := ep.ProcessMessage(msg2, addr2)
+
+	if echo2.ID != 2 {
+		t.Errorf("Expected second echo ID to be 2, got %d", echo2.ID)
+	}
+	if echo2.Message != msg2 {
+		t.Errorf("Expected message '%s', got '%s'", msg2, echo2.Message)
+	}
+	if echo2.ClientAddr != addr2 {
+		t.Errorf("Expected client address '%s', got '%s'", addr2, echo2.ClientAddr)
+	}
+}
+
+// TestEchoProcessor_ConcurrentProcessing ensures thread safety and correct ID assignment
+func TestEchoProcessor_ConcurrentProcessing(t *testing.T) {
+	ep := NewEchoProcessor()
+	numGoroutines := 100
+	messagesPerGoroutine := 10
+	totalMessages := numGoroutines * messagesPerGoroutine
+
+	var wg sync.WaitGroup
+	processedEchoes := make(chan Echo, totalMessages)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(gID int) {
+			defer wg.Done()
+			addr := fmt.Sprintf("192.168.1.%d:8080", gID)
+			for j := 0; j < messagesPerGoroutine; j++ {
+				msg := fmt.Sprintf("Goroutine %d, Message %d", gID, j)
+				echo := ep.ProcessMessage(msg, addr)
+				processedEchoes <- echo
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(processedEchoes)
+
+	// Collect and verify IDs
+	receivedIDs := make(map[int]bool)
+	for echo := range processedEchoes {
+		if receivedIDs[echo.ID] {
+			t.Errorf("Duplicate echo ID found: %d", echo.ID)
+		}
+		receivedIDs[echo.ID] = true
+	}
+
+	if len(receivedIDs) != totalMessages {
+		t.Errorf("Expected %d unique echoes, got %d", totalMessages, len(receivedIDs))
+	}
+
+	// Check if all IDs from 1 to totalMessages are present
+	for i := 1; i <= totalMessages; i++ {
+		if !receivedIDs[i] {
+			t.Errorf("Missing echo ID: %d", i)
+		}
+	}
+}
+
+// Mock rationale: We use net.Pipe to simulate a network connection in memory
+// without requiring actual network sockets, making tests deterministic and offline.
+func TestServer_HandleConnection(t *testing.T) {
+	// Capture log output to verify it
+	var logBuffer bytes.Buffer
+	log.SetOutput(&logBuffer)
+	defer func() {
+		log.SetOutput(os.Stderr) // Restore default output
+	}()
+
+	server := NewServer(0) // Port doesn't matter for handleConnection test
+	defer server.Stop()    // Ensure cleanup
+
+	// Create a pipe to simulate client-server connection
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	// Simulate client sending messages
+	go func() {
+		fmt.Fprintf(clientConn, "First echo\n")
+		time.Sleep(10 * time.Millisecond) // Simulate network delay
+		fmt.Fprintf(clientConn, "Second echo\n")
+		clientConn.Close() // Client closes connection
+	}()
+
+	// Run handleConnection in a goroutine
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		server.handleConnection(serverConn)
+		wg.Done()
+	}()
+
+	// Collect echoes from the server's channel
+	var receivedEchoes []Echo
+	collectDone := make(chan struct{})
+	go func() {
+		for echo := range server.echoChannel {
+			receivedEchoes = append(receivedEchoes, echo)
+			if len(receivedEchoes) == 2 { // Expecting 2 echoes
+				close(collectDone)
+				return
+			}
+		}
+	}()
+
+	// Wait for handleConnection to finish and echoes to be collected
+	select {
+	case <-collectDone:
+		// Echoes collected
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Timed out waiting for echoes to be collected")
+	}
+	wg.Wait() // Wait for handleConnection to finish
+
+	if len(receivedEchoes) != 2 {
+		t.Fatalf("Expected 2 echoes, got %d", len(receivedEchoes))
+	}
+
+	if receivedEchoes[0].Message != "First echo" {
+		t.Errorf("Expected first message 'First echo', got '%s'", receivedEchoes[0].Message)
+	}
+	if receivedEchoes[1].Message != "Second echo" {
+		t.Errorf("Expected second message 'Second echo', got '%s'", receivedEchoes[1].Message)
+	}
+
+	// Verify log output contains connection open/close messages
+	logOutput := logBuffer.String()
+	if !strings.Contains(logOutput, "New temporal conduit opened from pipe") {
+		t.Errorf("Expected log output to contain 'New temporal conduit opened', got:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "Temporal conduit from pipe closed.") {
+		t.Errorf("Expected log output to contain 'Temporal conduit from pipe closed', got:\n%s", logOutput)
+	}
+}
+
+// TestServer_StartAndStop ensures the server can start and stop gracefully
+func TestServer_StartAndStop(t *testing.T) {
+	// Capture log output
+	var logBuffer bytes.Buffer
+	log.SetOutput(&logBuffer)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+
+	// Use a real server on an ephemeral port (port 0)
+	// This is deterministic for local testing as it uses a free port.
+	server := NewServer(0)
+	err := server.Start()
+	if err != nil {
+		t.Fatalf("Failed to start server: %v", err)
+	}
+
+	// Give it a moment to start listening
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify server started log
+	logOutput := logBuffer.String()
+	if !strings.Contains(logOutput, "Temporal Echo Listener started on :") {
+		t.Errorf("Expected 'Server started' log, got:\n%s", logOutput)
+	}
+
+	// Now stop the server
+	server.Stop()
+
+	// Verify server stopped log
+	logOutput = logBuffer.String()
+	if !strings.Contains(logOutput, "Temporal Echo Listener stopped.") {
+		t.Errorf("Expected 'Server stopped' log, got:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "Echo logging goroutine stopped.") {
+		t.Errorf("Expected 'Echo logging goroutine stopped' log, got:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "Server listener shutting down.") {
+		t.Errorf("Expected 'Server listener shutting down' log, got:\n%s", logOutput)
+	}
+}
+
+// TestServer_EndToEnd_SingleClient tests a full cycle with a real client connection
+func TestServer_EndToEnd_SingleClient(t *testing.T) {
+	// Capture log output
+	var logBuffer bytes.Buffer
+	log.SetOutput(&logBuffer)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+
+	server := NewServer(0) // Use ephemeral port
+	err := server.Start()
+	if err != nil {
+		t.Fatalf("Failed to start server: %v", err)
+	}
+	defer server.Stop()
+
+	// Get the actual port the server is listening on
+	addr := server.listener.Addr().(*net.TCPAddr)
+	port := addr.Port
+
+	// Connect a client
+	clientConn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("Failed to connect client: %v", err)
+	}
+	defer clientConn.Close()
+
+	// Send messages
+	messages := []string{"First temporal ripple", "Second temporal ripple", "Third temporal ripple"}
+	for _, msg := range messages {
+		_, err := fmt.Fprintf(clientConn, "%s\n", msg)
+		if err != nil {
+			t.Fatalf("Failed to send message: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond) // Give server time to process
+	}
+
+	// Close client connection to signal EOF to server
+	clientConn.Close()
+
+	// Give server time to process and close connection
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify echoes were logged
+	logOutput := logBuffer.String()
+	for i, msg := range messages {
+		expectedLogPart := fmt.Sprintf("[ECHO %d]", i+1)
+		if !strings.Contains(logOutput, expectedLogPart) || !strings.Contains(logOutput, msg) {
+			t.Errorf("Expected log output to contain '%s' and '%s', but it didn't:\n%s", expectedLogPart, msg, logOutput)
+		}
+	}
+}
+
+// TestServer_EndToEnd_MultipleClients tests concurrent client connections
+func TestServer_EndToEnd_MultipleClients(t *testing.T) {
+	// Capture log output
+	var logBuffer bytes.Buffer
+	log.SetOutput(&logBuffer)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+
+	server := NewServer(0) // Use ephemeral port
+	err := server.Start()
+	if err != nil {
+		t.Fatalf("Failed to start server: %v", err)
+	}
+	defer server.Stop()
+
+	// Get the actual port
+	addr := server.listener.Addr().(*net.TCPAddr)
+	port := addr.Port
+
+	numClients := 5
+	messagesPerClient := 3
+	totalExpectedEchoes := numClients * messagesPerClient
+
+	var clientWg sync.WaitGroup
+	for i := 0; i < numClients; i++ {
+		clientWg.Add(1)
+		go func(clientID int) {
+			defer clientWg.Done()
+			conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+			if err != nil {
+				t.Errorf("Client %d failed to connect: %v", clientID, err)
+				return
+			}
+			defer conn.Close()
+
+			for j := 0; j < messagesPerClient; j++ {
+				msg := fmt.Sprintf("Client %d, Message %d", clientID, j)
+				_, err := fmt.Fprintf(conn, "%s\n", msg)
+				if err != nil {
+					t.Errorf("Client %d failed to send message: %v", clientID, err)
+					return
+				}
+				time.Sleep(time.Duration(clientID*10+j) * time.Millisecond) // Vary delay
+			}
+		}(i)
+	}
+
+	clientWg.Wait() // Wait for all clients to send messages and close
+	time.Sleep(500 * time.Millisecond) // Give server time to process all echoes
+
+	// Verify all echoes were logged
+	logOutput := logBuffer.String()
+	foundEchoes := 0
+	for i := 1; i <= totalExpectedEchoes; i++ {
+		expectedLogPart := fmt.Sprintf("[ECHO %d]", i)
+		if strings.Contains(logOutput, expectedLogPart) {
+			foundEchoes++
+		}
+	}
+
+	if foundEchoes != totalExpectedEchoes {
+		t.Errorf("Expected %d echoes to be logged, found %d.\nLog:\n%s", totalExpectedEchoes, foundEchoes, logOutput)
+	}
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-temporal-echo-listen
- **Provider**: gemini
- **Location**: `go-utils/nightly-nightly-temporal-echo-listen`
- **Files Created**: 3
- **Description**: A Go-based concurrent TCP server that listens for 'temporal echoes' (messages), processes them with timestamps and unique IDs, and logs them.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-temporal-echo-listen`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-temporal-echo-listen/README.md`
- Run tests located in `go-utils/nightly-nightly-temporal-echo-listen/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.