### PR TITLE
feat(groq): Generates whimsical mutant names, optionally deterministic via a seed.

### DIFF
--- a/rust-utils/nightly-nightly-mutant-name-generato/Cargo.toml
+++ b/rust-utils/nightly-nightly-mutant-name-generato/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "mutant_name_generator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-mutant-name-generato/README.md
+++ b/rust-utils/nightly-nightly-mutant-name-generato/README.md
@@ -1,0 +1,30 @@
+# Mutant Name Generator
+
+A tiny Rust CLI that creates a random, post‑apocalyptic mutant name.
+
+## Usage
+
+```sh
+cargo run --quiet -- [--seed <u64>]
+```
+
+- `--seed` optional integer to make the output deterministic.
+
+## Example
+
+```sh
+$ cargo run --quiet -- --seed 42
+Feral Reaper
+```
+
+## Building
+
+```sh
+cargo build --release
+```
+
+## Testing
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-mutant-name-generato/src/lib.rs
+++ b/rust-utils/nightly-nightly-mutant-name-generato/src/lib.rs
@@ -1,0 +1,32 @@
+/// Generate a mutant name using the given seed.
+/// Returns a string like "Feral Reaper".
+pub fn generate_name(seed: u64) -> String {
+    const ADJECTIVES: [&str; 10] = [
+        "Gloomy",
+        "Radiant",
+        "Feral",
+        "Mutant",
+        "Savage",
+        "Cursed",
+        "Wretched",
+        "Vicious",
+        "Silent",
+        "Grim",
+    ];
+    const NOUNS: [&str; 10] = [
+        "Scavenger",
+        "Wanderer",
+        "Beast",
+        "Ghoul",
+        "Reaper",
+        "Stalker",
+        "Marauder",
+        "Ravager",
+        "Nomad",
+        "Harbinger",
+    ];
+
+    let adj_index = (seed as usize) % ADJECTIVES.len();
+    let noun_index = ((seed / ADJECTIVES.len() as u64) as usize) % NOUNS.len();
+    format!("{} {}", ADJECTIVES[adj_index], NOUNS[noun_index])
+}

--- a/rust-utils/nightly-nightly-mutant-name-generato/src/main.rs
+++ b/rust-utils/nightly-nightly-mutant-name-generato/src/main.rs
@@ -1,0 +1,28 @@
+use std::env;
+use mutant_name_generator::generate_name;
+
+fn parse_seed(args: &[String]) -> Option<u64> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--seed" {
+            if let Some(val) = iter.next() {
+                return val.parse::<u64>().ok();
+            }
+        }
+    }
+    None
+}
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+    let seed = parse_seed(&args).unwrap_or_else(|| {
+        // Fallback: use current Unix timestamp as seed
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let duration = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default();
+        duration.as_secs()
+    });
+    let name = generate_name(seed);
+    println!("{}", name);
+}

--- a/rust-utils/nightly-nightly-mutant-name-generato/tests/test_name.rs
+++ b/rust-utils/nightly-nightly-mutant-name-generato/tests/test_name.rs
@@ -1,0 +1,15 @@
+use mutant_name_generator::generate_name;
+
+#[test]
+fn deterministic_name_with_seed_42() {
+    // Seed 42 should always produce "Feral Reaper"
+    let name = generate_name(42);
+    assert_eq!(name, "Feral Reaper");
+}
+
+#[test]
+fn deterministic_name_with_seed_7() {
+    // Seed 7 should always produce "Vicious Scavenger"
+    let name = generate_name(7);
+    assert_eq!(name, "Vicious Scavenger");
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-mutant-name-generator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-mutant-name-generato`
- **Files Created**: 5
- **Description**: Generates whimsical mutant names, optionally deterministic via a seed.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-mutant-name-generato`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-mutant-name-generato/README.md`
- Run tests located in `rust-utils/nightly-nightly-mutant-name-generato/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.