### PR TITLE
feat(groq): Shows the current or specified moon phase with ASCII art.

### DIFF
--- a/bash-utils/nightly-nightly-moon-phase-notifier/README.md
+++ b/bash-utils/nightly-nightly-moon-phase-notifier/README.md
@@ -1,0 +1,29 @@
+# nightly-moon-phase-notifier
+
+A whimsical Bash utility that tells you the current (or specified) moon phase with a cute ASCII illustration. Perfect for terminal enthusiasts who want a touch of lunar magic in their workflow.
+
+## Usage
+
+```sh
+# Use the system date (default)
+./src/moon_notifier.sh
+
+# Or specify a date (YYYY-MM-DD) via MOON_DATE environment variable
+MOON_DATE=2023-09-29 ./src/moon_notifier.sh
+```
+
+The script outputs the phase name and an ASCII art representation.
+
+## How it works
+
+- Calculates days since a known new‑moon reference (2000‑01‑06).
+- Uses the average lunar month (29.53 days) to determine the phase.
+- Maps the phase to one of eight common names and corresponding ASCII art.
+
+## Testing
+
+Run the test suite:
+
+```sh
+./tests/test_moon_notifier.sh
+```

--- a/bash-utils/nightly-nightly-moon-phase-notifier/src/moon_notifier.sh
+++ b/bash-utils/nightly-nightly-moon-phase-notifier/src/moon_notifier.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# nightly-moon-phase-notifier
+# Determines the moon phase for a given date (default: today) and prints an ASCII art.
+
+# Reference new moon date (2000-01-06)
+REF_DATE="2000-01-06"
+
+# Get target date
+if [[ -n "$MOON_DATE" ]]; then
+  TARGET_DATE="$MOON_DATE"
+else
+  TARGET_DATE=$(date +%F)
+fi
+
+# Convert dates to seconds since epoch
+ref_sec=$(date -d "$REF_DATE" +%s)
+target_sec=$(date -d "$TARGET_DATE" +%s)
+
+# Compute days elapsed
+days=$(( (target_sec - ref_sec) / 86400 ))
+
+# Lunar month length (average)
+LUNAR=29.53
+
+# Phase index (0-7)
+phase_index=$(printf "%.0f" "$(awk "BEGIN {print ( (days % $LUNAR) / $LUNAR ) * 8 }")")
+phase_index=$(( phase_index % 8 ))
+
+case $phase_index in
+  0) phase="New Moon"; art="   _..._   \n .'     '. \n|         |\n|         |\n '._____.' " ;;
+  1) phase="Waxing Crescent"; art="   _..._   \n .'     '. \n|   )     |\n|         |\n '._____.' " ;;
+  2) phase="First Quarter"; art="   _..._   \n .'     '. \n|   )   ( |\n|         |\n '._____.' " ;;
+  3) phase="Waxing Gibbous"; art="   _..._   \n .'     '. \n|   )   ( |\n|   (     |\n '._____.' " ;;
+  4) phase="Full Moon"; art="   _..._   \n .'*****'. \n|*******|\n|*******|\n '._____.' " ;;
+  5) phase="Waning Gibbous"; art="   _..._   \n .'*****'. \n|     ( |\n|   (   |\n '._____.' " ;;
+  6) phase="Last Quarter"; art="   _..._   \n .'     '. \n| (   )   |\n|         |\n '._____.' " ;;
+  7) phase="Waning Crescent"; art="   _..._   \n .'     '. \n|     (   |\n|         |\n '._____.' " ;;
+esac
+
+printf "Moon phase on %s: %s\n%s\n" "$TARGET_DATE" "$phase" "$art"

--- a/bash-utils/nightly-nightly-moon-phase-notifier/tests/test_moon_notifier.sh
+++ b/bash-utils/nightly-nightly-moon-phase-notifier/tests/test_moon_notifier.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../src" && pwd)
+NOTIFIER="$SCRIPT_DIR/moon_notifier.sh"
+
+run_and_check() {
+  local date=$1
+  local expected=$2
+  output=$(MOON_DATE="$date" "$NOTIFIER")
+  if [[ "$output" != *"$expected"* ]]; then
+    echo "FAIL: For date $date expected '$expected' in output."
+    echo "Output was:"
+    echo "$output"
+    exit 1
+  else
+    echo "PASS: $date -> $expected"
+  fi
+}
+
+# Known full moon: 2023-09-29
+run_and_check "2023-09-29" "Full Moon"
+
+# Known last quarter: 2023-09-21
+run_and_check "2023-09-21" "Last Quarter"
+
+echo "All tests passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-moon-phase-notifier
- **Provider**: groq
- **Location**: `bash-utils/nightly-nightly-moon-phase-notifier`
- **Files Created**: 3
- **Description**: Shows the current or specified moon phase with ASCII art.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `bash-utils/nightly-nightly-moon-phase-notifier`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `bash-utils/nightly-nightly-moon-phase-notifier/README.md`
- Run tests located in `bash-utils/nightly-nightly-moon-phase-notifier/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.