### PR TITLE
feat(groq): Sum up gear weights from a JSON list and output totals in kilograms and pounds.

### DIFF
--- a/node-utils/nightly-nightly-gear-weight-calculat/README.md
+++ b/node-utils/nightly-nightly-gear-weight-calculat/README.md
@@ -1,0 +1,38 @@
+# nightly-gear-weight-calculator
+
+Utility to sum up gear weights for post‑apocalyptic survivors. Accepts a JSON file describing items with weight and unit (kg or lb) and outputs the total weight in both kilograms and pounds.
+
+## Installation
+
+```sh
+npm install -g .
+```
+
+## Usage
+
+```sh
+node src/index.js path/to/items.json
+# or pipe JSON via stdin
+cat items.json | node src/index.js
+```
+
+## Input format
+
+```json
+[
+  {"name":"Backpack","weight":5,"unit":"kg"},
+  {"name":"Water Bottle","weight":2,"unit":"lb"}
+]
+```
+
+## Output
+
+```json
+{"totalKg":5.907184,"totalLb":13.0231}
+```
+
+## Testing
+
+```sh
+npm test
+```

--- a/node-utils/nightly-nightly-gear-weight-calculat/src/index.js
+++ b/node-utils/nightly-nightly-gear-weight-calculat/src/index.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+
+function convertToKg(item) {
+  if (item.unit === "kg") return item.weight;
+  if (item.unit === "lb") return item.weight * 0.453592;
+  throw new Error(`Unsupported unit: ${item.unit}`);
+}
+function convertToLb(item) {
+  if (item.unit === "lb") return item.weight;
+  if (item.unit === "kg") return item.weight * 2.20462;
+  throw new Error(`Unsupported unit: ${item.unit}`);
+}
+
+/**
+ * Compute total weight in kg and lb.
+ * @param {Array<{name:string,weight:number,unit:"kg"|"lb"}>} items
+ * @returns {{totalKg:number,totalLb:number}}
+ */
+function computeTotal(items) {
+  const totalKg = items.reduce((sum, i) => sum + convertToKg(i), 0);
+  const totalLb = items.reduce((sum, i) => sum + convertToLb(i), 0);
+  // round to 6 decimal places for readability
+  return {
+    totalKg: Math.round(totalKg * 1e6) / 1e6,
+    totalLb: Math.round(totalLb * 1e6) / 1e6,
+  };
+}
+
+// CLI handling
+if (require.main === module) {
+  const inputPath = process.argv[2];
+  let raw = "";
+  if (inputPath) {
+    raw = fs.readFileSync(inputPath, "utf8");
+    try {
+      const items = JSON.parse(raw);
+      const result = computeTotal(items);
+      console.log(JSON.stringify(result));
+    } catch (e) {
+      console.error("Error parsing input:", e.message);
+      process.exit(1);
+    }
+  } else {
+    // Read from stdin
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (raw += chunk));
+    process.stdin.on("end", () => {
+      try {
+        const items = JSON.parse(raw);
+        const result = computeTotal(items);
+        console.log(JSON.stringify(result));
+      } catch (e) {
+        console.error("Error parsing input:", e.message);
+        process.exit(1);
+      }
+    });
+    if (process.stdin.isTTY) {
+      console.error("No input provided.");
+      process.exit(1);
+    }
+  }
+}
+
+module.exports = { computeTotal };

--- a/node-utils/nightly-nightly-gear-weight-calculat/tests/test_index.js
+++ b/node-utils/nightly-nightly-gear-weight-calculat/tests/test_index.js
@@ -1,0 +1,18 @@
+const assert = require("assert");
+const { computeTotal } = require("../src/index");
+
+// Mock rationale: deterministic sample data
+const sample = [
+  { name: "Backpack", weight: 5, unit: "kg" },
+  { name: "Water Bottle", weight: 2, unit: "lb" },
+];
+
+const result = computeTotal(sample);
+
+// Expected calculations:
+// 2 lb = 0.907184 kg
+// totalKg = 5 + 0.907184 = 5.907184
+// 5 kg = 11.0231 lb, plus 2 lb = 13.0231 lb
+assert.strictEqual(result.totalKg, 5.907184);
+assert.strictEqual(result.totalLb, 13.0231);
+console.log("All tests passed");


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-gear-weight-calculator
- **Provider**: groq
- **Location**: `node-utils/nightly-nightly-gear-weight-calculat`
- **Files Created**: 3
- **Description**: Sum up gear weights from a JSON list and output totals in kilograms and pounds.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `node-utils/nightly-nightly-gear-weight-calculat`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `node-utils/nightly-nightly-gear-weight-calculat/README.md`
- Run tests located in `node-utils/nightly-nightly-gear-weight-calculat/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.