### PR TITLE
feat(gemini): An Ansible playbook to sweep away digital dust bunnies (old temporary files, logs, caches) from your servers, ensuring a tidy and efficient system.

### DIFF
--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/README.md
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/README.md
@@ -1,0 +1,65 @@
+# Nightly Digital Dust Bunny Sweeper
+
+## Summary
+This Ansible playbook, affectionately known as the "Digital Dust Bunny Sweeper," helps maintain a tidy and efficient server environment by automatically identifying and removing old, temporary files, logs, and cache entries that accumulate over time.
+
+## How it Works
+The playbook iterates through a configurable list of paths and age thresholds. For each specified path, it finds files older than the defined age and removes them. This helps reclaim disk space and prevent performance degradation caused by digital clutter.
+
+## Usage
+
+### Prerequisites
+- Ansible installed on your control machine.
+- SSH access to your target servers (or `localhost` for local cleanup).
+- Python installed on target servers (required for Ansible modules).
+
+### 1. Inventory Configuration (`src/inventory.ini`)
+Define the hosts you want to clean up. For local execution, `localhost` is sufficient.
+
+```ini
+[servers]
+localhost ansible_connection=local
+# Add your remote servers here:
+# webservers
+#   server1.example.com
+#   server2.example.com
+```
+
+### 2. Cleanup Paths Configuration (`vars/cleanup_paths.yml`)
+Specify the directories to scan and the age (in days) after which files should be considered "dust bunnies" and removed. You can define multiple targets.
+
+```yaml
+# Define the paths to sweep for digital dust bunnies and their maximum allowed age.
+# Files older than 'age_days' in 'path' will be removed.
+cleanup_targets:
+  - path: "/tmp/old_temp_files" # General temporary files
+    age_days: 1
+  - path: "/var/log/app_archives" # Archived application logs
+    age_days: 7
+  - path: "/home/{{ ansible_user }}/.cache/downloads" # User-specific download caches
+    age_days: 30
+```
+
+### 3. Running the Playbook
+Execute the playbook from your control machine:
+
+```bash
+ansible-playbook -i src/inventory.ini src/dust_bunny_sweeper.yml
+```
+
+To perform a dry run and see what *would* be removed without actually deleting anything, use the `--check` flag:
+
+```bash
+ansible-playbook -i src/inventory.ini src/dust_bunny_sweeper.yml --check
+```
+
+## Testing
+To ensure the Digital Dust Bunny Sweeper works as expected, a dedicated test playbook is provided. It creates temporary files, runs the main playbook in check mode and then for real, and verifies the cleanup.
+
+To run the tests:
+
+```bash
+ansible-playbook -i tests/inventory_test.ini tests/test_dust_bunny_sweeper.yml
+```
+
+This will create a temporary directory, populate it with old and new files, run the sweeper, and assert that only the old files are removed, then clean up the test directory.

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/dust_bunny_sweeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/dust_bunny_sweeper.yml
@@ -1,0 +1,49 @@
+---
+- name: Sweep away digital dust bunnies
+  hosts: all
+  become: true
+  vars_files:
+    - ../vars/cleanup_paths.yml
+  tasks:
+    - name: Ensure cleanup target directories exist
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: directory
+        mode: '0755'
+      loop: "{{ cleanup_targets }}"
+      loop_control:
+        label: "Ensuring {{ item.path }} exists"
+
+    - name: Find old files (digital dust bunnies)
+      ansible.builtin.find:
+        paths: "{{ item.path }}"
+        age: "{{ item.age_days }}d"
+        recurse: yes
+        file_type: file
+      register: old_files_per_path
+      loop: "{{ cleanup_targets }}"
+      loop_control:
+        label: "Finding old files in {{ item.path }}"
+
+    - name: Collect all files to delete
+      ansible.builtin.set_fact:
+        files_to_delete: "{{ files_to_delete | default([]) + item.files }}"
+      loop: "{{ old_files_per_path.results }}"
+      loop_control:
+        label: "Collecting files from {{ item.item.path }}"
+      when: item.files is defined and item.files | length > 0
+
+    - name: Delete found old files
+      ansible.builtin.file:
+        path: "{{ file_item.path }}"
+        state: absent
+      loop: "{{ files_to_delete | default([]) }}"
+      loop_control:
+        loop_var: file_item
+        label: "Deleting {{ file_item.path }}"
+      when: files_to_delete is defined and files_to_delete | length > 0
+
+    - name: Report on cleanup results
+      ansible.builtin.debug:
+        msg: "Swept {{ (files_to_delete | default([])) | length }} digital dust bunnies in total."
+      when: files_to_delete is defined

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/src/inventory.ini
@@ -1,0 +1,6 @@
+[servers]
+localhost ansible_connection=local
+# Add your remote servers here:
+# webservers
+#   server1.example.com
+#   server2.example.com

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/inventory_test.ini
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/inventory_test.ini
@@ -1,0 +1,2 @@
+[test_host]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/test_dust_bunny_sweeper.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/test_dust_bunny_sweeper.yml
@@ -1,0 +1,81 @@
+---
+- name: Test Digital Dust Bunny Sweeper
+  hosts: test_host
+  become: true
+  vars_files:
+    - tests/vars/test_cleanup_paths.yml # Use test-specific paths
+  vars:
+    test_dir: "{{ cleanup_targets[0].path }}"
+    old_file: "{{ test_dir }}/old_dust_bunny.log"
+    new_file: "{{ test_dir }}/fresh_sparkle.tmp"
+
+  tasks:
+    - name: Ensure test directory exists
+      ansible.builtin.file:
+        path: "{{ test_dir }}"
+        state: directory
+        mode: '0755'
+      delegate_to: localhost # Mock rationale: Ensure test setup is local and controlled.
+
+    - name: Create an old dummy file
+      ansible.builtin.shell: |
+        mkdir -p "{{ test_dir }}"
+        touch "{{ old_file }}"
+        # Ensure it's older than the 'age_days: 1' threshold
+        # Using 'touch -d' to set modification time to 2 days ago.
+        touch -d "2 days ago" "{{ old_file }}"
+      args:
+        creates: "{{ old_file }}"
+      delegate_to: localhost # Mock rationale: Create controlled test data locally.
+
+    - name: Create a new dummy file
+      ansible.builtin.file:
+        path: "{{ new_file }}"
+        state: touch
+      delegate_to: localhost # Mock rationale: Create controlled test data locally.
+
+    - name: Run dust bunny sweeper in check mode (expecting changes)
+      ansible.builtin.include_tasks: ../src/dust_bunny_sweeper.yml
+      args:
+        apply:
+          check_mode: true
+      register: check_mode_result
+      delegate_to: localhost # Mock rationale: Run the playbook against the local test environment.
+
+    - name: Assert check mode would remove the old file
+      ansible.builtin.assert:
+        that:
+          - "check_mode_result.results | selectattr('task_fields.name', 'equalto', 'Delete found old files') | map(attribute='changed') | first"
+        fail_msg: "Check mode did not detect changes for old file removal."
+      # Mock rationale: Verifies the playbook's logic without actual deletion by checking the 'changed' status of the deletion task.
+
+    - name: Run dust bunny sweeper for real
+      ansible.builtin.include_tasks: ../src/dust_bunny_sweeper.yml
+      register: real_run_result
+      delegate_to: localhost # Mock rationale: Run the playbook against the local test environment.
+
+    - name: Assert old file is absent
+      ansible.builtin.stat:
+        path: "{{ old_file }}"
+      register: old_file_stat
+      delegate_to: localhost # Mock rationale: Verify local file system state.
+
+    - name: Assert new file is present
+      ansible.builtin.stat:
+        path: "{{ new_file }}"
+      register: new_file_stat
+      delegate_to: localhost # Mock rationale: Verify local file system state.
+
+    - name: Verify old file was deleted and new file remains
+      ansible.builtin.assert:
+        that:
+          - "not old_file_stat.stat.exists"
+          - "new_file_stat.stat.exists"
+        fail_msg: "Old file was not deleted or new file was deleted unexpectedly."
+      # Mock rationale: Final verification of the playbook's effect on the controlled local environment.
+
+    - name: Clean up test directory
+      ansible.builtin.file:
+        path: "{{ test_dir }}"
+        state: absent
+      delegate_to: localhost # Mock rationale: Clean up local test artifacts.

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/vars/test_cleanup_paths.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/vars/test_cleanup_paths.yml
@@ -1,0 +1,3 @@
+cleanup_targets:
+  - path: "/tmp/ansible_test_dust_bunnies"
+    age_days: 1

--- a/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/vars/cleanup_paths.yml
+++ b/ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/vars/cleanup_paths.yml
@@ -1,0 +1,9 @@
+# Define the paths to sweep for digital dust bunnies and their maximum allowed age.
+# Files older than 'age_days' in 'path' will be removed.
+cleanup_targets:
+  - path: "/tmp/old_temp_files"
+    age_days: 1
+  - path: "/var/log/app_archives"
+    age_days: 7
+  - path: "/home/{{ ansible_user }}/.cache/downloads"
+    age_days: 30


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-digital-dust-bunny-sweeper
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8`
- **Files Created**: 7
- **Description**: An Ansible playbook to sweep away digital dust bunnies (old temporary files, logs, caches) from your servers, ensuring a tidy and efficient system.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-digital-dust-bunny-s-8/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.