### PR TITLE
feat(groq): Prints a human‑readable difference between two ISO8601 timestamps

### DIFF
--- a/rust-utils/nightly-nightly-chrono-delta-humaniz/Cargo.toml
+++ b/rust-utils/nightly-nightly-chrono-delta-humaniz/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "nightly-chrono-delta-humanizer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chrono = "0.4"

--- a/rust-utils/nightly-nightly-chrono-delta-humaniz/README.md
+++ b/rust-utils/nightly-nightly-chrono-delta-humaniz/README.md
@@ -1,0 +1,32 @@
+# nightly-chrono-delta-humanizer
+
+Utility that takes two ISO8601 timestamps and prints the human‑readable difference (days, hours, minutes, seconds).
+
+## Usage
+
+```bash
+cargo run -- <START_ISO> <END_ISO>
+```
+
+Example:
+
+```bash
+cargo run -- 2023-01-01T00:00:00Z 2023-01-02T03:04:05Z
+```
+
+Output:
+```
+1 day, 3 hours, 4 minutes, 5 seconds
+```
+
+## Building
+
+```bash
+cargo build --release
+```
+
+## Testing
+
+```bash
+cargo test
+```

--- a/rust-utils/nightly-nightly-chrono-delta-humaniz/src/main.rs
+++ b/rust-utils/nightly-nightly-chrono-delta-humaniz/src/main.rs
@@ -1,0 +1,49 @@
+use std::env;
+use chrono::{DateTime, Utc, Duration};
+
+fn parse_iso(s: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(s)
+        .expect("Invalid timestamp")
+        .with_timezone(&Utc)
+}
+
+fn human_readable_duration(start: DateTime<Utc>, end: DateTime<Utc>) -> String {
+    let mut delta = end - start;
+    if delta < Duration::zero() {
+        delta = -delta;
+    }
+    let days = delta.num_days();
+    let hours = delta.num_hours() % 24;
+    let minutes = delta.num_minutes() % 60;
+    let seconds = delta.num_seconds() % 60;
+    let mut parts = Vec::new();
+    if days != 0 {
+        parts.push(format!("{} day{}", days, if days != 1 { "s" } else { "" }));
+    }
+    if hours != 0 {
+        parts.push(format!("{} hour{}", hours, if hours != 1 { "s" } else { "" }));
+    }
+    if minutes != 0 {
+        parts.push(format!("{} minute{}", minutes, if minutes != 1 { "s" } else { "" }));
+    }
+    if seconds != 0 || parts.is_empty() {
+        parts.push(format!("{} second{}", seconds, if seconds != 1 { "s" } else { "" }));
+    }
+    parts.join(", ")
+}
+
+pub fn compute_delta(start: &str, end: &str) -> String {
+    let s = parse_iso(start);
+    let e = parse_iso(end);
+    human_readable_duration(s, e)
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        eprintln!("Usage: {} <START_ISO> <END_ISO>", args[0]);
+        std::process::exit(1);
+    }
+    let result = compute_delta(&args[1], &args[2]);
+    println!("{}", result);
+}

--- a/rust-utils/nightly-nightly-chrono-delta-humaniz/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-chrono-delta-humaniz/tests/test_main.rs
@@ -1,0 +1,27 @@
+#[cfg(test)]
+mod tests {
+    use super::super::compute_delta;
+
+    #[test]
+    fn test_basic_delta() {
+        let start = "2023-01-01T00:00:00Z";
+        let end = "2023-01-02T03:04:05Z";
+        let out = compute_delta(start, end);
+        assert_eq!(out, "1 day, 3 hours, 4 minutes, 5 seconds");
+    }
+
+    #[test]
+    fn test_reverse_order() {
+        let start = "2023-01-02T03:04:05Z";
+        let end = "2023-01-01T00:00:00Z";
+        let out = compute_delta(start, end);
+        assert_eq!(out, "1 day, 3 hours, 4 minutes, 5 seconds");
+    }
+
+    #[test]
+    fn test_same_timestamp() {
+        let ts = "2023-05-05T12:30:30Z";
+        let out = compute_delta(ts, ts);
+        assert_eq!(out, "0 seconds");
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-chrono-delta-humanizer
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-chrono-delta-humaniz`
- **Files Created**: 4
- **Description**: Prints a human‑readable difference between two ISO8601 timestamps

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-chrono-delta-humaniz`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-chrono-delta-humaniz/README.md`
- Run tests located in `rust-utils/nightly-nightly-chrono-delta-humaniz/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.