### PR TITLE
feat(groq): Terraform module that provisions a versioned, encrypted S3 bucket with lifecycle expiration and a read‑only IAM policy for post‑apocalyptic safe‑house storage.

### DIFF
--- a/terraform-modules/nightly-nightly-safehouse-s3-module-7/README.md
+++ b/terraform-modules/nightly-nightly-safehouse-s3-module-7/README.md
@@ -1,0 +1,42 @@
+# Nightly Safehouse S3 Module
+
+Creates an S3 bucket configured for post‑apocalyptic safe‑house storage.
+
+## Features
+- **Versioning** enabled
+- **Server‑side encryption** (AES256)
+- **Lifecycle rule**: automatically delete objects older than 30 days
+- **Read‑only IAM policy** for external services or users
+
+## Usage
+```hcl
+module "safehouse" {
+  source      = "./utils/nightly-safehouse-s3-module"
+  bucket_name = "my‑safehouse‑bucket"
+  tags = {
+    Environment = "production"
+    Project     = "safehouse"
+  }
+}
+```
+
+## Variables
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `bucket_name` | Name of the S3 bucket | `string` | n/a |
+| `tags` | Tags to apply to the bucket | `map(string)` | `{}` |
+
+## Outputs
+| Name | Description |
+|------|-------------|
+| `bucket_id` | ID of the created bucket |
+| `bucket_arn` | ARN of the created bucket |
+| `read_only_policy_arn` | ARN of the generated read‑only IAM policy |
+
+## Testing
+Run the provided test script:
+```bash
+cd utils/nightly-safehouse-s3-module
+bash tests/test_main.sh
+```
+The script validates the Terraform configuration and checks that the expected resources are present in a plan.

--- a/terraform-modules/nightly-nightly-safehouse-s3-module-7/src/main.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-module-7/src/main.tf
@@ -1,0 +1,59 @@
+resource "aws_s3_bucket" "safehouse" {
+  bucket = var.bucket_name
+  tags   = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "safehouse" {
+  bucket = aws_s3_bucket.safehouse.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "safehouse" {
+  bucket = aws_s3_bucket.safehouse.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "safehouse" {
+  bucket = aws_s3_bucket.safehouse.id
+
+  rule {
+    id     = "expire-after-30-days"
+    status = "Enabled"
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
+resource "aws_iam_policy" "read_only" {
+  name   = "${var.bucket_name}-read-only"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = ["s3:GetObject"],
+      Resource = "${aws_s3_bucket.safehouse.arn}/*"
+    }]
+  })
+}
+
+output "bucket_id" {
+  value = aws_s3_bucket.safehouse.id
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.safehouse.arn
+}
+
+output "read_only_policy_arn" {
+  value = aws_iam_policy.read_only.arn
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-module-7/src/outputs.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-module-7/src/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_id" {
+  description = "ID of the created bucket"
+  value       = aws_s3_bucket.safehouse.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the created bucket"
+  value       = aws_s3_bucket.safehouse.arn
+}
+
+output "read_only_policy_arn" {
+  description = "ARN of the generated read‑only IAM policy"
+  value       = aws_iam_policy.read_only.arn
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-module-7/src/variables.tf
+++ b/terraform-modules/nightly-nightly-safehouse-s3-module-7/src/variables.tf
@@ -1,0 +1,10 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to the bucket"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform-modules/nightly-nightly-safehouse-s3-module-7/tests/test_main.sh
+++ b/terraform-modules/nightly-nightly-safehouse-s3-module-7/tests/test_main.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e
+
+# Initialize Terraform (no backend) # Mock rationale: avoids remote state, keeps test offline
+terraform init -backend=false > /dev/null
+
+# Validate the configuration syntax
+terraform validate
+
+# Create a temporary tfvars file with mock inputs
+cat > terraform.tfvars <<EOF
+bucket_name = "test-safehouse-bucket"
+tags = {
+  Environment = "test"
+}
+EOF
+
+# Generate a plan using the mock variables
+terraform plan -var-file=terraform.tfvars -out=plan.out > /dev/null
+
+# Verify that the plan contains the expected resources using JSON output
+PLAN_JSON=$(terraform show -json plan.out)
+
+if ! echo "$PLAN_JSON" | grep -q '"aws_s3_bucket"'; then
+  echo "Missing aws_s3_bucket resource"
+  exit 1
+fi
+
+if ! echo "$PLAN_JSON" | grep -q '"aws_s3_bucket_versioning"'; then
+  echo "Missing versioning configuration"
+  exit 1
+fi
+
+if ! echo "$PLAN_JSON" | grep -q '"aws_s3_bucket_server_side_encryption_configuration"'; then
+  echo "Missing encryption configuration"
+  exit 1
+fi
+
+if ! echo "$PLAN_JSON" | grep -q '"aws_s3_bucket_lifecycle_configuration"'; then
+  echo "Missing lifecycle configuration"
+  exit 1
+fi
+
+if ! echo "$PLAN_JSON" | grep -q '"aws_iam_policy"'; then
+  echo "Missing IAM policy"
+  exit 1
+fi
+
+echo "All checks passed"


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-safehouse-s3-module
- **Provider**: groq
- **Location**: `terraform-modules/nightly-nightly-safehouse-s3-module-7`
- **Files Created**: 5
- **Description**: Terraform module that provisions a versioned, encrypted S3 bucket with lifecycle expiration and a read‑only IAM policy for post‑apocalyptic safe‑house storage.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `terraform-modules/nightly-nightly-safehouse-s3-module-7`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `terraform-modules/nightly-nightly-safehouse-s3-module-7/README.md`
- Run tests located in `terraform-modules/nightly-nightly-safehouse-s3-module-7/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.