### PR TITLE
feat(groq): Convert ISO‑8601 duration strings into a friendly English description via a tiny TypeScript CLI.

### DIFF
--- a/typescript-utils/nightly-nightly-iso8601-duration-cli/README.md
+++ b/typescript-utils/nightly-nightly-iso8601-duration-cli/README.md
@@ -1,0 +1,50 @@
+# nightly‑iso8601‑duration‑cli
+
+A tiny, zero‑dependency TypeScript command‑line utility that turns an ISO‑8601 duration (e.g. `P1Y2M3DT4H5M6S`) into a human‑readable English phrase.
+
+## Features
+
+- Parses years, months, weeks, days, hours, minutes, and seconds.
+- Handles both date‑only (`P3W`) and time‑only (`PT20M`) forms.
+- Returns a concise, comma‑separated description.
+- Provides helpful error messages for malformed inputs.
+
+## Installation
+
+```bash
+# Using npm (requires node >= 16)
+npm install -g ts-node typescript
+# Then you can run the script directly with ts-node
+```
+
+> The utility is deliberately lightweight – it only depends on the Node standard library.
+
+## Usage
+
+```bash
+# Run with ts-node (no compilation needed)
+ts-node src/index.ts <ISO‑8601‑duration>
+```
+
+Example:
+
+```bash
+$ ts-node src/index.ts P1Y2M3DT4H5M6S
+1 year, 2 months, 3 days, 4 hours, 5 minutes, 6 seconds
+```
+
+If the input cannot be parsed, the tool exits with a non‑zero status and prints an error message.
+
+## Development & Testing
+
+```bash
+# Install dev dependencies (jest is used for tests)
+npm install --save-dev jest @types/jest ts-jest
+
+# Run tests
+npm test
+```
+
+## License
+
+MIT © ApocalypsAI community

--- a/typescript-utils/nightly-nightly-iso8601-duration-cli/src/index.ts
+++ b/typescript-utils/nightly-nightly-iso8601-duration-cli/src/index.ts
@@ -1,0 +1,50 @@
+//!/usr/bin/env node
+
+/**
+ * Parse an ISO‑8601 duration string (e.g. "P1Y2M3DT4H5M6S") and return a human‑readable description.
+ * Supports years, months, weeks, days, hours, minutes, and seconds.
+ * If no component is present, returns "0 seconds".
+ */
+function parseDuration(iso: string): string {
+  const regex = /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
+  const match = iso.toUpperCase().match(regex);
+  if (!match) {
+    throw new Error(`Invalid ISO‑8601 duration: "${iso}"`);
+  }
+  const [_, years, months, weeks, days, hours, minutes, seconds] = match;
+  const parts: string[] = [];
+  if (years) parts.push(`${years} year${Number(years) === 1 ? '' : 's'}`);
+  if (months) parts.push(`${months} month${Number(months) === 1 ? '' : 's'}`);
+  if (weeks) parts.push(`${weeks} week${Number(weeks) === 1 ? '' : 's'}`);
+  if (days) parts.push(`${days} day${Number(days) === 1 ? '' : 's'}`);
+  if (hours) parts.push(`${hours} hour${Number(hours) === 1 ? '' : 's'}`);
+  if (minutes) parts.push(`${minutes} minute${Number(minutes) === 1 ? '' : 's'}`);
+  if (seconds) {
+    // Trim trailing zeros for whole numbers
+    const secNum = Number(seconds);
+    const secStr = Number.isInteger(secNum) ? secNum.toString() : seconds;
+    parts.push(`${secStr} second${secNum === 1 ? '' : 's'}`);
+  }
+  if (parts.length === 0) {
+    return '0 seconds';
+  }
+  return parts.join(', ');
+}
+
+// CLI handling
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.length !== 1) {
+    console.error('Usage: ts-node src/index.ts <ISO‑8601‑duration>');
+    process.exit(1);
+  }
+  try {
+    const result = parseDuration(args[0]);
+    console.log(result);
+  } catch (e) {
+    console.error((e as Error).message);
+    process.exit(1);
+  }
+}
+
+export { parseDuration };

--- a/typescript-utils/nightly-nightly-iso8601-duration-cli/tests/test_main.ts
+++ b/typescript-utils/nightly-nightly-iso8601-duration-cli/tests/test_main.ts
@@ -1,0 +1,39 @@
+import { parseDuration } from '../src/index';
+import * as assert from 'assert';
+
+// Mock rationale: these tests cover typical, edge‑case, and minimal inputs.
+
+function runTests() {
+  // Full duration
+  assert.strictEqual(
+    parseDuration('P1Y2M3DT4H5M6S'),
+    '1 year, 2 months, 3 days, 4 hours, 5 minutes, 6 seconds'
+  );
+
+  // Time‑only
+  assert.strictEqual(parseDuration('PT20M'), '20 minutes');
+
+  // Date‑only (weeks)
+  assert.strictEqual(parseDuration('P3W'), '3 weeks');
+
+  // Zero components (just "P")
+  assert.strictEqual(parseDuration('P'), '0 seconds');
+
+  // Fractional seconds
+  assert.strictEqual(parseDuration('PT0.5S'), '0.5 seconds');
+
+  // Invalid input should throw
+  let threw = false;
+  try {
+    parseDuration('invalid');
+  } catch (e) {
+    threw = true;
+  }
+  assert.ok(threw, 'Expected error for malformed input');
+
+  console.log('All tests passed.');
+}
+
+if (require.main === module) {
+  runTests();
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-iso8601-duration-cli
- **Provider**: groq
- **Location**: `typescript-utils/nightly-nightly-iso8601-duration-cli`
- **Files Created**: 3
- **Description**: Convert ISO‑8601 duration strings into a friendly English description via a tiny TypeScript CLI.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `typescript-utils/nightly-nightly-iso8601-duration-cli`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `typescript-utils/nightly-nightly-iso8601-duration-cli/README.md`
- Run tests located in `typescript-utils/nightly-nightly-iso8601-duration-cli/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.