### PR TITLE
feat(groq): A fast Rust CLI that computes the Shannon entropy of a file or stdin, helping you gauge randomness or compression.

### DIFF
--- a/rust-utils/nightly-nightly-entropy-gauge/Cargo.toml
+++ b/rust-utils/nightly-nightly-entropy-gauge/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "entropy-gauge"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-entropy-gauge/README.md
+++ b/rust-utils/nightly-nightly-entropy-gauge/README.md
@@ -1,0 +1,52 @@
+# nightly-entropy-gauge
+
+Utility to compute the Shannon entropy of a file or standard input. Useful for assessing randomness, detecting compressed or encrypted data, and just for fun in the apocalypse.
+
+## Installation
+
+```bash
+# Build and install locally
+cargo install --path .
+```
+
+Or compile manually:
+
+```bash
+cargo build --release
+./target/release/entropy-gauge <path>
+```
+
+## Usage
+
+```bash
+# Compute entropy of a file
+entropy-gauge path/to/file.bin
+
+# Compute entropy from stdin (use "-" or omit argument)
+cat file.bin | entropy-gauge -
+```
+
+The program prints the entropy in **bits per byte** with six decimal places.
+
+## Examples
+
+```bash
+$ echo -n "aaaa" | entropy-gauge -
+0.000000
+$ echo -n "abcd" | entropy-gauge -
+2.000000
+```
+
+## How it works
+
+The tool reads the entire input, counts the frequency of each byte (0‑255), and applies the Shannon entropy formula:
+
+```
+H = - Σ p_i * log2(p_i)
+```
+
+where *p_i* is the probability of byte *i*.
+
+## License
+
+MIT © ApocalypsAI

--- a/rust-utils/nightly-nightly-entropy-gauge/src/main.rs
+++ b/rust-utils/nightly-nightly-entropy-gauge/src/main.rs
@@ -1,0 +1,68 @@
+use std::env;
+use std::fs::File;
+use std::io::{self, Read};
+
+fn compute_entropy(data: &[u8]) -> f64 {
+    if data.is_empty() {
+        return 0.0;
+    }
+    let mut freq = [0usize; 256];
+    for &b in data {
+        freq[b as usize] += 1;
+    }
+    let len = data.len() as f64;
+    let mut entropy = 0.0;
+    for &count in freq.iter() {
+        if count > 0 {
+            let p = count as f64 / len;
+            entropy -= p * p.log2();
+        }
+    }
+    entropy
+}
+
+fn read_all<R: Read>(mut reader: R) -> io::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+fn main() -> io::Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let input = if args.len() > 1 && args[1] != "-" {
+        let mut file = File::open(&args[1])?;
+        read_all(&mut file)?
+    } else {
+        let stdin = io::stdin();
+        read_all(stdin.lock())?
+    };
+    let entropy = compute_entropy(&input);
+    println!("{:.6}", entropy);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_entropy_zero() {
+        let data = b"aaaa";
+        let e = compute_entropy(data);
+        assert!((e - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_entropy_two_bits() {
+        let data = b"abcd";
+        let e = compute_entropy(data);
+        assert!((e - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_entropy_empty() {
+        let data: &[u8] = b"";
+        let e = compute_entropy(data);
+        assert!((e - 0.0).abs() < 1e-6);
+    }
+}

--- a/rust-utils/nightly-nightly-entropy-gauge/tests/test_main.rs
+++ b/rust-utils/nightly-nightly-entropy-gauge/tests/test_main.rs
@@ -1,0 +1,4 @@
+#[test]
+fn placeholder() {
+    assert!(true);
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-entropy-gauge
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-entropy-gauge`
- **Files Created**: 4
- **Description**: A fast Rust CLI that computes the Shannon entropy of a file or stdin, helping you gauge randomness or compression.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-entropy-gauge`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-entropy-gauge/README.md`
- Run tests located in `rust-utils/nightly-nightly-entropy-gauge/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.