### PR TITLE
feat(groq): A whimsical Rust CLI that creates a random post‑apocalyptic scavenger inventory list.

### DIFF
--- a/rust-utils/nightly-nightly-scavenger-inventory-2/Cargo.toml
+++ b/rust-utils/nightly-nightly-scavenger-inventory-2/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "scavenger_inventory"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = "0.8"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "2"

--- a/rust-utils/nightly-nightly-scavenger-inventory-2/README.md
+++ b/rust-utils/nightly-nightly-scavenger-inventory-2/README.md
@@ -1,0 +1,33 @@
+# Nightly Scavenger Inventory Generator
+
+A whimsical Rust CLI that creates a random post‑apocalyptic scavenger inventory list.
+
+## Usage
+
+```sh
+cargo run --quiet
+# or with a fixed seed for reproducible output
+SCAV_SEED=42 cargo run --quiet
+```
+
+The program prints five items with quantities, e.g.:
+
+```
+3 x Canned Beans
+1 x Rusty Pipe
+5 x Solar Charger
+2 x Mutant Mushroom
+4 x Tattered Map
+```
+
+## Build
+
+```sh
+cargo build --release
+```
+
+## Test
+
+```sh
+cargo test
+```

--- a/rust-utils/nightly-nightly-scavenger-inventory-2/src/main.rs
+++ b/rust-utils/nightly-nightly-scavenger-inventory-2/src/main.rs
@@ -1,0 +1,58 @@
+use rand::prelude::*;
+use std::env;
+
+const ITEMS: &[&str] = &[
+    "Canned Beans",
+    "Rusty Pipe",
+    "Solar Charger",
+    "Mutant Mushroom",
+    "Tattered Map",
+    "Water Purifier",
+    "Makeshift Armor",
+    "Old Radio",
+    "Scrap Metal",
+    "Radiation Suit",
+];
+
+fn generate_inventory(seed: Option<u64>) -> Vec<(u32, &'static str)> {
+    let mut rng: StdRng = match seed {
+        Some(s) => SeedableRng::seed_from_u64(s),
+        None => StdRng::from_entropy(),
+    };
+    let mut chosen = Vec::new();
+    let mut indices: Vec<usize> = (0..ITEMS.len()).collect();
+    indices.shuffle(&mut rng);
+    for &idx in indices.iter().take(5) {
+        let qty = rng.gen_range(1..=10);
+        chosen.push((qty, ITEMS[idx]));
+    }
+    chosen
+}
+
+fn main() {
+    let seed = env::var("SCAV_SEED")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok());
+    let inventory = generate_inventory(seed);
+    for (qty, item) in inventory {
+        println!("{} x {}", qty, item);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_inventory_fixed_seed() {
+        let inv = generate_inventory(Some(42));
+        let expected = vec![
+            (4, "Radiation Suit"),
+            (9, "Scrap Metal"),
+            (2, "Old Radio"),
+            (5, "Solar Charger"),
+            (3, "Canned Beans"),
+        ];
+        assert_eq!(inv, expected);
+    }
+}

--- a/rust-utils/nightly-nightly-scavenger-inventory-2/tests/integration_test.rs
+++ b/rust-utils/nightly-nightly-scavenger-inventory-2/tests/integration_test.rs
@@ -1,0 +1,15 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+
+#[test]
+fn test_cli_output_fixed_seed() {
+    let mut cmd = Command::cargo_bin("scavenger_inventory").unwrap();
+    cmd.env("SCAV_SEED", "42");
+    cmd.assert()
+        .success()
+        .stdout(contains("4 x Radiation Suit"))
+        .stdout(contains("9 x Scrap Metal"))
+        .stdout(contains("2 x Old Radio"))
+        .stdout(contains("5 x Solar Charger"))
+        .stdout(contains("3 x Canned Beans"));
+}


### PR DESCRIPTION
## Implementation Summary
- **Utility**: nightly-scavenger-inventory-generator
- **Provider**: groq
- **Location**: `rust-utils/nightly-nightly-scavenger-inventory-2`
- **Files Created**: 4
- **Description**: A whimsical Rust CLI that creates a random post‑apocalyptic scavenger inventory list.

## Rationale
- Automated proposal from the Groq generator delivering a fresh community utility.
- This utility was generated using the **groq** AI provider.

## Why safe to merge
- Utility is isolated to `rust-utils/nightly-nightly-scavenger-inventory-2`.
- README + tests ship together (see folder contents).
- No secrets or credentials touched.
- All changes are additive and self-contained.

## Test Plan
- Follow the instructions in the generated README at `rust-utils/nightly-nightly-scavenger-inventory-2/README.md`
- Run tests located in `rust-utils/nightly-nightly-scavenger-inventory-2/tests/`

## Links
- Generated docs and examples committed alongside this change.

## Mock Justification
- Not applicable; generator did not introduce new mocks.