### PR TITLE
feat(groq): An Ansible playbook that configures a daily cron job to toggle a smart plug for automated plant watering.

### DIFF
--- a/ansible-playbooks/nightly-nightly-plant-watering-sched-4/README.md
+++ b/ansible-playbooks/nightly-nightly-plant-watering-sched-4/README.md
@@ -1,0 +1,21 @@
+# Plant Watering Scheduler
+
+This Ansible playbook sets up a daily cron job that triggers a smart plug to water your plants. It is whimsical yet practical for home automation enthusiasts.
+
+## Requirements
+
+- Ansible 2.9+
+- Access to the smart plug's HTTP API (IP address)
+
+## Variables
+
+- `plant_watering_plug_ip` (string): IP address of the smart plug.
+- `plant_watering_time` (string, default "07:00"): Time of day to water plants (24h format).
+
+## Usage
+
+```bash
+ansible-playbook -i inventory.ini src/playbook.yml -e "plant_watering_plug_ip=192.168.1.50 plant_watering_time=07:00"
+```
+
+The playbook will create a cron job that runs a `curl` command to toggle the plug at the specified time.

--- a/ansible-playbooks/nightly-nightly-plant-watering-sched-4/src/playbook.yml
+++ b/ansible-playbooks/nightly-nightly-plant-watering-sched-4/src/playbook.yml
@@ -1,0 +1,20 @@
+---
+- name: Configure plant watering scheduler
+  hosts: all
+  become: true
+  vars:
+    plant_watering_plug_ip: "{{ plant_watering_plug_ip | default('192.168.1.100') }}"
+    plant_watering_time: "{{ plant_watering_time | default('07:00') }}"
+  tasks:
+    - name: Ensure curl is installed
+      ansible.builtin.package:
+        name: curl
+        state: present
+
+    - name: Create cron job for plant watering
+      ansible.builtin.cron:
+        name: "Plant watering via smart plug"
+        minute: "{{ plant_watering_time.split(':')[1] }}"
+        hour: "{{ plant_watering_time.split(':')[0] }}"
+        job: "curl -X POST http://{{ plant_watering_plug_ip }}/relay/0"
+        user: root

--- a/ansible-playbooks/nightly-nightly-plant-watering-sched-4/tests/test_playbook.py
+++ b/ansible-playbooks/nightly-nightly-plant-watering-sched-4/tests/test_playbook.py
@@ -1,0 +1,26 @@
+import unittest
+import yaml
+import os
+
+class TestPlantWateringPlaybook(unittest.TestCase):
+    def setUp(self):
+        playbook_path = os.path.join(os.path.dirname(__file__), '..', 'src', 'playbook.yml')
+        with open(playbook_path, 'r') as f:
+            self.playbook = yaml.safe_load(f)
+
+    def test_playbook_structure(self):
+        # Ensure top-level is a list with at least one dict
+        self.assertIsInstance(self.playbook, list)
+        self.assertGreaterEqual(len(self.playbook), 1)
+        first = self.playbook[0]
+        self.assertIn('tasks', first)
+        tasks = first['tasks']
+        # Check that there is a cron task
+        cron_tasks = [t for t in tasks if 'cron' in t]
+        self.assertTrue(any(cron_tasks), "Cron task not defined")
+        cron_task = cron_tasks[0]['cron']
+        self.assertEqual(cron_task['name'], "Plant watering via smart plug")
+        self.assertIn('job', cron_task)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-plant-watering-scheduler
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-plant-watering-sched-4`
- **Files Created**: 3
- **Description**: An Ansible playbook that configures a daily cron job to toggle a smart plug for automated plant watering.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-plant-watering-sched-4`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-plant-watering-sched-4/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-plant-watering-sched-4/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.