### PR TITLE
feat(groq): CLI tool that adds a human‑readable duration to the current time and prints the future ISO‑8601 timestamp.

### DIFF
--- a/rust-utils/nightly-nightly-future-timestamp/Cargo.toml
+++ b/rust-utils/nightly-nightly-future-timestamp/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "nightly-future-timestamp"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chrono = "0.4"
+regex = "1"

--- a/rust-utils/nightly-nightly-future-timestamp/README.md
+++ b/rust-utils/nightly-nightly-future-timestamp/README.md
@@ -1,0 +1,52 @@
+# nightly-future-timestamp
+
+A tiny, whimsical yet useful command‑line utility written in Rust.
+
+## What it does
+
+`nightly-future-timestamp` takes a single *duration* argument (e.g. `2d5h30m`) and prints the ISO‑8601 timestamp that will occur after adding that duration to the current UTC time.
+
+The duration syntax supports:
+
+- `d` – days
+- `h` – hours
+- `m` – minutes
+- `s` – seconds
+
+The components can appear in any order and are optional, but at least one must be present. Examples:
+
+```
+$ nightly-future-timestamp 1h
+2023-09-15T14:23:45Z
+
+$ nightly-future-timestamp 2d5h30m
+2023-09-17T19:53:45Z
+```
+
+## Installation
+
+```bash
+# Clone the repository (or copy the generated folder) and build
+git clone https://github.com/polsala/ApocalypsAI.git
+cd utils/nightly-future-timestamp
+cargo build --release
+# The binary will be at target/release/nightly-future-timestamp
+```
+
+## Usage
+
+```bash
+nightly-future-timestamp <duration>
+```
+
+If the argument cannot be parsed, the program exits with a non‑zero status and prints an error message.
+
+## Testing
+
+Run the built‑in test suite with:
+
+```bash
+cargo test
+```
+
+The tests are deterministic and do not depend on the actual current time.

--- a/rust-utils/nightly-nightly-future-timestamp/src/main.rs
+++ b/rust-utils/nightly-nightly-future-timestamp/src/main.rs
@@ -1,0 +1,86 @@
+use chrono::{DateTime, Duration, Utc};
+use regex::Regex;
+use std::env;
+
+fn parse_duration(input: &str) -> Result<Duration, String> {
+    // Regex captures optional groups for days, hours, minutes, seconds
+    let re = Regex::new(r"(?i)^(?:(?P<days>\d+)d)?(?:(?P<hours>\d+)h)?(?:(?P<minutes>\d+)m)?(?:(?P<seconds>\d+)s)?$")
+        .map_err(|e| format!("Invalid regex: {}", e))?;
+    let caps = re.captures(input).ok_or_else(|| format!("Could not parse duration '{}'. Expected format like '2d5h30m'", input))?;
+
+    let days = caps.name("days").map_or(0, |m| m.as_str().parse::<i64>().unwrap_or(0));
+    let hours = caps.name("hours").map_or(0, |m| m.as_str().parse::<i64>().unwrap_or(0));
+    let minutes = caps.name("minutes").map_or(0, |m| m.as_str().parse::<i64>().unwrap_or(0));
+    let seconds = caps.name("seconds").map_or(0, |m| m.as_str().parse::<i64>().unwrap_or(0));
+
+    if days == 0 && hours == 0 && minutes == 0 && seconds == 0 {
+        return Err(format!("Duration '{}' does not contain any recognizable component", input));
+    }
+
+    Ok(Duration::seconds(seconds)
+        + Duration::minutes(minutes)
+        + Duration::hours(hours)
+        + Duration::days(days))
+}
+
+/// Adds a parsed duration to a given base datetime.
+/// This function is pure and therefore easy to test.
+pub fn add_duration(base: DateTime<Utc>, dur_str: &str) -> Result<DateTime<Utc>, String> {
+    let dur = parse_duration(dur_str)?;
+    Ok(base + dur)
+}
+
+fn print_usage() {
+    eprintln!("Usage: nightly-future-timestamp <duration>");
+    eprintln!("Duration format: combination of <number>d, <number>h, <number>m, <number>s (e.g., '2d5h30m')");
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        print_usage();
+        std::process::exit(1);
+    }
+    let dur_str = &args[1];
+    match add_duration(Utc::now(), dur_str) {
+        Ok(future) => println!("{}", future.to_rfc3339()),
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn test_parse_simple() {
+        let dur = parse_duration("1h").expect("should parse");
+        assert_eq!(dur, Duration::hours(1));
+    }
+
+    #[test]
+    fn test_parse_complex() {
+        let dur = parse_duration("2d5h30m").expect("should parse");
+        let expected = Duration::days(2) + Duration::hours(5) + Duration::minutes(30);
+        assert_eq!(dur, expected);
+    }
+
+    #[test]
+    fn test_add_duration() {
+        // Fixed base time: 2023-01-01T00:00:00Z
+        let base = Utc.ymd(2023, 1, 1).and_hms(0, 0, 0);
+        let future = add_duration(base, "1d2h").expect("add should succeed");
+        let expected = Utc.ymd(2023, 1, 2).and_hms(2, 0, 0);
+        assert_eq!(future, expected);
+    }
+
+    #[test]
+    fn test_invalid_duration() {
+        let err = parse_duration("abc").unwrap_err();
+        assert!(err.contains("Could not parse duration"));
+    }
+}

--- a/rust-utils/nightly-nightly-future-timestamp/tests/integration_test.rs
+++ b/rust-utils/nightly-nightly-future-timestamp/tests/integration_test.rs
@@ -1,0 +1,14 @@
+// Integration tests for nightly-future-timestamp
+// These tests invoke the public `add_duration` function directly,
+// ensuring deterministic behavior without needing to mock system time.
+
+use nightly_future_timestamp::add_duration;
+use chrono::{TimeZone, Utc};
+
+#[test]
+fn integration_future_timestamp() {
+    let base = Utc.ymd(2022, 12, 31).and_hms(23, 0, 0);
+    let result = add_duration(base, "1h30m").expect("should compute future time");
+    let expected = Utc.ymd(2023, 1, 1).and_hms(0, 30, 0);
+    assert_eq!(result, expected);
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-future-timestamp
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-future-timestamp`
- **Files Created**: 4
- **Description**: CLI tool that adds a human‑readable duration to the current time and prints the future ISO‑8601 timestamp.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-future-timestamp`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-future-timestamp/README.md`
- Run tests located in `rust-utils/nightly-nightly-future-timestamp/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.