### PR TITLE
feat(groq): An Ansible playbook that distributes a random fun fact to target hosts, writing it to a configurable file for a whimsical login message.

### DIFF
--- a/ansible-playbooks/nightly-nightly-ansible-fun-fact-dis/README.md
+++ b/ansible-playbooks/nightly-nightly-ansible-fun-fact-dis/README.md
@@ -1,0 +1,24 @@
+# Nightly Ansible Fun Fact Distributor
+
+Utility that distributes a random fun fact to target hosts, writing it to a configurable file (default `/etc/motd_fun_fact`). Each run picks a different fact from a curated list, adding a whimsical touch to server logins.
+
+## Usage
+
+```bash
+ansible-playbook -i src/inventory.ini src/fun_fact.yml
+```
+
+You can override the destination path with the `dest_path` extra variable:
+
+```bash
+ansible-playbook -i src/inventory.ini src/fun_fact.yml -e "dest_path=/tmp/my_fact.txt"
+```
+
+## Variables
+
+- `fun_facts`: list of strings (default provided).
+- `dest_path`: destination file path where the fact will be written (default `/etc/motd_fun_fact`).
+
+## How it works
+
+The playbook selects a random fact using the `random` filter and writes it to the specified file on each host.

--- a/ansible-playbooks/nightly-nightly-ansible-fun-fact-dis/src/fun_fact.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-fun-fact-dis/src/fun_fact.yml
@@ -1,0 +1,24 @@
+---
+- name: Distribute a random fun fact
+  hosts: all
+  become: true
+  vars:
+    dest_path: /etc/motd_fun_fact
+    fun_facts:
+      - "Honey never spoils."
+      - "Bananas are berries, but strawberries aren't."
+      - "Octopuses have three hearts."
+      - "A day on Venus is longer than its year."
+      - "There are more stars in the universe than grains of sand on Earth."
+  tasks:
+    - name: Choose a random fact
+      set_fact:
+        selected_fact: "{{ fun_facts | random }}"
+
+    - name: Write the fact to the destination file
+      copy:
+        dest: "{{ dest_path }}"
+        content: "{{ selected_fact }}\n"
+        owner: root
+        group: root
+        mode: '0644'

--- a/ansible-playbooks/nightly-nightly-ansible-fun-fact-dis/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-ansible-fun-fact-dis/src/inventory.ini
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-ansible-fun-fact-dis/tests/test_fun_fact.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-fun-fact-dis/tests/test_fun_fact.yml
@@ -1,0 +1,41 @@
+---
+- name: Verify fun fact distribution
+  hosts: localhost
+  become: false
+  vars:
+    dest_path: /tmp/motd_fun_fact_test
+    expected_facts:
+      - "Honey never spoils."
+      - "Bananas are berries, but strawberries aren't."
+      - "Octopuses have three hearts."
+      - "A day on Venus is longer than its year."
+      - "There are more stars in the universe than grains of sand on Earth."
+  tasks:
+    - name: Run the fun_fact playbook with custom destination
+      import_playbook: ../src/fun_fact.yml
+      vars:
+        dest_path: "{{ dest_path }}"
+
+    - name: Ensure the fact file exists
+      stat:
+        path: "{{ dest_path }}"
+      register: fact_file
+
+    - name: Assert file exists
+      assert:
+        that:
+          - fact_file.stat.exists
+
+    - name: Read the fact file content
+      slurp:
+        src: "{{ dest_path }}"
+      register: fact_content
+
+    - name: Decode fact text
+      set_fact:
+        fact_text: "{{ fact_content.content | b64decode | trim }}"
+
+    - name: Assert fact is from the predefined list
+      assert:
+        that:
+          - fact_text in expected_facts


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansible-fun-fact-distributor
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-ansible-fun-fact-dis`
- **Files Created**: 4
- **Description**: An Ansible playbook that distributes a random fun fact to target hosts, writing it to a configurable file for a whimsical login message.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-ansible-fun-fact-dis`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-ansible-fun-fact-dis/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-ansible-fun-fact-dis/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.