### PR TITLE
feat(groq): Synchronize a remote APT package mirror to a local directory using rsync.

### DIFF
--- a/ansible-playbooks/nightly-nightly-apt-mirror-magic/README.md
+++ b/ansible-playbooks/nightly-nightly-apt-mirror-magic/README.md
@@ -1,0 +1,29 @@
+# nightly-apt-mirror-magic
+
+Synchronize a remote APT package mirror to a local directory using rsync.
+Useful for creating offline package caches for isolated environments.
+
+## Requirements
+
+- Ansible 2.9+
+- rsync installed on the target host
+- SSH access to the remote mirror host
+
+## Variables
+
+- `remote_mirror`: URL of the remote mirror (e.g., user@mirror.example.com:/var/www/ubuntu)
+- `local_mirror_dir`: Path on the target where the mirror will be stored (default: /var/local/apt-mirror)
+
+## Usage
+
+Create an inventory file with the target host(s) and run:
+
+```
+ansible-playbook -i inventory.ini src/playbook.yml -e "remote_mirror=user@mirror.example.com:/var/www/ubuntu"
+```
+
+The playbook will ensure the local directory exists and then rsync the contents.
+
+## License
+
+MIT

--- a/ansible-playbooks/nightly-nightly-apt-mirror-magic/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-apt-mirror-magic/src/inventory.ini
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-apt-mirror-magic/src/playbook.yml
+++ b/ansible-playbooks/nightly-nightly-apt-mirror-magic/src/playbook.yml
@@ -1,0 +1,23 @@
+- name: APT Mirror Sync
+  hosts: all
+  become: true
+  vars:
+    local_mirror_dir: /var/local/apt-mirror
+  tasks:
+    - name: Ensure local mirror directory exists
+      file:
+        path: "{{ local_mirror_dir }}"
+        state: directory
+        mode: '0755'
+
+    - name: Sync remote mirror to local directory
+      ansible.builtin.command:
+        cmd: rsync -avz --delete "{{ remote_mirror }}/" "{{ local_mirror_dir }}/"
+      args:
+        warn: false
+      register: rsync_result
+      changed_when: rsync_result.rc != 0
+
+    - name: Report rsync output
+      debug:
+        var: rsync_result.stdout

--- a/ansible-playbooks/nightly-nightly-apt-mirror-magic/tests/test_playbook.yml
+++ b/ansible-playbooks/nightly-nightly-apt-mirror-magic/tests/test_playbook.yml
@@ -1,0 +1,27 @@
+- name: Test APT Mirror Sync Playbook
+  hosts: localhost
+  gather_facts: false
+  vars:
+    local_mirror_dir: "/tmp/apt-mirror-test"
+  tasks:
+    - name: Create dummy remote source
+      file:
+        path: "/tmp/mock_remote"
+        state: directory
+
+    - name: Set remote_mirror variable to dummy source
+      set_fact:
+        remote_mirror: "/tmp/mock_remote"
+
+    - name: Include the mirror sync playbook
+      import_playbook: ../src/playbook.yml
+
+    - name: Verify local directory was created
+      stat:
+        path: "{{ local_mirror_dir }}"
+      register: dir_stat
+
+    - name: Assert directory exists
+      assert:
+        that:
+          - dir_stat.stat.isdir


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-apt-mirror-magic
- **Provider**: groq
- **Location**: `ansible-playbooks/nightly-nightly-apt-mirror-magic`
- **Files Created**: 4
- **Description**: Synchronize a remote APT package mirror to a local directory using rsync.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-apt-mirror-magic`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-apt-mirror-magic/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-apt-mirror-magic/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.