### PR TITLE
feat(groq): Generates whimsical post‑apocalypse themed fortune messages in the terminal.

### DIFF
--- a/rust-utils/nightly-nightly-apocalypse-fortune/Cargo.toml
+++ b/rust-utils/nightly-nightly-apocalypse-fortune/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "nightly-apocalypse-fortune"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = "0.8"

--- a/rust-utils/nightly-nightly-apocalypse-fortune/README.md
+++ b/rust-utils/nightly-nightly-apocalypse-fortune/README.md
@@ -1,0 +1,21 @@
+# Nightly Apocalypse Fortune
+
+A tiny Rust CLI that prints a random post‑apocalypse themed fortune message. Perfect for a quick morale boost in the wasteland.
+
+## Installation
+
+```sh
+cargo install --path .
+```
+
+## Usage
+
+```sh
+nightly-apocalypse-fortune
+```
+
+Each run prints one of several whimsical fortunes.
+
+## How it works
+
+The program stores a static list of fortunes and selects one at random using the `rand` crate.

--- a/rust-utils/nightly-nightly-apocalypse-fortune/src/main.rs
+++ b/rust-utils/nightly-nightly-apocalypse-fortune/src/main.rs
@@ -1,0 +1,43 @@
+use rand::seq::SliceRandom;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+static FORTUNES: &[&str] = &[
+    "You will find a fresh water source behind the old billboard.",
+    "A friendly mutant will share its secret stash of canned beans.",
+    "Radiation levels will drop tomorrow; perfect time to venture out.",
+    "Your compass points to a hidden cache of batteries.",
+    "A solar flare will power your solar panel for a full day.",
+    "You will discover a functional radio and hear good news.",
+    "A stray dog will become your loyal companion.",
+    "A sudden rain will reveal a safe path through the dunes.",
+    "You will stumble upon a library still intact—knowledge is power.",
+    "A mysterious traveler will teach you a new survival skill."
+];
+
+fn get_fortune<R: rand::Rng + ?Sized>(rng: &mut R) -> &'static str {
+    FORTUNES.choose(rng).unwrap_or(&"Stay hopeful.")
+}
+
+fn main() {
+    let mut rng = rand::thread_rng();
+    let fortune = get_fortune(&mut rng);
+    println!("{}", fortune);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    #[test]
+    fn deterministic_fortune() {
+        // Seed with a known value (all zeros)
+        let seed: [u8; 32] = [0; 32];
+        let mut rng = StdRng::from_seed(seed);
+        let fortune = get_fortune(&mut rng);
+        // With this seed, the chosen fortune should be the first in the list
+        assert_eq!(fortune, "You will find a fresh water source behind the old billboard.");
+    }
+}

--- a/rust-utils/nightly-nightly-apocalypse-fortune/tests/fortune_test.rs
+++ b/rust-utils/nightly-nightly-apocalypse-fortune/tests/fortune_test.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+
+#[test]
+fn runs_and_outputs() {
+    // Execute the compiled binary via `cargo run`
+    let output = Command::new("cargo")
+        .args(&["run", "--quiet"])
+        .output()
+        .expect("failed to execute cargo run");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let known = [
+        "You will find a fresh water source behind the old billboard.",
+        "A friendly mutant will share its secret stash of canned beans.",
+        "Radiation levels will drop tomorrow; perfect time to venture out.",
+        "Your compass points to a hidden cache of batteries.",
+        "A solar flare will power your solar panel for a full day.",
+        "You will discover a functional radio and hear good news.",
+        "A stray dog will become your loyal companion.",
+        "A sudden rain will reveal a safe path through the dunes.",
+        "You will stumble upon a library still intact—knowledge is power.",
+        "A mysterious traveler will teach you a new survival skill."
+    ];
+    let trimmed = stdout.trim();
+    assert!(known.contains(&trimmed));
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-apocalypse-fortune
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-apocalypse-fortune`
- **Files Created**: 4
- **Description**: Generates whimsical post‑apocalypse themed fortune messages in the terminal.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-apocalypse-fortune`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-apocalypse-fortune/README.md`
- Run tests located in `rust-utils/nightly-nightly-apocalypse-fortune/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.