### PR TITLE
feat(groq): A tiny Dockerized Go HTTP server that serves a random whimsical quote on each request.

### DIFF
--- a/docker-tools/nightly-nightly-docker-quote-server-4/Dockerfile
+++ b/docker-tools/nightly-nightly-docker-quote-server-4/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY src/ ./
+RUN go build -o quote-server .
+
+FROM alpine:3.19
+WORKDIR /app
+COPY --from=builder /app/quote-server .
+EXPOSE 8080
+ENTRYPOINT ["./quote-server"]

--- a/docker-tools/nightly-nightly-docker-quote-server-4/README.md
+++ b/docker-tools/nightly-nightly-docker-quote-server-4/README.md
@@ -1,0 +1,35 @@
+# Nightly Docker Quote Server
+
+A whimsical Dockerized Go HTTP server that returns a random quote each time you hit the root endpoint.
+
+## Build
+
+```sh
+docker build -t nightly-docker-quote-server .
+```
+
+## Run
+
+```sh
+docker run -p 8080:8080 nightly-docker-quote-server
+```
+
+## Usage
+
+```sh
+curl http://localhost:8080/
+```
+
+Will return a plain‑text quote, e.g.:
+
+> "The early bird gets the worm, but the second mouse gets the cheese."
+
+## How it works
+
+The server is a single‑binary Go program compiled inside a multi‑stage Docker build. On each request it picks a random entry from an embedded slice of whimsical quotes.
+
+## Testing
+
+```sh
+go test ./...
+```

--- a/docker-tools/nightly-nightly-docker-quote-server-4/src/main.go
+++ b/docker-tools/nightly-nightly-docker-quote-server-4/src/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+    "fmt"
+    "log"
+    "math/rand"
+    "net/http"
+    "time"
+)
+
+var quotes = []string{
+    "The early bird gets the worm, but the second mouse gets the cheese.",
+    "When life gives you lemons, make lemonade… and then find someone whose life gave them vodka.",
+    "I put the 'pro' in procrastination.",
+    "If at first you don't succeed, skydiving is not for you.",
+    "Debugging: Being the detective in a crime movie where you are also the murderer.",
+}
+
+// getRandomQuote returns a random quote from the quotes slice.
+// It is deterministic when the random seed is set.
+func getRandomQuote() string {
+    if len(quotes) == 0 {
+        return ""
+    }
+    idx := rand.Intn(len(quotes))
+    return quotes[idx]
+}
+
+// quoteHandler writes a random quote to the response.
+func quoteHandler(w http.ResponseWriter, r *http.Request) {
+    fmt.Fprintln(w, getRandomQuote())
+}
+
+func main() {
+    rand.Seed(time.Now().UnixNano())
+    http.HandleFunc("/", quoteHandler)
+    log.Println("Starting server on :8080")
+    if err := http.ListenAndServe(":8080", nil); err != nil {
+        log.Fatalf("Server failed: %v", err)
+    }
+}

--- a/docker-tools/nightly-nightly-docker-quote-server-4/tests/main_test.go
+++ b/docker-tools/nightly-nightly-docker-quote-server-4/tests/main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+    "math/rand"
+    "testing"
+)
+
+func TestGetRandomQuoteDeterministic(t *testing.T) {
+    // Mock rationale: set a fixed seed to make the random choice predictable.
+    rand.Seed(42)
+    got := getRandomQuote()
+    expected := "If at first you don't succeed, skydiving is not for you."
+    if got != expected {
+        t.Fatalf("expected %q, got %q", expected, got)
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-docker-quote-server
- **Provider**: groq
- **Location**: `docker-tools/nightly-nightly-docker-quote-server-4`
- **Files Created**: 4
- **Description**: A tiny Dockerized Go HTTP server that serves a random whimsical quote on each request.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `docker-tools/nightly-nightly-docker-quote-server-4`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `docker-tools/nightly-nightly-docker-quote-server-4/README.md`
- Run tests located in `docker-tools/nightly-nightly-docker-quote-server-4/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.