### PR TITLE
feat(groq): Estimates remaining battery life with a post-apocalypse twist.

### DIFF
--- a/rust-utils/nightly-nightly-battery-hope-estimat/Cargo.toml
+++ b/rust-utils/nightly-nightly-battery-hope-estimat/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "battery-hope-estimator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-utils/nightly-nightly-battery-hope-estimat/README.md
+++ b/rust-utils/nightly-nightly-battery-hope-estimat/README.md
@@ -1,0 +1,38 @@
+# Battery Hope Estimator
+
+A tiny Rust CLI that estimates how many hours of power remain given current capacity and average draw, and adds a whimsical apocalypse‑themed message.
+
+## Usage
+
+```sh
+battery-hope-estimator <capacity_mAh> <draw_mA> [efficiency]
+```
+
+- `capacity_mAh`: current battery capacity in milliamp‑hours.
+- `draw_mA`: average current draw in milliamps.
+- `efficiency` (optional, default 0.9): efficiency factor (0‑1).
+
+Example:
+
+```sh
+battery-hope-estimator 4000 500
+```
+
+Outputs:
+
+```
+Estimated remaining time: 7.20 hours.
+Stay powered, survivor!
+```
+
+## Build
+
+```sh
+cargo build --release
+```
+
+## Test
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-battery-hope-estimat/src/lib.rs
+++ b/rust-utils/nightly-nightly-battery-hope-estimat/src/lib.rs
@@ -1,0 +1,6 @@
+pub fn estimate_hours(capacity_mah: f64, draw_ma: f64, efficiency: f64) -> f64 {
+    if draw_ma <= 0.0 || efficiency <= 0.0 {
+        return 0.0;
+    }
+    (capacity_mah * efficiency) / draw_ma
+}

--- a/rust-utils/nightly-nightly-battery-hope-estimat/src/main.rs
+++ b/rust-utils/nightly-nightly-battery-hope-estimat/src/main.rs
@@ -1,0 +1,33 @@
+use std::env;
+use battery_hope_estimator::estimate_hours;
+
+fn print_usage() {
+    eprintln!("Usage: battery-hope-estimator <capacity_mAh> <draw_mA> [efficiency]");
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 || args.len() > 4 {
+        print_usage();
+        std::process::exit(1);
+    }
+    let capacity: f64 = args[1].parse().unwrap_or_else(|_| {
+        eprintln!("Invalid capacity");
+        std::process::exit(1);
+    });
+    let draw: f64 = args[2].parse().unwrap_or_else(|_| {
+        eprintln!("Invalid draw");
+        std::process::exit(1);
+    });
+    let efficiency: f64 = if args.len() == 4 {
+        args[3].parse().unwrap_or_else(|_| {
+            eprintln!("Invalid efficiency");
+            std::process::exit(1);
+        })
+    } else {
+        0.9
+    };
+    let hours = estimate_hours(capacity, draw, efficiency);
+    println!("Estimated remaining time: {:.2} hours.", hours);
+    println!("Stay powered, survivor!");
+}

--- a/rust-utils/nightly-nightly-battery-hope-estimat/tests/estimate.rs
+++ b/rust-utils/nightly-nightly-battery-hope-estimat/tests/estimate.rs
@@ -1,0 +1,24 @@
+#[cfg(test)]
+mod tests {
+    use battery_hope_estimator::estimate_hours;
+
+    #[test]
+    fn test_basic_estimate() {
+        let hours = estimate_hours(4000.0, 500.0, 0.9);
+        // (4000 * 0.9) / 500 = 7.2
+        assert!((hours - 7.2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_zero_draw() {
+        let hours = estimate_hours(4000.0, 0.0, 0.9);
+        assert_eq!(hours, 0.0);
+    }
+
+    #[test]
+    fn test_low_efficiency() {
+        let hours = estimate_hours(4000.0, 500.0, 0.5);
+        // (4000 * 0.5) / 500 = 4.0
+        assert!((hours - 4.0).abs() < 1e-6);
+    }
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-battery-hope-estimator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-battery-hope-estimat`
- **Files Created**: 5
- **Description**: Estimates remaining battery life with a post-apocalypse twist.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-battery-hope-estimat`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-battery-hope-estimat/README.md`
- Run tests located in `rust-utils/nightly-nightly-battery-hope-estimat/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.