### PR TITLE
feat(gemini): An Ansible playbook to help maintain a digital garden by identifying and "weeding" stale markdown notes into a compost bin.

### DIFF
--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/README.md
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/README.md
@@ -1,0 +1,100 @@
+# Nightly Digital Garden Weeder
+
+This Ansible playbook helps maintain a tidy "digital garden" or personal knowledge base by identifying and "weeding" stale markdown notes. Notes that haven't been modified within a configurable number of days are moved to a designated "compost bin" directory, allowing you to review them later or simply keep your active garden fresh.
+
+## Features
+
+*   **Stale Note Detection**: Identifies `.md` files that haven't been touched in a while.
+*   **Automated Weeding**: Moves stale notes to a specified "compost bin" directory.
+*   **Configurable**: Easily adjust the garden path, stale threshold, and compost bin location.
+*   **Idempotent**: Running the playbook multiple times will only move files once.
+
+## Prerequisites
+
+*   Ansible installed on your control machine.
+*   SSH access to the target machine(s) where your digital garden resides (or `ansible_connection=local` for local execution).
+*   Python 3 on the target machine(s) (for Ansible's modules).
+
+## Usage
+
+1.  **Define your inventory**:
+    Create an `inventory.ini` file (or use an existing one) that lists the hosts where your digital garden is located.
+
+    ```ini
+    [garden_hosts]
+    your_garden_server ansible_host=your.server.ip.or.hostname
+    # Or for local execution:
+    # localhost ansible_connection=local
+    ```
+
+2.  **Configure variables**:
+    Edit `src/vars/main.yml` to set your `garden_path`, `stale_days`, and `compost_path`.
+
+    ```yaml
+    # src/vars/main.yml
+    garden_path: "/home/user/my_digital_garden"
+    stale_days: 90 # Files not modified in the last 90 days are considered stale
+    compost_path: "/home/user/my_digital_garden_compost"
+    ```
+
+3.  **Run the playbook**:
+    Execute the `weeder.yml` playbook, specifying your inventory.
+
+    ```bash
+    ansible-playbook -i inventory.ini src/weeder.yml
+    ```
+
+    The playbook will report which files, if any, were moved to the compost bin.
+
+## Example Output
+
+```
+PLAY [Weed the Digital Garden] *************************************************
+
+TASK [Gathering Facts] *********************************************************
+ok: [your_garden_server]
+
+TASK [Ensure compost bin exists] ***********************************************
+ok: [your_garden_server]
+
+TASK [Find stale markdown files] ***********************************************
+ok: [your_garden_server]
+
+TASK [Move stale files to compost bin] *****************************************
+changed: [your_garden_server] => (item={'path': '/home/user/my_digital_garden/old_idea.md', 'mtime': 1672531200.0})
+
+TASK [Report on weeded files] **************************************************
+ok: [your_garden_server] => {
+    "msg": "Weeded 1 file(s) from the digital garden: ['/home/user/my_digital_garden/old_idea.md']"
+}
+
+PLAY RECAP *********************************************************************
+your_garden_server         : ok=5    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+## Development & Testing
+
+The `tests/` directory contains a setup for local testing using `ansible-playbook` itself. This allows for deterministic, offline testing of the playbook's logic.
+
+1.  **Setup test environment**:
+    ```bash
+    ansible-playbook -i tests/inventory_test.ini tests/test_setup.yml
+    ```
+    This creates dummy garden and compost directories with recent and stale files in `/tmp/test_digital_garden` and `/tmp/test_digital_garden_compost`.
+
+2.  **Run the main weeder playbook against the test environment**:
+    ```bash
+    ansible-playbook -i tests/inventory_test.ini src/weeder.yml -e "garden_path=/tmp/test_digital_garden compost_path=/tmp/test_digital_garden_compost"
+    ```
+    Note: The `-e` flags override the `vars/main.yml` paths to point to the test directories.
+
+3.  **Verify the results**:
+    ```bash
+    ansible-playbook -i tests/inventory_test.ini tests/test_weeder.yml
+    ```
+    This playbook asserts that the correct files were moved and others remained.
+
+4.  **Clean up test environment**:
+    ```bash
+    ansible-playbook -i tests/inventory_test.ini tests/test_cleanup.yml
+    ```

--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/inventory.ini
@@ -1,0 +1,2 @@
+[garden_hosts]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/vars/main.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/vars/main.yml
@@ -1,0 +1,3 @@
+garden_path: "/tmp/digital_garden"
+stale_days: 30 # Files not modified in the last 30 days are considered stale
+compost_path: "/tmp/digital_garden_compost"

--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/weeder.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/src/weeder.yml
@@ -1,0 +1,45 @@
+---
+- name: Weed the Digital Garden
+  hosts: garden_hosts
+  gather_facts: yes
+  vars_files:
+    - vars/main.yml
+
+  tasks:
+    - name: Ensure compost bin exists
+      ansible.builtin.file:
+        path: "{{ compost_path }}"
+        state: directory
+        mode: '0755'
+
+    - name: Find stale markdown files
+      ansible.builtin.find:
+        paths: "{{ garden_path }}"
+        patterns: "*.md"
+        age: "{{ stale_days }}d"
+        age_stamp: mtime
+        recurse: yes
+      register: stale_files_result
+
+    - name: Move stale files to compost bin
+      ansible.builtin.command:
+        cmd: mv "{{ item.path }}" "{{ compost_path }}/"
+      loop: "{{ stale_files_result.files }}"
+      loop_control:
+        label: "{{ item.path }}"
+      register: moved_files
+      changed_when: moved_files.rc == 0
+      failed_when: moved_files.rc != 0 and "No such file or directory" not in moved_files.stderr
+      # Mock rationale: The 'command' module is used here to simulate file system operations.
+      # In a real test, this would interact with the actual file system. For offline testing,
+      # the test playbook will set up a mock file system state and then assert the expected
+      # changes after this playbook runs. The 'changed_when' and 'failed_when' ensure
+      # deterministic behavior based on command exit codes.
+
+    - name: Report on weeded files
+      ansible.builtin.set_fact:
+        weeded_file_paths: "{{ moved_files.results | selectattr('changed', 'equalto', true) | map(attribute='item.path') | list }}"
+
+    - name: Display weeded files
+      ansible.builtin.debug:
+        msg: "Weeded {{ weeded_file_paths | length }} file(s) from the digital garden: {{ weeded_file_paths }}"

--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/tests/inventory_test.ini
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/tests/inventory_test.ini
@@ -1,0 +1,2 @@
+[garden_hosts]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/tests/test_cleanup.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/tests/test_cleanup.yml
@@ -1,0 +1,17 @@
+---
+- name: Cleanup test digital garden environment
+  hosts: garden_hosts
+  gather_facts: no
+
+  vars:
+    test_garden_path: "/tmp/test_digital_garden"
+    test_compost_path: "/tmp/test_digital_garden_compost"
+
+  tasks:
+    - name: Remove test directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ test_garden_path }}"
+        - "{{ test_compost_path }}"

--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/tests/test_setup.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/tests/test_setup.yml
@@ -1,0 +1,55 @@
+---
+- name: Setup test digital garden environment
+  hosts: garden_hosts
+  gather_facts: no
+
+  vars:
+    test_garden_path: "/tmp/test_digital_garden"
+    test_compost_path: "/tmp/test_digital_garden_compost"
+    current_time: "{{ lookup('pipe', 'date +%s') | int }}"
+    # Mock rationale: Using 'lookup('pipe', 'date +%s')' to get current time.
+    # This is deterministic for the purpose of creating files with specific mtimes
+    # relative to a 'current' point in time. The actual 'stale_days' logic
+    # in the main playbook will then operate on these fixed mtimes.
+
+  tasks:
+    - name: Ensure test directories are clean
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ test_garden_path }}"
+        - "{{ test_compost_path }}"
+
+    - name: Ensure test directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: '0755'
+      loop:
+        - "{{ test_garden_path }}"
+        - "{{ test_compost_path }}"
+
+    - name: Create a recent markdown file (not stale)
+      ansible.builtin.copy:
+        content: "This is a recent note."
+        dest: "{{ test_garden_path }}/recent_note.md"
+        mode: '0644'
+      register: recent_file
+      # Mock rationale: Creating a file with current timestamp.
+      # Ansible's 'copy' module sets mtime to current time by default.
+
+    - name: Create a stale markdown file (older than 30 days)
+      ansible.builtin.copy:
+        content: "This is an old, stale note."
+        dest: "{{ test_garden_path }}/stale_note.md"
+        mode: '0644'
+      register: stale_file
+
+    - name: Set mtime for stale file to be older than 30 days
+      ansible.builtin.command:
+        cmd: touch -d "@{{ current_time - (31 * 24 * 60 * 60) }}" "{{ test_garden_path }}/stale_note.md"
+      changed_when: true
+      # Mock rationale: 'touch -d' is used to explicitly set a past modification time.
+      # This is crucial for deterministic testing of the 'age' filter in the main playbook.
+      # It ensures the file is definitively older than the 'stale_days' threshold (30 days).

--- a/ansible-playbooks/nightly-nightly-digital-garden-weede-2/tests/test_weeder.yml
+++ b/ansible-playbooks/nightly-nightly-digital-garden-weede-2/tests/test_weeder.yml
@@ -1,0 +1,49 @@
+---
+- name: Verify digital garden weeder playbook results
+  hosts: garden_hosts
+  gather_facts: no
+
+  vars:
+    test_garden_path: "/tmp/test_digital_garden"
+    test_compost_path: "/tmp/test_digital_garden_compost"
+
+  tasks:
+    - name: Check if recent_note.md is still in the garden
+      ansible.builtin.stat:
+        path: "{{ test_garden_path }}/recent_note.md"
+      register: recent_note_stat
+
+    - name: Assert recent_note.md exists in garden
+      ansible.builtin.assert:
+        that:
+          - recent_note_stat.stat.exists
+        fail_msg: "ERROR: recent_note.md should still be in the garden!"
+      # Mock rationale: Asserting file existence after the main playbook runs.
+      # This verifies the 'find' module's 'age' filter correctly ignored the recent file.
+
+    - name: Check if stale_note.md is in the compost bin
+      ansible.builtin.stat:
+        path: "{{ test_compost_path }}/stale_note.md"
+      register: stale_note_stat
+
+    - name: Assert stale_note.md exists in compost bin
+      ansible.builtin.assert:
+        that:
+          - stale_note_stat.stat.exists
+        fail_msg: "ERROR: stale_note.md should have been moved to the compost bin!"
+      # Mock rationale: Asserting file existence in the compost bin.
+      # This verifies the 'find' module correctly identified the stale file
+      # and the 'command' module successfully moved it.
+
+    - name: Check if stale_note.md is NOT in the garden anymore
+      ansible.builtin.stat:
+        path: "{{ test_garden_path }}/stale_note.md"
+      register: stale_note_in_garden_stat
+
+    - name: Assert stale_note.md is NOT in the garden
+      ansible.builtin.assert:
+        that:
+          - not stale_note_in_garden_stat.stat.exists
+        fail_msg: "ERROR: stale_note.md should NOT be in the garden anymore!"
+      # Mock rationale: Asserting file non-existence in the original garden path.
+      # This confirms the move operation was successful and the file is no longer there.


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-digital-garden-weeder
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-digital-garden-weede-2`
- **Files Created**: 8
- **Description**: An Ansible playbook to help maintain a digital garden by identifying and "weeding" stale markdown notes into a compost bin.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-digital-garden-weede-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-digital-garden-weede-2/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-digital-garden-weede-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.