### PR TITLE
feat(groq): A tiny concurrent HTTP service that turns posted messages into QR code PNGs, perfect for secret post‑apocalypse communications.

### DIFF
--- a/go-utils/nightly-nightly-qr-broadcast/README.md
+++ b/go-utils/nightly-nightly-qr-broadcast/README.md
@@ -1,0 +1,35 @@
+# QR Broadcast Service
+
+A tiny Go HTTP service that receives a JSON payload with a `message` field and returns a PNG QR code representing that message. Perfect for secret post‑apocalypse communications.
+
+## Build
+
+```sh
+go build -o qr-broadcast ./src
+```
+
+## Run
+
+```sh
+./qr-broadcast
+```
+
+The server listens on `localhost:8080`.
+
+## API
+
+`POST /qr`
+
+Payload:
+
+```json
+{ "message": "Your secret text" }
+```
+
+Response: `image/png` containing the QR code.
+
+## Example
+
+```sh
+curl -X POST -d '{"message":"Hello"}' -H "Content-Type: application/json" http://localhost:8080/qr --output hello.png
+```

--- a/go-utils/nightly-nightly-qr-broadcast/src/go.mod
+++ b/go-utils/nightly-nightly-qr-broadcast/src/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/qr-broadcast
+
+go 1.22
+
+require github.com/skip2/go-qrcode v1.2.0

--- a/go-utils/nightly-nightly-qr-broadcast/src/main.go
+++ b/go-utils/nightly-nightly-qr-broadcast/src/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+    "encoding/json"
+    "log"
+    "net/http"
+    "github.com/skip2/go-qrcode"
+)
+
+type request struct {
+    Message string `json:"message"`
+}
+
+func qrHandler(w http.ResponseWriter, r *http.Request) {
+    if r.Method != http.MethodPost {
+        http.Error(w, "only POST allowed", http.StatusMethodNotAllowed)
+        return
+    }
+    var req request
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        http.Error(w, "invalid json", http.StatusBadRequest)
+        return
+    }
+    if req.Message == "" {
+        http.Error(w, "message required", http.StatusBadRequest)
+        return
+    }
+    png, err := qrcode.Encode(req.Message, qrcode.Medium, 256)
+    if err != nil {
+        http.Error(w, "failed to generate QR", http.StatusInternalServerError)
+        return
+    }
+    w.Header().Set("Content-Type", "image/png")
+    w.Write(png)
+}
+
+func main() {
+    http.HandleFunc("/qr", qrHandler)
+    log.Println("Starting QR Broadcast service on :8080")
+    if err := http.ListenAndServe(":8080", nil); err != nil {
+        log.Fatalf("server error: %v", err)
+    }
+}

--- a/go-utils/nightly-nightly-qr-broadcast/tests/main_test.go
+++ b/go-utils/nightly-nightly-qr-broadcast/tests/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "io/ioutil"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+func TestQRHandlerSuccess(t *testing.T) {
+    payload := map[string]string{"message": "test"}
+    body, _ := json.Marshal(payload)
+    req := httptest.NewRequest(http.MethodPost, "/qr", bytes.NewReader(body))
+    w := httptest.NewRecorder()
+    qrHandler(w, req)
+
+    resp := w.Result()
+    if resp.StatusCode != http.StatusOK {
+        t.Fatalf("expected 200, got %d", resp.StatusCode)
+    }
+    if ct := resp.Header.Get("Content-Type"); ct != "image/png" {
+        t.Fatalf("expected image/png content type, got %s", ct)
+    }
+    data, _ := ioutil.ReadAll(resp.Body)
+    if len(data) == 0 {
+        t.Fatalf("expected non-empty PNG data")
+    }
+    // PNG signature check
+    if !bytes.HasPrefix(data, []byte{0x89, 0x50, 0x4e, 0x47}) {
+        t.Fatalf("response does not start with PNG signature")
+    }
+}
+
+func TestQRHandlerBadMethod(t *testing.T) {
+    req := httptest.NewRequest(http.MethodGet, "/qr", nil)
+    w := httptest.NewRecorder()
+    qrHandler(w, req)
+    if w.Code != http.StatusMethodNotAllowed {
+        t.Fatalf("expected 405, got %d", w.Code)
+    }
+}
+
+func TestQRHandlerInvalidJSON(t *testing.T) {
+    req := httptest.NewRequest(http.MethodPost, "/qr", bytes.NewReader([]byte("{invalid")))
+    w := httptest.NewRecorder()
+    qrHandler(w, req)
+    if w.Code != http.StatusBadRequest {
+        t.Fatalf("expected 400, got %d", w.Code)
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-qr-broadcast
- **Provider**: groq
- **Location**: `go-utils/nightly-nightly-qr-broadcast`
- **Files Created**: 4
- **Description**: A tiny concurrent HTTP service that turns posted messages into QR code PNGs, perfect for secret post‑apocalypse communications.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `go-utils/nightly-nightly-qr-broadcast`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `go-utils/nightly-nightly-qr-broadcast/README.md`
- Run tests located in `go-utils/nightly-nightly-qr-broadcast/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.