### PR TITLE
feat(groq): Concurrent HTTP latency checker that pings multiple URLs and reports a JSON summary of response times.

### DIFF
--- a/go-utils/nightly-nightly-network-pulse/README.md
+++ b/go-utils/nightly-nightly-network-pulse/README.md
@@ -1,0 +1,41 @@
+# Nightly Network Pulse
+
+A whimsical yet practical concurrent HTTP latency checker.  Give it a list of URLs and it will ping them in parallel, then output a JSON array with each URL's status code, response time (ms), and any error.
+
+## Build
+
+```sh
+go build -o network-pulse ./src/main.go
+```
+
+## Usage
+
+```sh
+./network-pulse -timeout 3 https://example.com https://golang.org
+```
+
+* `-timeout` – request timeout in seconds (default 5)
+
+The program prints a pretty‑printed JSON summary to stdout.
+
+## Example Output
+
+```json
+[
+  {
+    "url": "https://example.com",
+    "status_code": 200,
+    "duration_ms": 123.4
+  },
+  {
+    "url": "https://nonexistent.invalid",
+    "error": "dial tcp: lookup nonexistent.invalid: no such host"
+  }
+]
+```
+
+## Testing
+
+```sh
+go test ./tests/...
+```

--- a/go-utils/nightly-nightly-network-pulse/src/main.go
+++ b/go-utils/nightly-nightly-network-pulse/src/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+    "encoding/json"
+    "flag"
+    "fmt"
+    "net/http"
+    "os"
+    "sync"
+    "time"
+)
+
+type Result struct {
+    URL        string  `json:"url"`
+    StatusCode int     `json:"status_code,omitempty"`
+    DurationMs float64 `json:"duration_ms,omitempty"`
+    Error      string  `json:"error,omitempty"`
+}
+
+func ping(url string, timeout time.Duration) Result {
+    client := http.Client{Timeout: timeout}
+    start := time.Now()
+    resp, err := client.Get(url)
+    elapsed := time.Since(start).Seconds() * 1000 // milliseconds
+    if err != nil {
+        return Result{URL: url, Error: err.Error()}
+    }
+    defer resp.Body.Close()
+    return Result{URL: url, StatusCode: resp.StatusCode, DurationMs: elapsed}
+}
+
+func main() {
+    timeout := flag.Int("timeout", 5, "request timeout in seconds")
+    flag.Parse()
+    urls := flag.Args()
+    if len(urls) == 0 {
+        fmt.Fprintln(os.Stderr, "Usage: network-pulse [options] <url1> <url2> ...")
+        os.Exit(1)
+    }
+
+    var wg sync.WaitGroup
+    results := make([]Result, len(urls))
+    for i, u := range urls {
+        wg.Add(1)
+        go func(idx int, url string) {
+            defer wg.Done()
+            results[idx] = ping(url, time.Duration(*timeout)*time.Second)
+        }(i, u)
+    }
+    wg.Wait()
+
+    out, _ := json.MarshalIndent(results, "", "  ")
+    fmt.Println(string(out))
+}

--- a/go-utils/nightly-nightly-network-pulse/tests/main_test.go
+++ b/go-utils/nightly-nightly-network-pulse/tests/main_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "io"
+    "net/http"
+    "net/http/httptest"
+    "os"
+    "testing"
+    "time"
+)
+
+func TestPingSuccess(t *testing.T) {
+    // Server that responds after a short delay
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        time.Sleep(10 * time.Millisecond)
+        w.WriteHeader(http.StatusOK)
+        w.Write([]byte("ok"))
+    }))
+    defer srv.Close()
+
+    res := ping(srv.URL, 2*time.Second)
+    if res.Error != "" {
+        t.Fatalf("unexpected error: %s", res.Error)
+    }
+    if res.StatusCode != http.StatusOK {
+        t.Fatalf("expected 200, got %d", res.StatusCode)
+    }
+    if res.DurationMs < 9 || res.DurationMs > 50 {
+        t.Fatalf("unexpected duration %f ms", res.DurationMs)
+    }
+}
+
+func TestPingTimeout(t *testing.T) {
+    // Server that sleeps longer than the timeout
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        time.Sleep(200 * time.Millisecond)
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer srv.Close()
+
+    res := ping(srv.URL, 50*time.Millisecond)
+    if res.Error == "" {
+        t.Fatalf("expected timeout error, got none")
+    }
+}
+
+func TestMainOutput(t *testing.T) {
+    // Fast server
+    fast := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer fast.Close()
+    // Slow server with different status
+    slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        time.Sleep(30 * time.Millisecond)
+        w.WriteHeader(http.StatusTeapot)
+    }))
+    defer slow.Close()
+
+    // Capture stdout
+    oldStdout := os.Stdout
+    r, w, _ := os.Pipe()
+    os.Stdout = w
+
+    // Simulate command‑line arguments
+    os.Args = []string{"cmd", "-timeout", "1", fast.URL, slow.URL}
+    main()
+
+    w.Close()
+    os.Stdout = oldStdout
+    var buf bytes.Buffer
+    io.Copy(&buf, r)
+
+    var results []Result
+    if err := json.Unmarshal(buf.Bytes(), &results); err != nil {
+        t.Fatalf("invalid JSON output: %v", err)
+    }
+    if len(results) != 2 {
+        t.Fatalf("expected 2 results, got %d", len(results))
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-network-pulse
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-network-pulse`
- **Files Created**: 3
- **Description**: Concurrent HTTP latency checker that pings multiple URLs and reports a JSON summary of response times.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-network-pulse`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-network-pulse/README.md`
- Run tests located in `go-utils/nightly-nightly-network-pulse/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.