### PR TITLE
feat(groq): Terraform module that creates a versioned S3 bucket with a random suffix and a 30‑day lifecycle rule for post‑apocalyptic supplies.

### DIFF
--- a/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/README.md
@@ -1,0 +1,40 @@
+# Nightly Safehouse S3 Terraform Module
+
+A whimsical Terraform module that creates a version‑enabled S3 bucket for storing post‑apocalyptic supplies. The bucket name is prefixed by a user‑provided string and suffixed with a random ID to avoid collisions. Includes a lifecycle rule that expires objects after 30 days.
+
+## Usage
+
+```hcl
+module "safehouse_s3" {
+  source             = "github.com/yourorg/polsala/terraform-modules/nightly-safehouse-s3"
+  bucket_name_prefix = "my-safehouse"
+  tags = {
+    Environment = "apocalypse"
+    Owner       = "survivor"
+  }
+}
+```
+
+Run:
+
+```sh
+terraform init
+terraform apply
+```
+
+## Inputs
+
+- `bucket_name_prefix` (string, required): Prefix for the bucket name.
+- `tags` (map(string), optional): Tags to apply to the bucket.
+- `aws_region` (string, optional): AWS region (default `us-east-1`).
+
+## Outputs
+
+- `bucket_id` – The name of the bucket.
+- `bucket_arn` – The ARN of the bucket.
+
+## Testing
+
+```sh
+cd tests && ./test_main.sh
+```

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/src/main.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/src/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+resource "aws_s3_bucket" "safehouse" {
+  bucket = "${var.bucket_name_prefix}-${random_id.suffix.hex}"
+  tags   = var.tags
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    id      = "expire-old-objects"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/src/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_id" {
+  description = "The name of the S3 bucket."
+  value       = aws_s3_bucket.safehouse.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the S3 bucket."
+  value       = aws_s3_bucket.safehouse.arn
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/src/variables.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/src/variables.tf
@@ -1,0 +1,16 @@
+variable "bucket_name_prefix" {
+  description = "Prefix for the S3 bucket name."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to the bucket."
+  type        = map(string)
+  default     = {}
+}
+
+variable "aws_region" {
+  description = "AWS region."
+  type        = string
+  default     = "us-east-1"
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-8/tests/test_main.sh
+++ b/terraform-modules/nightly-nightly-safehouse-s3-8/tests/test_main.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# Mock rationale: Use local backend and dummy provider config; no real AWS calls.
+terraform -chdir=../src init -backend=false > /dev/null
+
+# Validate configuration
+terraform -chdir=../src validate
+
+# Generate a plan and capture output
+PLAN_OUTPUT=$(terraform -chdir=../src plan -no-color -input=false -var='bucket_name_prefix=testsafehouse' 2>&1)
+
+# Check that the plan includes an aws_s3_bucket resource
+if echo "$PLAN_OUTPUT" | grep -q 'aws_s3_bucket.safehouse'; then
+  echo "PASS: S3 bucket resource found in plan."
+  exit 0
+else
+  echo "FAIL: S3 bucket resource not found."
+  exit 1
+fi


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-safehouse-s3
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-safehouse-s3-8`
- **Files Created**: 5
- **Description**: Terraform module that creates a versioned S3 bucket with a random suffix and a 30‑day lifecycle rule for post‑apocalyptic supplies.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-safehouse-s3-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-safehouse-s3-8/README.md`
- Run tests located in `terraform-modules/nightly-nightly-safehouse-s3-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.