### PR TITLE
feat(groq): Removes duplicate entries from an SSH known_hosts file while preserving comments and order.

### DIFF
--- a/bash-utils/nightly-nightly-ssh-known-hosts-dedu/README.md
+++ b/bash-utils/nightly-nightly-ssh-known-hosts-dedu/README.md
@@ -1,0 +1,28 @@
+# Nightly SSH Known Hosts Deduper
+
+Utility to remove duplicate entries from an SSH `known_hosts` file while preserving comments and the original order. Useful for cleaning up after many SSH connections.
+
+## Usage
+
+```sh
+./src/deduper.sh path/to/known_hosts          # prints deduped content to stdout
+./src/deduper.sh -i path/to/known_hosts       # edits the file in place
+```
+
+The script keeps the first occurrence of each unique host entry (based on the first field) and discards subsequent duplicates. Comment lines (starting with `#`) are left untouched.
+
+## How it works
+
+- Reads the file line‑by‑line.
+- Tracks the first field of each non‑comment line.
+- Emits the line only if the first field has not been seen before.
+- Optionally writes the cleaned content back to the original file (`-i` flag).
+
+## Requirements
+
+- Bash (tested on 4.4+)
+- No external dependencies.
+
+## License
+
+MIT © ApocalypsAI Community

--- a/bash-utils/nightly-nightly-ssh-known-hosts-dedu/src/deduper.sh
+++ b/bash-utils/nightly-nightly-ssh-known-hosts-dedu/src/deduper.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [-i] <known_hosts_file>"
+  exit 1
+}
+
+inplace=false
+while getopts ":i" opt; do
+  case $opt in
+    i) inplace=true ;;
+    *) usage ;;
+  esac
+done
+shift $((OPTIND-1))
+
+[[ $# -eq 1 ]] || usage
+file="$1"
+[[ -f "$file" ]] || { echo "File not found: $file" >&2; exit 1; }
+
+process() {
+  awk '
+    /^#/ {print; next}
+    { if (!seen[$1]++) print }
+  '
+}
+
+if $inplace; then
+  tmp=$(mktemp)
+  process < "$file" > "$tmp"
+  mv "$tmp" "$file"
+else
+  process < "$file"
+fi

--- a/bash-utils/nightly-nightly-ssh-known-hosts-dedu/tests/test_deduper.sh
+++ b/bash-utils/nightly-nightly-ssh-known-hosts-dedu/tests/test_deduper.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a temporary known_hosts file
+tmpfile=$(mktemp)
+cat > "$tmpfile" <<'EOF'
+# Sample known_hosts
+example.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC1
+example.com,192.168.1.1 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2
+example.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC1
+another.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3
+# End of file
+EOF
+
+# Expected output after deduplication (first occurrence kept)
+read -r -d '' expected <<'EOT'
+# Sample known_hosts
+example.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC1
+example.com,192.168.1.1 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2
+another.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3
+# End of file
+EOT
+
+# Run script without -i, capture stdout
+output=$(../src/deduper.sh "$tmpfile")
+if [[ "$output" != "$expected" ]]; then
+  echo "Test failed: stdout output does not match expected"
+  echo "Got:"
+  echo "$output"
+  echo "Expected:"
+  echo "$expected"
+  exit 1
+fi
+
+# Run script with -i (in‑place)
+../src/deduper.sh -i "$tmpfile"
+inplace_output=$(cat "$tmpfile")
+if [[ "$inplace_output" != "$expected" ]]; then
+  echo "Test failed: in‑place file content does not match expected"
+  exit 1
+fi
+
+echo "All tests passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ssh-known-hosts-deduper
- **Provider**: groq
- **Location**: `bash-utils/nightly-nightly-ssh-known-hosts-dedu`
- **Files Created**: 3
- **Description**: Removes duplicate entries from an SSH known_hosts file while preserving comments and order.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `bash-utils/nightly-nightly-ssh-known-hosts-dedu`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `bash-utils/nightly-nightly-ssh-known-hosts-dedu/README.md`
- Run tests located in `bash-utils/nightly-nightly-ssh-known-hosts-dedu/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.