### PR TITLE
feat(gemini): A Terraform module to provision a highly available static website on AWS S3/CloudFront, serving as a resilient community message beacon.

### DIFF
--- a/terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/README.md
+++ b/terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/README.md
@@ -1,0 +1,73 @@
+# Nightly Cloud Sanctuary Beacon
+
+A Terraform module designed to provision a highly available, resilient static website on AWS, acting as a digital sanctuary beacon for community messages, emergency broadcasts, or shared wisdom in the post-apocalyptic landscape.
+
+## Features
+
+*   **Static Website Hosting**: Leverages AWS S3 for cost-effective and scalable static content storage.
+*   **Global Content Delivery**: Utilizes AWS CloudFront for low-latency content delivery and HTTPS.
+*   **Custom Domain Support**: Optionally integrates with AWS Route 53 for custom domain names.
+*   **Secure Access**: Configures S3 bucket policies and CloudFront Origin Access Control (OAC) for secure content delivery.
+*   **Whimsical Resilience**: A digital whisper in the void, always there, always accessible.
+
+## Usage
+
+This module creates the necessary AWS resources for a static website. You'll need to upload your `index.html`, `error.html`, and other static assets to the created S3 bucket.
+
+### Prerequisites
+
+*   An AWS account with appropriate permissions to create S3 buckets, CloudFront distributions, and Route 53 records.
+*   Terraform CLI installed.
+*   AWS CLI configured with credentials.
+
+### Example
+
+```terraform
+module "sanctuary_beacon" {
+  source = "./src" # Or a Git URL if published
+
+  bucket_name_prefix = "apocalypsai-beacon"
+  domain_name        = "beacon.example.com" # Optional: if you own this domain in Route 53
+  tags = {
+    Project     = "ApocalypsAI"
+    Environment = "Production"
+  }
+}
+
+output "cloudfront_domain_name" {
+  description = "The domain name of the CloudFront distribution."
+  value       = module.sanctuary_beacon.cloudfront_domain_name
+}
+
+output "s3_bucket_website_endpoint" {
+  description = "The S3 bucket website endpoint."
+  value       = module.sanctuary_beacon.s3_bucket_website_endpoint
+}
+```
+
+### Inputs
+
+| Name                 | Description                                                               | Type     | Default | Required |
+| :------------------- | :------------------------------------------------------------------------ | :------- | :------ | :------- |
+| `bucket_name_prefix` | A prefix for the S3 bucket name. The full name will be generated.         | `string` | `null`  | yes      |
+| `domain_name`        | (Optional) The custom domain name for the CloudFront distribution.        | `string` | `null`  | no       |
+| `tags`               | A map of tags to assign to the resources.                                 | `map`    | `{}`    | no       |
+
+### Outputs
+
+| Name                       | Description                                   |
+| :------------------------- | :-------------------------------------------- |
+| `s3_bucket_id`             | The ID of the S3 bucket.                      |
+| `s3_bucket_arn`            | The ARN of the S3 bucket.                     |
+| `s3_bucket_website_endpoint` | The S3 bucket website endpoint.             |
+| `cloudfront_distribution_id` | The ID of the CloudFront distribution.      |
+| `cloudfront_domain_name`   | The domain name of the CloudFront distribution. |
+
+## Development & Testing
+
+To test this module locally:
+
+1.  Navigate to the `tests/` directory.
+2.  Run the `test.sh` script: `./test.sh`
+
+This script will run `terraform init -backend=false`, `terraform validate`, and `terraform plan -detailed-exitcode` to ensure the module is syntactically correct and produces a valid plan without actually provisioning resources.

--- a/terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/src/main.tf
+++ b/terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/src/main.tf
@@ -1,0 +1,137 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "website_bucket" {
+  bucket = "${var.bucket_name_prefix}-${random_string.suffix.result}"
+  tags   = var.tags
+}
+
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+  numeric = true
+}
+
+resource "aws_s3_bucket_website_configuration" "website_config" {
+  bucket = aws_s3_bucket.website_bucket.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+}
+
+resource "aws_cloudfront_origin_access_control" "oac" {
+  name                              = "${aws_s3_bucket.website_bucket.id}-oac"
+  description                       = "OAC for S3 bucket ${aws_s3_bucket.website_bucket.id}"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  bucket = aws_s3_bucket.website_bucket.id
+  policy = data.aws_iam_policy_document.s3_policy.json
+}
+
+data "aws_iam_policy_document" "s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.website_bucket.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "cloudfront:SourceArn"
+      values   = [aws_cloudfront_distribution.s3_distribution.arn]
+    }
+  }
+}
+
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  origin {
+    domain_name              = aws_s3_bucket.website_bucket.bucket_regional_domain_name
+    origin_id                = aws_s3_bucket.website_bucket.id
+    origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "CloudFront distribution for ApocalypsAI Sanctuary Beacon"
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = aws_s3_bucket.website_bucket.id
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  dynamic "aliases" {
+    for_each = var.domain_name != null ? [var.domain_name] : []
+    content {
+      name = aliases.value
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_route53_record" "cname_record" {
+  count = var.domain_name != null ? 1 : 0
+
+  zone_id = data.aws_route53_zone.selected_zone[0].zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.s3_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.s3_distribution.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+data "aws_route53_zone" "selected_zone" {
+  count        = var.domain_name != null ? 1 : 0
+  name         = var.domain_name
+  private_zone = false
+}

--- a/terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/src/outputs.tf
@@ -1,0 +1,24 @@
+output "s3_bucket_id" {
+  description = "The ID of the S3 bucket."
+  value       = aws_s3_bucket.website_bucket.id
+}
+
+output "s3_bucket_arn" {
+  description = "The ARN of the S3 bucket."
+  value       = aws_s3_bucket.website_bucket.arn
+}
+
+output "s3_bucket_website_endpoint" {
+  description = "The S3 bucket website endpoint."
+  value       = aws_s3_bucket_website_configuration.website_config.website_endpoint
+}
+
+output "cloudfront_distribution_id" {
+  description = "The ID of the CloudFront distribution."
+  value       = aws_cloudfront_distribution.s3_distribution.id
+}
+
+output "cloudfront_domain_name" {
+  description = "The domain name of the CloudFront distribution."
+  value       = aws_cloudfront_distribution.s3_distribution.domain_name
+}

--- a/terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/src/variables.tf
+++ b/terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/src/variables.tf
@@ -1,0 +1,16 @@
+variable "bucket_name_prefix" {
+  description = "A prefix for the S3 bucket name. A random suffix will be appended."
+  type        = string
+}
+
+variable "domain_name" {
+  description = "(Optional) The custom domain name for the CloudFront distribution. Requires the domain to be managed in Route 53."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/tests/main.tf
+++ b/terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/tests/main.tf
@@ -1,0 +1,41 @@
+# Mock rationale: This configuration uses the module with dummy values
+# to allow `terraform validate` and `terraform plan` to run offline
+# without requiring actual AWS credentials or provisioning resources.
+# The `aws` provider block is minimal and doesn't require authentication
+# for `validate` or `plan` operations.
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1" # Mock rationale: A default region is needed for provider configuration, but no actual API calls are made during plan/validate.
+}
+
+module "test_sanctuary_beacon" {
+  source = "../src"
+
+  bucket_name_prefix = "test-apocalypsai-beacon"
+  domain_name        = "test.example.com" # Mock rationale: A dummy domain for testing the Route 53 resource creation logic.
+  tags = {
+    Environment = "Test"
+    Purpose     = "ModuleTest"
+  }
+}
+
+output "test_cloudfront_domain" {
+  value = module.test_sanctuary_beacon.cloudfront_domain_name
+}
+
+output "test_s3_endpoint" {
+  value = module.test_sanctuary_beacon.s3_bucket_website_endpoint
+}

--- a/terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/tests/test.sh
+++ b/terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/tests/test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "--- Running Terraform module tests ---"
+
+# Initialize Terraform in the test directory
+echo "Initializing Terraform..."
+terraform init -backend=false # Mock rationale: Prevents Terraform from trying to connect to a real backend, making the test offline.
+if [ $? -ne 0 ]; then
+  echo "Terraform init failed!"
+  exit 1
+fi
+echo "Terraform init successful."
+
+# Validate the Terraform configuration
+echo "Validating Terraform configuration..."
+terraform validate
+if [ $? -ne 0 ]; then
+  echo "Terraform validation failed!"
+  exit 1
+fi
+echo "Terraform validation successful."
+
+# Plan the Terraform configuration and check for changes
+# -detailed-exitcode: 0 = no changes, 1 = error, 2 = changes
+echo "Planning Terraform configuration (expecting changes)..."
+terraform plan -detailed-exitcode -out=tfplan.out
+PLAN_EXIT_CODE=$?
+
+if [ $PLAN_EXIT_CODE -eq 0 ]; then
+  echo "Terraform plan showed no changes, but new resources are expected. Test failed!"
+  rm -f tfplan.out
+  exit 1
+elif [ $PLAN_EXIT_CODE -eq 1 ]; then
+  echo "Terraform plan failed!"
+  rm -f tfplan.out
+  exit 1
+elif [ $PLAN_EXIT_CODE -eq 2 ]; then
+  echo "Terraform plan successful (changes detected, as expected for new resources)."
+  rm -f tfplan.out
+  echo "--- All Terraform module tests passed! ---"
+  exit 0
+else
+  echo "Unexpected exit code from terraform plan: $PLAN_EXIT_CODE. Test failed!"
+  rm -f tfplan.out
+  exit 1
+fi


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-cloud-sanctuary-beacon
- **Provider**: gemini
- **Location**: `terraform-modules/nightly-nightly-cloud-sanctuary-beac-2`
- **Files Created**: 6
- **Description**: A Terraform module to provision a highly available static website on AWS S3/CloudFront, serving as a resilient community message beacon.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-cloud-sanctuary-beac-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/README.md`
- Run tests located in `terraform-modules/nightly-nightly-cloud-sanctuary-beac-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.