### PR TITLE
feat(gemini): An Ansible playbook to identify and optionally clean up digital 'dust bunnies' like old backup files, temporary files, and empty files across managed systems.

### DIFF
--- a/ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/README.md
+++ b/ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/README.md
@@ -1,0 +1,76 @@
+# Nightly Ansible Digital Dust Bunny Sweeper
+
+This Ansible playbook helps you keep your managed systems tidy by identifying and optionally cleaning up "digital dust bunnies." These include old backup files, temporary files, and empty files that can accumulate over time, consuming disk space and cluttering directories.
+
+## Features
+
+*   **Identifies:** Locates files matching common backup/temp patterns (`.bak`, `~`, `.tmp`, `.old`, `core.*`) and empty files.
+*   **Reports:** Provides a clear summary of all identified dust bunnies.
+*   **Cleans Up (Optional):** Can be configured to remove the identified files.
+*   **Dry Run Mode:** Always runs in dry-run mode by default, allowing you to review findings before any changes are made.
+
+## Usage
+
+1.  **Inventory:** Ensure you have an `inventory.ini` file listing your target hosts.
+
+    ```ini
+    [servers]
+    server1.example.com
+    server2.example.com
+    ```
+
+2.  **Configuration:** Review and customize `vars/main.yml` to define:
+    *   `dust_bunny_target_paths`: Directories to scan.
+    *   `dust_bunny_file_patterns`: Glob patterns for files to consider.
+    *   `dust_bunny_age_threshold_days`: Minimum age (in days) for a file to be considered a "dust bunny" (only applies to pattern-matched files, not empty files).
+    *   `dust_bunny_dry_run`: Set to `false` to enable actual deletion (defaults to `true`).
+
+3.  **Run in Dry-Run Mode (Recommended First):**
+    This will only report what *would* be cleaned up.
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/dust_bunny_sweeper.yml
+    ```
+
+4.  **Run for Cleanup:**
+    First, set `dust_bunny_dry_run: false` in `vars/main.yml`.
+    Then execute:
+
+    ```bash
+    ansible-playbook -i src/inventory.ini src/dust_bunny_sweeper.yml
+    ```
+
+    You can also override `dry_run` from the command line:
+    ```bash
+    ansible-playbook -i src/inventory.ini src/dust_bunny_sweeper.yml -e "dust_bunny_dry_run=false"
+    ```
+
+## Example `vars/main.yml`
+
+```yaml
+---
+dust_bunny_target_paths:
+  - /tmp
+  - /var/log
+  - /etc/nginx/conf.d
+  - /home/{{ ansible_user }}/backups # Example for user-specific paths
+
+dust_bunny_file_patterns:
+  - "*.bak"
+  - "*~"
+  - "*.tmp"
+  - "*.old"
+  - "core.*" # Core dump files
+
+dust_bunny_age_threshold_days: 30 # Files older than 30 days matching patterns
+
+dust_bunny_dry_run: true # Set to false to enable deletion
+```
+
+## Testing
+
+To run the tests, you'll need `ansible` installed. The tests create temporary mock files on `localhost`, run the playbook in various modes, and assert the outcomes.
+
+```bash
+ansible-playbook -i tests/inventory_test.ini tests/test_dust_bunny_sweeper.yml
+```

--- a/ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/src/dust_bunny_sweeper.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/src/dust_bunny_sweeper.yml
@@ -1,0 +1,62 @@
+---
+- name: Identify and clean up digital dust bunnies
+  hosts: all
+  gather_facts: false
+  vars_files:
+    - ../vars/main.yml
+
+  tasks:
+    - name: Create target directories if they don't exist (for local testing safety)
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: '0755'
+      loop: "{{ dust_bunny_target_paths }}"
+      delegate_to: localhost
+      when: ansible_connection == 'local' # Only for local testing, remote 'find' handles non-existent paths
+
+    - name: Find old backup/temporary files
+      ansible.builtin.find:
+        paths: "{{ dust_bunny_target_paths }}"
+        patterns: "{{ dust_bunny_file_patterns | join(',') }}"
+        age: "{{ dust_bunny_age_threshold_days }}d"
+        recurse: true
+        file_type: file
+      register: old_temp_files
+      ignore_errors: true # In case a path doesn't exist or permissions issue
+
+    - name: Find empty files
+      ansible.builtin.find:
+        paths: "{{ dust_bunny_target_paths }}"
+        size: "0"
+        recurse: true
+        file_type: file
+      register: empty_files
+      ignore_errors: true
+
+    - name: Combine all dust bunnies
+      ansible.builtin.set_fact:
+        all_dust_bunnies: "{{ old_temp_files.files | map(attribute='path') | list + empty_files.files | map(attribute='path') | list }}"
+
+    - name: Report identified dust bunnies (Dry Run)
+      ansible.builtin.debug:
+        msg: "Identified dust bunny: {{ item }}"
+      loop: "{{ all_dust_bunnies }}"
+      when: dust_bunny_dry_run | bool
+
+    - name: Report identified dust bunnies (Actual Run - will be deleted)
+      ansible.builtin.debug:
+        msg: "Deleting dust bunny: {{ item }}"
+      loop: "{{ all_dust_bunnies }}"
+      when: not dust_bunny_dry_run | bool
+
+    - name: Delete identified dust bunnies
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ all_dust_bunnies }}"
+      when: not dust_bunny_dry_run | bool
+      # Mock rationale: In a real scenario, this would delete files on the target host.
+      # For testing, we ensure the test playbook creates mock files in a temporary
+      # location, and this task will delete them from that temporary location.
+      # The 'when' condition ensures it only runs when dry_run is false.

--- a/ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/src/inventory.ini
+++ b/ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/src/inventory.ini
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/tests/inventory_test.ini
+++ b/ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/tests/inventory_test.ini
@@ -1,0 +1,2 @@
+[test_hosts]
+localhost ansible_connection=local

--- a/ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/tests/test_dust_bunny_sweeper.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/tests/test_dust_bunny_sweeper.yml
@@ -1,0 +1,129 @@
+---
+- name: Test Digital Dust Bunny Sweeper
+  hosts: test_hosts
+  gather_facts: false
+  vars:
+    test_dir: "/tmp/ansible_test_dust_bunnies_{{ lookup('pipe', 'date +%s%N') }}"
+    dust_bunny_target_paths:
+      - "{{ test_dir }}"
+    dust_bunny_file_patterns:
+      - "*.bak"
+      - "*~"
+      - "*.tmp"
+      - "*.old"
+      - "core.*"
+    dust_bunny_age_threshold_days: 0 # For testing, consider all matching files as old enough
+
+  tasks:
+    - name: Create test directory
+      ansible.builtin.file:
+        path: "{{ test_dir }}"
+        state: directory
+        mode: '0755'
+      delegate_to: localhost
+      # Mock rationale: Creates a temporary directory on localhost to simulate a target system's file structure.
+
+    - name: Create mock dust bunny files
+      ansible.builtin.copy:
+        content: "{{ item.content }}"
+        dest: "{{ test_dir }}/{{ item.name }}"
+        force: true
+      loop:
+        - { name: "config.txt.bak", content: "old config backup" }
+        - { name: "report.log~", content: "vim swap file" }
+        - { name: "temp_data.tmp", content: "temporary data" }
+        - { name: "empty_file.txt", content: "" } # Empty file
+        - { name: "important_file.conf", content: "active configuration" } # Should not be touched
+        - { name: "another_old_file.old", content: "another old file" }
+        - { name: "core.dump.1234", content: "core dump content" }
+      delegate_to: localhost
+      # Mock rationale: Populates the temporary directory with files that the playbook should identify as dust bunnies,
+      # and one file that should be ignored, allowing for deterministic testing of the find/delete logic.
+
+    - name: Run playbook in dry-run mode
+      ansible.builtin.include_tasks: ../src/dust_bunny_sweeper.yml
+      vars:
+        dust_bunny_dry_run: true
+      register: dry_run_result
+      # Mock rationale: Executes the main playbook against the mock environment.
+      # The 'register' captures the output for assertions.
+
+    - name: Assert dry-run identified dust bunnies
+      ansible.builtin.assert:
+        that:
+          - "'Identified dust bunny: {{ test_dir }}/config.txt.bak' in dry_run_result.ansible_included_tasks[0].tasks[4].results | map(attribute='msg') | list"
+          - "'Identified dust bunny: {{ test_dir }}/report.log~' in dry_run_result.ansible_included_tasks[0].tasks[4].results | map(attribute='msg') | list"
+          - "'Identified dust bunny: {{ test_dir }}/temp_data.tmp' in dry_run_result.ansible_included_tasks[0].tasks[4].results | map(attribute='msg') | list"
+          - "'Identified dust bunny: {{ test_dir }}/empty_file.txt' in dry_run_result.ansible_included_tasks[0].tasks[4].results | map(attribute='msg') | list"
+          - "'Identified dust bunny: {{ test_dir }}/another_old_file.old' in dry_run_result.ansible_included_tasks[0].tasks[4].results | map(attribute='msg') | list"
+          - "'Identified dust bunny: {{ test_dir }}/core.dump.1234' in dry_run_result.ansible_included_tasks[0].tasks[4].results | map(attribute='msg') | list"
+          - "not 'Identified dust bunny: {{ test_dir }}/important_file.conf' in dry_run_result.ansible_included_tasks[0].tasks[4].results | map(attribute='msg') | list"
+      # Mock rationale: Verifies that the debug messages from the dry-run correctly list the expected dust bunnies
+      # and exclude the important file. This confirms the find logic.
+
+    - name: Check files still exist after dry-run
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop:
+        - "{{ test_dir }}/config.txt.bak"
+        - "{{ test_dir }}/report.log~"
+        - "{{ test_dir }}/temp_data.tmp"
+        - "{{ test_dir }}/empty_file.txt"
+        - "{{ test_dir }}/important_file.conf"
+        - "{{ test_dir }}/another_old_file.old"
+        - "{{ test_dir }}/core.dump.1234"
+      register: stat_result
+      delegate_to: localhost
+      # Mock rationale: Confirms that the dry-run did not actually delete any files.
+
+    - name: Assert files still exist
+      ansible.builtin.assert:
+        that: "item.stat.exists"
+      loop: "{{ stat_result.results }}"
+      # Mock rationale: Ensures all mock files are still present after the dry run.
+
+    - name: Run playbook in actual cleanup mode
+      ansible.builtin.include_tasks: ../src/dust_bunny_sweeper.yml
+      vars:
+        dust_bunny_dry_run: false
+      register: cleanup_result
+      # Mock rationale: Executes the main playbook with deletion enabled.
+
+    - name: Check files after cleanup
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop:
+        - "{{ test_dir }}/config.txt.bak"
+        - "{{ test_dir }}/report.log~"
+        - "{{ test_dir }}/temp_data.tmp"
+        - "{{ test_dir }}/empty_file.txt"
+        - "{{ test_dir }}/another_old_file.old"
+        - "{{ test_dir }}/core.dump.1234"
+      register: cleaned_stat_result
+      delegate_to: localhost
+      # Mock rationale: Checks the status of the dust bunny files after the cleanup run.
+
+    - name: Assert dust bunny files are absent
+      ansible.builtin.assert:
+        that: "not item.stat.exists"
+      loop: "{{ cleaned_stat_result.results }}"
+      # Mock rationale: Verifies that all expected dust bunny files have been deleted.
+
+    - name: Assert important file still exists
+      ansible.builtin.stat:
+        path: "{{ test_dir }}/important_file.conf"
+      register: important_file_stat
+      delegate_to: localhost
+      # Mock rationale: Confirms that the file not matching dust bunny patterns was not deleted.
+
+    - name: Assert important file was not deleted
+      ansible.builtin.assert:
+        that: "important_file_stat.stat.exists"
+      # Mock rationale: Ensures the non-dust-bunny file remains untouched.
+
+    - name: Clean up test directory
+      ansible.builtin.file:
+        path: "{{ test_dir }}"
+        state: absent
+      delegate_to: localhost
+      # Mock rationale: Removes the temporary test directory and all its contents, leaving no artifacts.

--- a/ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/vars/main.yml
+++ b/ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/vars/main.yml
@@ -1,0 +1,16 @@
+---
+dust_bunny_target_paths:
+  - /tmp
+  - /var/log
+  - /etc/nginx/conf.d
+
+dust_bunny_file_patterns:
+  - "*.bak"
+  - "*~"
+  - "*.tmp"
+  - "*.old"
+  - "core.*"
+
+dust_bunny_age_threshold_days: 30
+
+dust_bunny_dry_run: true


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-ansible-dust-bunny-sweeper
- **Provider**: gemini
- **Location**: `ansible-playbooks/nightly-nightly-ansible-dust-bunny-s`
- **Files Created**: 6
- **Description**: An Ansible playbook to identify and optionally clean up digital 'dust bunnies' like old backup files, temporary files, and empty files across managed systems.

## Rationale
- Automated proposal from the Gemini generator delivering a fresh community utility.
- This utility was generated using the **gemini** AI provider.

## Why safe to merge
- Utility is isolated to `ansible-playbooks/nightly-nightly-ansible-dust-bunny-s`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/README.md`
- Run tests located in `ansible-playbooks/nightly-nightly-ansible-dust-bunny-s/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.