### PR TITLE
feat(groq): Shows system uptime with a mood‑matching emoji in a single line.

### DIFF
--- a/bash-utils/nightly-nightly-uptime-emoji-report-3/README.md
+++ b/bash-utils/nightly-nightly-uptime-emoji-report-3/README.md
@@ -1,0 +1,32 @@
+# nightly-uptime-emoji-report
+
+A whimsical Bash utility that reports system uptime accompanied by an emoji that reflects how long the system has been running.
+
+## Usage
+
+```sh
+./src/uptime-emoji.sh          # reads actual system uptime
+./src/uptime-emoji.sh 3600     # mock: 1 hour uptime (for testing)
+```
+
+## Emoji mapping
+
+- < 1 hour   : 🐣 (just hatched)
+- 1‑6 hours  : 🌞 (bright and fresh)
+- 6‑24 hours : 🌤 (daytime)
+- 1‑3 days  : 🌥 (getting tired)
+- > 3 days   : 🌙 (night owl)
+
+The script prints a single line, e.g.:
+
+```
+Uptime: 5h 23m 🌞
+```
+
+## How it works
+
+The script either reads `/proc/uptime` (Linux) or accepts a single argument representing seconds for easier testing. It converts seconds to a human‑readable format and selects the appropriate emoji.
+
+## License
+
+MIT

--- a/bash-utils/nightly-nightly-uptime-emoji-report-3/src/uptime-emoji.sh
+++ b/bash-utils/nightly-nightly-uptime-emoji-report-3/src/uptime-emoji.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# nightly-uptime-emoji-report
+# Prints system uptime with an emoji reflecting duration.
+# Usage: ./uptime-emoji.sh [seconds]
+# If seconds argument is provided, it is used instead of reading /proc/uptime (useful for testing).
+
+set -euo pipefail
+
+# Function to convert seconds to human readable format
+human_readable() {
+    local total=$1
+    local days=$((total/86400))
+    local hours=$(( (total%86400)/3600 ))
+    local minutes=$(( (total%3600)/60 ))
+    local secs=$((total%60))
+    local result=""
+    if (( days > 0 )); then
+        result+="${days}d "
+    fi
+    if (( hours > 0 || days > 0 )); then
+        result+="${hours}h "
+    fi
+    if (( minutes > 0 || hours > 0 || days > 0 )); then
+        result+="${minutes}m "
+    fi
+    result+="${secs}s"
+    echo "$result"
+}
+
+# Determine uptime in seconds
+if [[ $# -ge 1 ]]; then
+    uptime_seconds=$1
+else
+    # Read from /proc/uptime, first field is seconds with fractions
+    if [[ -f /proc/uptime ]]; then
+        uptime_seconds=$(awk '{print int($1)}' /proc/uptime)
+    else
+        echo "Cannot determine uptime on this system." >&2
+        exit 1
+    fi
+fi
+
+# Select emoji based on uptime
+if (( uptime_seconds < 3600 )); then
+    emoji="🐣"
+elif (( uptime_seconds < 21600 )); then
+    emoji="🌞"
+elif (( uptime_seconds < 86400 )); then
+    emoji="🌤"
+elif (( uptime_seconds < 259200 )); then
+    emoji="🌥"
+else
+    emoji="🌙"
+fi
+
+human=$(human_readable "$uptime_seconds")
+echo "Uptime: $human $emoji"

--- a/bash-utils/nightly-nightly-uptime-emoji-report-3/tests/test_uptime_emoji.sh
+++ b/bash-utils/nightly-nightly-uptime-emoji-report-3/tests/test_uptime_emoji.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tests for nightly-uptime-emoji-report
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../src" && pwd)"
+UTIME="$SCRIPT_DIR/uptime-emoji.sh"
+
+run_test() {
+    local seconds=$1
+    local expected_emoji=$2
+    local output
+    output=$("$UTIME" "$seconds")
+    if [[ "$output" != *"$expected_emoji"* ]]; then
+        echo "FAIL: seconds=$seconds expected emoji $expected_emoji got '$output'"
+        exit 1
+    else
+        echo "PASS: seconds=$seconds -> $expected_emoji"
+    fi
+}
+
+run_test 0 "🐣"
+run_test 3599 "🐣"
+run_test 3600 "🌞"
+run_test 21599 "🌞"
+run_test 21600 "🌤"
+run_test 86399 "🌤"
+run_test 86400 "🌥"
+run_test 259199 "🌥"
+run_test 259200 "🌙"
+
+echo "All tests passed."


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-uptime-emoji-report
- **Provider**: groq
- **Location**: `bash-utils/nightly-nightly-uptime-emoji-report-3`
- **Files Created**: 3
- **Description**: Shows system uptime with a mood‑matching emoji in a single line.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `bash-utils/nightly-nightly-uptime-emoji-report-3`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `bash-utils/nightly-nightly-uptime-emoji-report-3/README.md`
- Run tests located in `bash-utils/nightly-nightly-uptime-emoji-report-3/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.