### PR TITLE
feat(groq): Terraform module that creates a secure, versioned S3 bucket with a whimsical supply list object and auto‑deletion of old items.

### DIFF
--- a/terraform-modules/nightly-nightly-apocalypse-supply-bu/README.md
+++ b/terraform-modules/nightly-nightly-apocalypse-supply-bu/README.md
@@ -1,0 +1,34 @@
+# Apocalypse Supply Bucket
+
+A whimsical Terraform module that provisions a secure S3 bucket named "apocalypse-supply-<random>" with versioning, server‑side encryption, and a lifecycle rule that deletes objects older than 30 days. It also creates an initial placeholder object `supply-list.txt` containing a fun list of survival items.
+
+## Usage
+
+```hcl
+module "supply_bucket" {
+  source = "git::https://github.com/yourorg/apocalypsai.git//terraform-modules/nightly-apocalypse-supply-bucket"
+  bucket_name_prefix = "apocalypse-supply"
+}
+```
+
+## Inputs
+
+- `bucket_name_prefix` (string): Prefix for bucket name. Default `"apocalypse-supply"`.
+
+## Outputs
+
+- `bucket_name` – The name of the created bucket.
+- `supply_object_key` – Key of the placeholder object.
+
+## Requirements
+
+- Terraform >= 1.0
+- AWS provider configured.
+
+## Testing
+
+Run the test script to validate the module locally:
+
+```bash
+bash tests/test_main.sh
+```

--- a/terraform-modules/nightly-nightly-apocalypse-supply-bu/src/main.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-supply-bu/src/main.tf
@@ -1,0 +1,70 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+variable "bucket_name_prefix" {
+  description = "Prefix for the S3 bucket name"
+  type        = string
+  default     = "apocalypse-supply"
+}
+
+# Generate a random suffix to ensure global uniqueness
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+resource "aws_s3_bucket" "supply_bucket" {
+  bucket        = "${var.bucket_name_prefix}-${random_pet.suffix.id}"
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "expire-old-supplies"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+
+    filter {}
+  }
+
+  tags = {
+    Purpose = "ApocalypseSupply"
+  }
+}
+
+resource "aws_s3_bucket_object" "supply_list" {
+  bucket                 = aws_s3_bucket.supply_bucket.id
+  key                    = "supply-list.txt"
+  content = <<-EOT
+    - Water (2 liters per person per day)
+    - Non-perishable food
+    - First aid kit
+    - Flashlight + batteries
+    - Multi-tool
+    - Radio (hand crank)
+  EOT
+  server_side_encryption = "AES256"
+}

--- a/terraform-modules/nightly-nightly-apocalypse-supply-bu/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-supply-bu/src/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  description = "Name of the created S3 bucket"
+  value       = aws_s3_bucket.supply_bucket.id
+}
+
+output "supply_object_key" {
+  description = "Key of the placeholder supply list object"
+  value       = aws_s3_bucket_object.supply_list.key
+}

--- a/terraform-modules/nightly-nightly-apocalypse-supply-bu/src/variables.tf
+++ b/terraform-modules/nightly-nightly-apocalypse-supply-bu/src/variables.tf
@@ -1,0 +1,5 @@
+variable "bucket_name_prefix" {
+  description = "Prefix for the S3 bucket name"
+  type        = string
+  default     = "apocalypse-supply"
+}

--- a/terraform-modules/nightly-nightly-apocalypse-supply-bu/tests/test_main.sh
+++ b/terraform-modules/nightly-nightly-apocalypse-supply-bu/tests/test_main.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Initialize Terraform with a local (no‑remote) backend
+terraform -chdir=../src init -backend=false > /dev/null
+
+# Validate the configuration – this does not require AWS credentials
+terraform -chdir=../src validate
+
+echo "All tests passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-apocalypse-supply-bucket
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-apocalypse-supply-bu`
- **Files Created**: 5
- **Description**: Terraform module that creates a secure, versioned S3 bucket with a whimsical supply list object and auto‑deletion of old items.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-apocalypse-supply-bu`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-apocalypse-supply-bu/README.md`
- Run tests located in `terraform-modules/nightly-nightly-apocalypse-supply-bu/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.