### PR TITLE
feat(groq): A tiny Bash tool that reports directory size in human‑readable and JSON formats, with optional threshold filtering.

### DIFF
--- a/bash-utils/nightly-nightly-quick-disk-usage-rep/README.md
+++ b/bash-utils/nightly-nightly-quick-disk-usage-rep/README.md
@@ -1,0 +1,22 @@
+# nightly-quick-disk-usage-report
+
+Utility that scans a directory and prints a concise disk usage summary in both human‑readable and JSON formats. Useful for CI pipelines or quick local checks.
+
+## Usage
+
+```sh
+./src/disk_report.sh <path> [threshold_bytes]
+```
+
+- `<path>`: directory to analyze (default: current directory)
+- `threshold_bytes` (optional): only report if size exceeds this value; otherwise exits with code 0 and no output.
+
+## Output
+
+- Human‑readable line: `Size: 1.23 MiB (1290240 bytes)`
+- JSON line: `{"path":"...","size_bytes":1290240,"size_human":"1.23 MiB"}`
+
+## Exit codes
+
+- `0` – success (or size below threshold)
+- `1` – error (invalid path)

--- a/bash-utils/nightly-nightly-quick-disk-usage-rep/src/disk_report.sh
+++ b/bash-utils/nightly-nightly-quick-disk-usage-rep/src/disk_report.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Convert a byte count to a human‑readable string
+human_readable() {
+  local bytes=$1
+  if ((bytes < 1024)); then
+    echo "${bytes} B"
+  elif ((bytes < 1024*1024)); then
+    printf "%.2f KiB\n" "$(awk "BEGIN {printf %f,$bytes/1024}")"
+  elif ((bytes < 1024*1024*1024)); then
+    printf "%.2f MiB\n" "$(awk "BEGIN {printf %f,$bytes/(1024*1024)}")"
+  else
+    printf "%.2f GiB\n" "$(awk "BEGIN {printf %f,$bytes/(1024*1024*1024)}")"
+  fi
+}
+
+main() {
+  local target="${1:-.}"
+  local threshold="${2:-0}"
+  if [[ ! -d "$target" ]]; then
+    echo "Error: $target is not a directory" >&2
+    exit 1
+  fi
+  # Size in bytes (du -sb works on GNU coreutils; fallback to du -sk and convert)
+  local size_bytes
+  if du --version >/dev/null 2>&1; then
+    size_bytes=$(du -sb "$target" | cut -f1)
+  else
+    # macOS fallback: du -sk gives KiB
+    size_bytes=$(du -sk "$target" | awk '{print $1 * 1024}')
+  fi
+  if (( size_bytes < threshold )); then
+    exit 0
+  fi
+  local size_human
+  size_human=$(human_readable "$size_bytes")
+  echo "Size: $size_human ($size_bytes bytes)"
+  # JSON output – ensure proper escaping of the path
+  local abs_path
+  abs_path=$(realpath "$target")
+  local json
+  json=$(printf '{"path":"%s","size_bytes":%s,"size_human":"%s"}' "$abs_path" "$size_bytes" "$size_human")
+  echo "$json"
+}
+
+main "$@"

--- a/bash-utils/nightly-nightly-quick-disk-usage-rep/tests/test_disk_report.sh
+++ b/bash-utils/nightly-nightly-quick-disk-usage-rep/tests/test_disk_report.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load the utility script (functions are sourced, not executed)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../src" && pwd)"
+source "$SCRIPT_DIR/disk_report.sh"
+
+# Simple assertion helper
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="${3:-}"
+  if [[ "$expected" != "$actual" ]]; then
+    echo "FAIL: $msg Expected '$expected' but got '$actual'" >&2
+    exit 1
+  fi
+}
+
+# Create a temporary workspace
+TMPDIR=$(mktemp -d)
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+# Populate with files of known size (1 KB and 2 KB)
+dd if=/dev/zero of="$TMPDIR/file1.bin" bs=1 count=1024 status=none
+dd if=/dev/zero of="$TMPDIR/file2.bin" bs=1 count=2048 status=none
+
+# Expected total size = 3072 bytes
+EXPECTED_SIZE=3072
+
+# Run the script and capture its output
+OUTPUT=$(bash "$SCRIPT_DIR/disk_report.sh" "$TMPDIR")
+HUMAN_LINE=$(echo "$OUTPUT" | head -n1)
+JSON_LINE=$(echo "$OUTPUT" | tail -n1)
+
+# Verify the human‑readable line
+assert_eq "Size: 3.00 KiB (3072 bytes)" "$HUMAN_LINE" "Human‑readable output"
+
+# Extract size_bytes from the JSON line (simple grep/awk, no jq needed)
+SIZE_BYTES=$(echo "$JSON_LINE" | grep -o '"size_bytes":[0-9]*' | cut -d: -f2)
+assert_eq "$EXPECTED_SIZE" "$SIZE_BYTES" "JSON size_bytes field"
+
+# Verify that the script respects the threshold argument (no output when below)
+NO_OUTPUT=$(bash "$SCRIPT_DIR/disk_report.sh" "$TMPDIR" 5000 || true)
+if [[ -n "$NO_OUTPUT" ]]; then
+  echo "FAIL: Expected no output when size below threshold" >&2
+  exit 1
+fi
+
+echo "All tests passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-quick-disk-usage-report
- **Provider**: groq
- **Location**: `bash-utils/nightly-nightly-quick-disk-usage-rep`
- **Files Created**: 3
- **Description**: A tiny Bash tool that reports directory size in human‑readable and JSON formats, with optional threshold filtering.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `bash-utils/nightly-nightly-quick-disk-usage-rep`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `bash-utils/nightly-nightly-quick-disk-usage-rep/README.md`
- Run tests located in `bash-utils/nightly-nightly-quick-disk-usage-rep/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.